### PR TITLE
test(shot): add retain() regression coverage for the --max-bytes path

### DIFF
--- a/src/shot.rs
+++ b/src/shot.rs
@@ -723,4 +723,53 @@ mod tests {
         assert!(from_ansi(Vec::new(), 0, 1, 1).is_err());
         assert!(from_ansi(Vec::new(), 1, 0, 1).is_err());
     }
+
+    #[test]
+    fn retain_appends_bytes_when_under_the_limit() {
+        let mut buffer = Vec::new();
+        retain(&mut buffer, b"hello", 16).unwrap();
+        assert_eq!(buffer, b"hello");
+    }
+
+    #[test]
+    fn retain_preserves_existing_bytes_across_multiple_calls() {
+        let mut buffer = Vec::new();
+        retain(&mut buffer, b"abc", 16).unwrap();
+        retain(&mut buffer, b"defgh", 16).unwrap();
+        assert_eq!(buffer, b"abcdefgh");
+    }
+
+    #[test]
+    fn retain_allows_appending_exactly_to_the_max_bytes_boundary() {
+        let mut buffer = Vec::new();
+        retain(&mut buffer, b"abc", 8).unwrap();
+        // Exactly fills the buffer; second call with an empty slice should still succeed.
+        retain(&mut buffer, b"", 8).unwrap();
+        retain(&mut buffer, b"de", 8).unwrap();
+        assert_eq!(buffer, b"abcde");
+    }
+
+    #[test]
+    fn retain_rejects_an_append_that_would_exceed_max_bytes() {
+        let mut buffer = b"abc".to_vec();
+        let err = retain(&mut buffer, b"defghij", 8).unwrap_err();
+        let message = err.to_string();
+        assert!(
+            message.contains("exceeds --max-bytes"),
+            "error should mention the cap, got: {message}"
+        );
+        assert!(
+            message.contains("8"),
+            "error should include the configured cap, got: {message}"
+        );
+        // The buffer must not be partially mutated on failure.
+        assert_eq!(buffer, b"abc");
+    }
+
+    #[test]
+    fn retain_rejects_when_the_first_call_already_overflows() {
+        let mut buffer = Vec::new();
+        assert!(retain(&mut buffer, b"abcdef", 4).is_err());
+        assert!(buffer.is_empty(), "rejected appends must not write anything");
+    }
 }


### PR DESCRIPTION
`shot::retain` is the single guard between the terminal byte stream and the configured scrollback cap, but until now it had no direct unit coverage: every `--max-bytes` assertion lived in the higher-level `from_ansi` tests, which only exercise the empty-input path.

Five new tests in `src/shot.rs` pin the contract that the function must:

- append bytes that fit under the cap,
- preserve bytes across multiple calls so the cap is a hard ceiling,
- accept an empty append at the exact cap (the boundary should not be off-by-one),
- reject an append that would exceed the cap with a message that names both the trigger and the configured limit, leaving the buffer unchanged on failure,
- reject a first-call overflow without writing anything to the buffer.

The failure-path tests are the load-bearing ones here: today a rejected call returns an error before any byte is appended, which is the behavior callers depend on. `cargo test` stays at 51 unit + 11 integration + 1 doctest, all green.