### PR TITLE
feat: expose OpenTUI semantic snapshots

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,6 +1,6 @@
 # Changesets
 
-`@kitlangton/terminal-control` and its native binary packages are published as one fixed-version group.
+`@kitlangton/terminal-control`, `@kitlangton/terminal-control-opentui`, and the native binary packages are published as one fixed-version group.
 
 For user-facing npm changes, create a changeset with `bun run changeset` and commit the generated
 metadata. Release preparation must keep npm manifests, `Cargo.toml`, `Cargo.lock`, and `bun.lock` on

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,6 +5,7 @@
   "fixed": [
     [
       "@kitlangton/terminal-control",
+      "@kitlangton/terminal-control-opentui",
       "@kitlangton/terminal-control-darwin-arm64",
       "@kitlangton/terminal-control-darwin-x64",
       "@kitlangton/terminal-control-linux-arm64-gnu",

--- a/.changeset/semantic-snapshot.md
+++ b/.changeset/semantic-snapshot.md
@@ -1,0 +1,6 @@
+---
+"@kitlangton/terminal-control": minor
+"@kitlangton/terminal-control-opentui": minor
+---
+
+Create a private application semantic socket for every launched command and add `show --format semantic` for optional application-provided UI snapshots.

--- a/.changeset/semantic-snapshot.md
+++ b/.changeset/semantic-snapshot.md
@@ -3,4 +3,4 @@
 "@kitlangton/terminal-control-opentui": minor
 ---
 
-Create a private application semantic socket for every launched command and add `show --format semantic` for optional application-provided UI snapshots.
+Create a private application semantic socket for commands launched with the OpenTUI host profile and add `show --format semantic` for optional application-provided UI snapshots.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,8 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run --cwd packages/test typecheck
       - run: TERMCTRL_TEST_BINARY="$PWD/target/release/termctrl" bun test packages/test/src/index.test.ts
+      - run: bun run --cwd packages/opentui typecheck
+      - run: bun run --cwd packages/opentui test
+      - run: bun run --cwd packages/opentui release:check
       - run: bun run validate:npm "$PWD/target/release/termctrl"
       - run: cargo package

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -105,9 +105,11 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
       - run: npm install --global npm@latest
+      - run: npm install --ignore-scripts --no-package-lock --workspaces=false
+        working-directory: packages/opentui
       - uses: actions/download-artifact@v8
         with:
           pattern: npm-*
           path: npm-artifacts
           merge-multiple: true
-      - run: node scripts/publish-npm-tarballs.mjs npm-artifacts
+      - run: node scripts/release-packages.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 /target
 /node_modules
-/packages/test/node_modules
+/packages/*/node_modules
 /packages/*/bin/cellshot
-/packages/test/dist
+/packages/*/dist
 /.cellshot-artifacts
 /npm-artifacts
 /captures

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -53,4 +53,4 @@ Raw terminal output bytes containing text and terminal control sequences. Files 
 
 ### Semantic Snapshot
 
-Optional application-provided structured UI state read with `show --format semantic`. Terminal Control advertises a private `TERMCTRL_SEMANTIC_SOCKET`; a cooperating application may expose one `semantic.snapshot` capability over it. No provider produces an empty snapshot. Semantic state describes interactable application elements and complements, but does not replace, visible terminal evidence from `show`. The OpenTUI adapter package derives snapshots consistently from a live renderer.
+Optional application-provided structured UI state read with `show --format semantic`. For applications launched with the OpenTUI host profile, Terminal Control advertises a private `TERMCTRL_SEMANTIC_SOCKET`; a cooperating application may expose one `semantic.snapshot` capability over it. No provider produces an empty snapshot. Semantic state describes interactable application elements and complements, but does not replace, visible terminal evidence from `show`. The OpenTUI adapter package derives snapshots consistently from a live renderer.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -53,4 +53,4 @@ Raw terminal output bytes containing text and terminal control sequences. Files 
 
 ### Semantic Snapshot
 
-Optional application-provided structured UI state read with `show --format semantic`. Terminal Control advertises a private `TERMCTRL_SEMANTIC_SOCKET`; a cooperating application may expose one `semantic.snapshot` capability over it. No provider produces an empty snapshot. Semantic state describes interactable application elements and complements, but does not replace, visible terminal evidence from `show`. The OpenTUI adapter package derives Snapshots consistently from a live renderer.
+Optional application-provided structured UI state read with `show --format semantic`. Terminal Control advertises a private `TERMCTRL_SEMANTIC_SOCKET`; a cooperating application may expose one `semantic.snapshot` capability over it. No provider produces an empty snapshot. Semantic state describes interactable application elements and complements, but does not replace, visible terminal evidence from `show`. The OpenTUI adapter package derives snapshots consistently from a live renderer.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -50,3 +50,7 @@ Agents inspect marker names with `termctrl markers` and inspect exact recording 
 ### ANSI/VT Stream
 
 Raw terminal output bytes containing text and terminal control sequences. Files commonly use an `.ansi` suffix, but the suffix does not imply a separate container format.
+
+### Semantic Snapshot
+
+Optional application-provided structured UI state read with `show --format semantic`. Terminal Control advertises a private `TERMCTRL_SEMANTIC_SOCKET`; a cooperating application may expose one `semantic.snapshot` capability over it. No provider produces an empty snapshot. Semantic state describes interactable application elements and complements, but does not replace, visible terminal evidence from `show`. The OpenTUI adapter package derives Snapshots consistently from a live renderer.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ termctrl start demo --cols 112 --rows 34 -- my-terminal-app
 termctrl wait demo "Ready"
 termctrl send demo text:help enter
 termctrl show demo
+termctrl show demo --format semantic
 termctrl save demo --format png --out captures/help.png
 termctrl stop demo
 ```
@@ -118,6 +119,7 @@ termctrl stop demo
   running sessions; `list --all` also shows retained exited sessions and stale sockets.
 - `prune --dry-run` previews retained exited sessions and stale sockets; `prune` removes them without
   deleting recording artifacts.
+- `show --format semantic` reads optional structured UI semantics provided by the application.
 - `resize demo --cols 132 --rows 38` tests responsive layouts.
 - `restart demo` relaunches with the stored command, cwd, viewport, and recording settings.
 - An exited session keeps its final screen for `show` until stopped.
@@ -137,6 +139,32 @@ termctrl logs demo --ansi > captures/demo-output.ansi
 ```
 
 Full-screen alternate-screen TUIs do not produce useful logs; read their visible screen with `show`.
+
+## Semantic UI Snapshots
+
+Terminal Control gives every launched application a private `TERMCTRL_SEMANTIC_SOCKET`. Applications
+may connect to it and provide structured UI semantics without changing terminal output:
+
+```bash
+termctrl show demo --format semantic
+```
+
+Applications that do not implement the protocol continue to work normally; semantic output is an
+empty snapshot. OpenTUI applications can install the adapter package and pass their live renderer:
+
+```bash
+bun add @kitlangton/terminal-control-opentui
+```
+
+```ts
+import { provideTerminalControl } from "@kitlangton/terminal-control-opentui"
+
+const semanticProvider = provideTerminalControl(renderer, {
+  application: { name: "my-tui", version: "1.0.0" },
+})
+
+renderer.once("destroy", () => semanticProvider.close())
+```
 
 ## Enter A Shared Workspace
 
@@ -300,6 +328,7 @@ See [docs/typescript-client.md](docs/typescript-client.md) for artifacts, record
 ## Notes
 
 - Persistent sessions use owner-only local Unix sockets and are supported on macOS and Linux.
+- Every launched command receives a private semantic provider path in `TERMCTRL_SEMANTIC_SOCKET`.
 - `--host opentui` answers startup probes needed by current OpenTUI applications.
 - Terminal state and reflow use the statically linked Ghostty terminal core; renderers export PNG, SVG, JSON, text, and raw ANSI artifacts.
 - Run `termctrl <command> --help` for dimensions, timing, color, rendering, and output options.

--- a/README.md
+++ b/README.md
@@ -142,10 +142,12 @@ Full-screen alternate-screen TUIs do not produce useful logs; read their visible
 
 ## Semantic UI Snapshots
 
-Terminal Control gives every launched application a private `TERMCTRL_SEMANTIC_SOCKET`. Applications
-may connect to it and provide structured UI semantics without changing terminal output:
+Terminal Control gives applications launched with `--host opentui` a private
+`TERMCTRL_SEMANTIC_SOCKET`. Applications may connect to it and provide structured UI semantics
+without changing terminal output:
 
 ```bash
+termctrl start demo --host opentui -- my-tui
 termctrl show demo --format semantic
 ```
 
@@ -328,7 +330,6 @@ See [docs/typescript-client.md](docs/typescript-client.md) for artifacts, record
 ## Notes
 
 - Persistent sessions use owner-only local Unix sockets and are supported on macOS and Linux.
-- Every launched command receives a private semantic provider path in `TERMCTRL_SEMANTIC_SOCKET`.
-- `--host opentui` answers startup probes needed by current OpenTUI applications.
+- `--host opentui` provides `TERMCTRL_SEMANTIC_SOCKET` and answers startup probes needed by current OpenTUI applications.
 - Terminal state and reflow use the statically linked Ghostty terminal core; renderers export PNG, SVG, JSON, text, and raw ANSI artifacts.
 - Run `termctrl <command> --help` for dimensions, timing, color, rendering, and output options.

--- a/bun.lock
+++ b/bun.lock
@@ -36,6 +36,19 @@
         "termctrl": "bin/termctrl",
       },
     },
+    "packages/opentui": {
+      "name": "@kitlangton/terminal-control-opentui",
+      "version": "0.4.1",
+      "devDependencies": {
+        "@opentui/core": "^0.4.5",
+        "@types/bun": "^1.3.0",
+        "@types/node": "^24.0.0",
+        "typescript": "^5.9.0",
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.4.0 <1",
+      },
+    },
     "packages/test": {
       "name": "@kitlangton/terminal-control",
       "version": "0.4.1",
@@ -61,16 +74,6 @@
   },
   "packages": {
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
-
-    "@kitlangton/terminal-control-darwin-arm64": ["@kitlangton/terminal-control-darwin-arm64@workspace:packages/darwin-arm64"],
-
-    "@kitlangton/terminal-control-darwin-x64": ["@kitlangton/terminal-control-darwin-x64@workspace:packages/darwin-x64"],
-
-    "@kitlangton/terminal-control-linux-arm64-gnu": ["@kitlangton/terminal-control-linux-arm64-gnu@workspace:packages/linux-arm64-gnu"],
-
-    "@kitlangton/terminal-control-linux-x64-gnu": ["@kitlangton/terminal-control-linux-x64-gnu@workspace:packages/linux-x64-gnu"],
-
-    "@kitlangton/terminal-control": ["@kitlangton/terminal-control@workspace:packages/test"],
 
     "@changesets/apply-release-plan": ["@changesets/apply-release-plan@7.1.1", "", { "dependencies": { "@changesets/config": "^3.1.4", "@changesets/get-version-range-type": "^0.4.0", "@changesets/git": "^3.0.4", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "detect-indent": "^6.0.0", "fs-extra": "^7.0.1", "lodash.startcase": "^4.4.0", "outdent": "^0.5.0", "prettier": "^2.7.1", "resolve-from": "^5.0.0", "semver": "^7.5.3" } }, "sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA=="],
 
@@ -162,6 +165,18 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
+    "@kitlangton/terminal-control": ["@kitlangton/terminal-control@workspace:packages/test"],
+
+    "@kitlangton/terminal-control-darwin-arm64": ["@kitlangton/terminal-control-darwin-arm64@workspace:packages/darwin-arm64"],
+
+    "@kitlangton/terminal-control-darwin-x64": ["@kitlangton/terminal-control-darwin-x64@workspace:packages/darwin-x64"],
+
+    "@kitlangton/terminal-control-linux-arm64-gnu": ["@kitlangton/terminal-control-linux-arm64-gnu@workspace:packages/linux-arm64-gnu"],
+
+    "@kitlangton/terminal-control-linux-x64-gnu": ["@kitlangton/terminal-control-linux-x64-gnu@workspace:packages/linux-x64-gnu"],
+
+    "@kitlangton/terminal-control-opentui": ["@kitlangton/terminal-control-opentui@workspace:packages/opentui"],
+
     "@manypkg/find-root": ["@manypkg/find-root@1.1.0", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@types/node": "^12.7.1", "find-up": "^4.1.0", "fs-extra": "^8.1.0" } }, "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA=="],
 
     "@manypkg/get-packages": ["@manypkg/get-packages@1.1.3", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@changesets/types": "^4.0.1", "@manypkg/find-root": "^1.1.0", "fs-extra": "^8.1.0", "globby": "^11.0.0", "read-yaml-file": "^1.1.0" } }, "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A=="],
@@ -171,6 +186,24 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@opentui/core": ["@opentui/core@0.4.5", "", { "dependencies": { "bun-ffi-structs": "0.2.4", "diff": "9.0.0", "marked": "17.0.1", "string-width": "7.2.0", "strip-ansi": "7.1.2" }, "optionalDependencies": { "@opentui/core-darwin-arm64": "0.4.5", "@opentui/core-darwin-x64": "0.4.5", "@opentui/core-linux-arm64": "0.4.5", "@opentui/core-linux-arm64-musl": "0.4.5", "@opentui/core-linux-x64": "0.4.5", "@opentui/core-linux-x64-musl": "0.4.5", "@opentui/core-win32-arm64": "0.4.5", "@opentui/core-win32-x64": "0.4.5" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-JsgRTPkA6e+Vxmumxai6SElOSlRQkbzNKHlCfemlArRiLhfC1IZ9RXJo2QH4xSu+uBOWAM90uss73/pPlkdEig=="],
+
+    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.4.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-8KUG0oRidnR+oW1RSZJ72/PhZLl+qRRMk5U/mieF4c0SJ5V3tYACpBZAKzQfHNd1f7QzD8FHZct1lPpQgtmkWg=="],
+
+    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.4.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-R2bocsg55gwjOqCp/MWFgFYzRmsduKegB6nzgFAPCvAD/L5Jf30xpWJWFlSg3x8vxe1L9WJ84dfqa4M7mZZ3wA=="],
+
+    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.4.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-R4MZ25a4CzOAGVjW9aj1hUfzQGVfCJwrwBDbNs2SXaIvzcZqkxCVtU4FoQ5LsaD0j/BdNQVg2CIfFkFsm1fDuQ=="],
+
+    "@opentui/core-linux-arm64-musl": ["@opentui/core-linux-arm64-musl@0.4.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ieqdyKI6EIYPalYAETB2wsdP83hr5Ifi+dFnBFUmdEEFHsoKwBmn2S7bsTOYlX7Bg03F4/YPIg+IvRpeC+cUJw=="],
+
+    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.4.5", "", { "os": "linux", "cpu": "x64" }, "sha512-SNyuQoxMKI1vuJhgxSSW96adWM6LqFl2SoS3GM4tGeneGOanVVG2Y06PvlytXvF4cKik97t0rqkVMRetmOs93w=="],
+
+    "@opentui/core-linux-x64-musl": ["@opentui/core-linux-x64-musl@0.4.5", "", { "os": "linux", "cpu": "x64" }, "sha512-mKVKcIcPiSVVZZsdPSBoWwoa2/TCeQAaMDeHF7PFw2kt5bTXZPP7xxWfRQLCNIcA1eaGl59UuwUWHDR2Ve548Q=="],
+
+    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.4.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-GHTTsqeR45q2Iek9Rb7ty+x/hAKn2jZ1ujlCgPR8LBKyF7h0E1dNFryoZ7ehMc3kJndP1sKn836IemKFqxuDdQ=="],
+
+    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.4.5", "", { "os": "win32", "cpu": "x64" }, "sha512-Y8T/yXCDGagRGiQrtmuB6AhRcPucKFs/Dre3v8kJwNYqDccI4FzUPKclZ7djfmRZNjl7JUqPhZZP/PwDpQocMg=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.4", "", { "os": "android", "cpu": "arm" }, "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ=="],
 
@@ -248,7 +281,7 @@
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
-    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
@@ -259,6 +292,8 @@
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "bun-ffi-structs": ["bun-ffi-structs@0.2.4", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-AJzsqoVFs1KBbJbWHIYrVZLDC3NhTqqh25awRXqzoLzmBAKr5oqk6+CwuYHAekKx+VBCYVohBoKuRq40dV+TYg=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
@@ -278,7 +313,11 @@
 
     "detect-indent": ["detect-indent@6.1.0", "", {}, "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="],
 
+    "diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
+
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
+
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
 
@@ -307,6 +346,8 @@
     "fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
@@ -345,6 +386,8 @@
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
@@ -428,7 +471,9 @@
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
-    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
@@ -462,6 +507,8 @@
 
     "vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
 
+    "web-tree-sitter": ["web-tree-sitter@0.25.10", "", { "peerDependencies": { "@types/emscripten": "^1.40.0" }, "optionalPeers": ["@types/emscripten"] }, "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
@@ -474,11 +521,15 @@
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
+    "enquirer/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "read-yaml-file/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
     "rollup/@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "enquirer/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "read-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
   }

--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
     },
     "packages/opentui": {
       "name": "@kitlangton/terminal-control-opentui",
-      "version": "0.4.1",
+      "version": "0.0.0",
       "devDependencies": {
         "@opentui/core": "^0.4.5",
         "@types/bun": "^1.3.0",

--- a/docs/driver-protocol.md
+++ b/docs/driver-protocol.md
@@ -31,6 +31,9 @@ increment `protocolVersion`; clients reject unsupported versions rather than gue
 {"id":4,"method":"capture","sessionId":"app","params":{"settleMs":250,"deadlineMs":5000}}
 ```
 
+Set launch `host` to `"opentui"` for OpenTUI startup probe responses and the private
+`TERMCTRL_SEMANTIC_SOCKET` used by compatible semantic snapshot adapters.
+
 ## Capture Semantics
 
 A driver `capture` response contains a structured visible frame, derived `text`, and a completion `reason`: `idle`, `deadline`, `exited`, or `outputclosed`. A test client should normally require `idle` or `exited` instead of accepting a deadline fallback as a stable snapshot.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,10 +1,10 @@
 # Releasing Terminal Control
 
 Terminal Control releases one aligned version across the public `terminal-control` crate, the
-`@kitlangton/terminal-control` client, and four native npm packages. The independently versioned
-`@kitlangton/terminal-control-opentui` adapter publishes from its package-local Node release script.
-npm packages are published by the manual `npm-release.yml` workflow; crates.io publication and the
-GitHub release are separate explicit steps.
+`@kitlangton/terminal-control` client, the `@kitlangton/terminal-control-opentui` adapter, and four native npm
+packages. The adapter publishes from its package-local Node release script while the fixed native
+tarball set keeps its existing publisher. npm packages are published by the manual
+`npm-release.yml` workflow; crates.io publication and the GitHub release are separate explicit steps.
 
 ## Prepare The Version
 
@@ -21,7 +21,9 @@ have Changesets.
    `main` through CI.
 
 Native packaging rejects a Rust executable whose `termctrl --version` differs from its npm package
-manifest. Do not bypass that check or publish package formats at different versions.
+manifest. The OpenTUI release script reads the TypeScript client version and updates its package
+manifest to match before publishing. Do not bypass the native checks or publish package formats at
+different versions.
 
 ## Validate The Release
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,9 +1,10 @@
 # Releasing Terminal Control
 
 Terminal Control releases one aligned version across the public `terminal-control` crate, the
-`@kitlangton/terminal-control` client, and four native npm packages. npm packages are assembled and
-published by the manual `npm-release.yml` workflow; crates.io publication and the GitHub release are
-separate explicit steps.
+`@kitlangton/terminal-control` client, and four native npm packages. The independently versioned
+`@kitlangton/terminal-control-opentui` adapter publishes from its package-local Node release script.
+npm packages are published by the manual `npm-release.yml` workflow; crates.io publication and the
+GitHub release are separate explicit steps.
 
 ## Prepare The Version
 
@@ -39,7 +40,8 @@ gh workflow run npm-release.yml --ref main -f publish=false
 
 Confirm the workflow run targets the intended release commit. Its matrix builds macOS and Linux
 binaries for arm64 and x64, verifies the complete fixed-version tarball set, and installs the packed
-client from clean Bun and Node/Vitest consumers.
+client from clean Bun and Node/Vitest consumers. The OpenTUI adapter validates independently with
+`bun run --cwd packages/opentui release:check`.
 
 ## Publish
 
@@ -50,9 +52,10 @@ cargo publish --locked
 gh workflow run npm-release.yml --ref main -f publish=true
 ```
 
-The npm workflow uses trusted publishing through GitHub Actions OIDC and is retry-safe: it skips an
-exact package version already present in npm. crates.io publication requires Cargo credentials for an
-owner of `terminal-control`; do not add registry tokens to the repository.
+The npm workflow runs `node scripts/release-packages.mjs`, which publishes the fixed native/client
+tarball set and then invokes the OpenTUI package's normal `npm publish`. Both publishers are
+retry-safe and skip an exact package version already present in npm. crates.io publication requires
+Cargo credentials for an owner of `terminal-control`; do not add registry tokens to the repository.
 
 After both registries report the new version, create the matching tag and GitHub release:
 
@@ -71,6 +74,6 @@ Install the released package in a clean consumer and confirm `termctrl --version
 
 ## Trusted Publishing
 
-Each npm package must configure `anomalyco/terminal-control` and workflow `npm-release.yml` as its
-trusted publisher. The publish job uses Node 24, current npm, and `id-token: write`; it does not use a
-long-lived npm token.
+Each npm package, including the OpenTUI adapter, must configure `anomalyco/terminal-control` and
+workflow `npm-release.yml` as its trusted publisher. The publish job uses Node 24, current npm, and
+`id-token: write`; it does not use a long-lived npm token.

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
     "packages/*"
   ],
   "scripts": {
-    "build:npm": "bun run --cwd packages/test build",
-    "test:npm": "bun run --cwd packages/test typecheck && bun run --cwd packages/test test",
+    "build:npm": "bun run --cwd packages/test build && bun run --cwd packages/opentui build",
+    "test:npm": "bun run --cwd packages/test typecheck && bun run --cwd packages/test test && bun run --cwd packages/opentui typecheck && bun run --cwd packages/opentui test",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "validate:npm": "node scripts/validate-npm-packages.mjs",
-    "release-packages": "node scripts/publish-npm-tarballs.mjs"
+    "release-packages": "node scripts/release-packages.mjs"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.7"

--- a/packages/opentui/LICENSE
+++ b/packages/opentui/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Kit Langton
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/opentui/README.md
+++ b/packages/opentui/README.md
@@ -1,0 +1,42 @@
+# @kitlangton/terminal-control-opentui
+
+Expose a consistent semantic snapshot from any OpenTUI application controlled by Terminal Control.
+
+```bash
+bun add @kitlangton/terminal-control-opentui @opentui/core
+```
+
+Pass the application's live `CliRenderer` during startup:
+
+```ts
+import { provideTerminalControl } from "@kitlangton/terminal-control-opentui"
+
+const terminalControl = provideTerminalControl(renderer, {
+  application: { name: "my-tui", version: "1.0.0" },
+})
+
+renderer.once("destroy", () => terminalControl.close())
+```
+
+Outside Terminal Control the integration is a no-op. Inside a named session, inspect the semantic
+tree with:
+
+```bash
+termctrl show app --format semantic
+```
+
+The package walks the live OpenTUI render tree and consistently discovers visible focused editors,
+focusable controls, and reachable mouse targets. It derives roles, labels, focus state, and live
+numeric element handles without requiring every application to maintain its own walker.
+
+`elements(renderer)` and `semanticSnapshot(renderer)` are also exported for tests and custom
+integrations.
+
+Publish the package directly from this directory:
+
+```bash
+npm publish --access public
+```
+
+The repository-level `npm run release-packages` command calls this package's retry-safe `release`
+script after publishing the native Terminal Control package set.

--- a/packages/opentui/README.md
+++ b/packages/opentui/README.md
@@ -18,10 +18,11 @@ const terminalControl = provideTerminalControl(renderer, {
 renderer.once("destroy", () => terminalControl.close())
 ```
 
-Outside Terminal Control the integration is a no-op. Inside a named session, inspect the semantic
-tree with:
+Outside Terminal Control the integration is a no-op. Launch the application with Terminal Control's
+OpenTUI host profile, then inspect the semantic tree:
 
 ```bash
+termctrl start app --host opentui -- my-tui
 termctrl show app --format semantic
 ```
 

--- a/packages/opentui/package.json
+++ b/packages/opentui/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@kitlangton/terminal-control-opentui",
+  "version": "0.4.1",
+  "description": "Expose consistent OpenTUI semantic snapshots through Terminal Control",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/anomalyco/terminal-control.git",
+    "directory": "packages/opentui"
+  },
+  "type": "module",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "types": "./dist/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc -p tsconfig.build.json",
+    "test": "bun test src/index.test.ts",
+    "typecheck": "tsc --noEmit",
+    "prepack": "npm run build",
+    "release": "node script/release.mjs",
+    "release:check": "node script/release.mjs --check"
+  },
+  "peerDependencies": {
+    "@opentui/core": ">=0.4.0 <1"
+  },
+  "devDependencies": {
+    "@opentui/core": "^0.4.5",
+    "@types/bun": "^1.3.0",
+    "@types/node": "^24.0.0",
+    "typescript": "^5.9.0"
+  }
+}

--- a/packages/opentui/package.json
+++ b/packages/opentui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control-opentui",
-  "version": "0.4.1",
+  "version": "0.0.0",
   "description": "Expose consistent OpenTUI semantic snapshots through Terminal Control",
   "license": "MIT",
   "repository": {

--- a/packages/opentui/script/release.mjs
+++ b/packages/opentui/script/release.mjs
@@ -1,22 +1,34 @@
-import { readFile } from "node:fs/promises"
+import { readFile, writeFile } from "node:fs/promises"
 import { spawnSync } from "node:child_process"
 import { fileURLToPath } from "node:url"
 
-const manifest = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"))
+const manifestUrl = new URL("../package.json", import.meta.url)
+const originalManifest = await readFile(manifestUrl, "utf8")
+const manifest = JSON.parse(originalManifest)
+const terminalControl = JSON.parse(
+  await readFile(new URL("../../test/package.json", import.meta.url), "utf8"),
+)
 const check = process.argv.includes("--check")
 
+const aligned = manifest.version !== terminalControl.version
+if (aligned) {
+  console.log(`aligning ${manifest.name} from ${manifest.version} to ${terminalControl.version}`)
+  manifest.version = terminalControl.version
+  await writeFile(manifestUrl, `${JSON.stringify(manifest, null, 2)}\n`)
+}
+
 if (check) {
-  run("npm", ["publish", "--dry-run", "--access", "public"])
-  console.log(`validated ${manifest.name}@${manifest.version} release`)
-  process.exit(0)
-}
-
-if (isPublished(manifest.name, manifest.version)) {
+  try {
+    run("npm", ["publish", "--dry-run", "--access", "public"])
+    console.log(`validated ${manifest.name}@${manifest.version} release`)
+  } finally {
+    if (aligned) await writeFile(manifestUrl, originalManifest)
+  }
+} else if (isPublished(manifest.name, manifest.version)) {
   console.log(`skipping already published ${manifest.name}@${manifest.version}`)
-  process.exit(0)
+} else {
+  run("npm", ["publish", "--access", "public", "--provenance"])
 }
-
-run("npm", ["publish", "--access", "public", "--provenance"])
 
 function isPublished(name, version) {
   const result = spawnSync("npm", ["view", `${name}@${version}`, "version", "--json"], {
@@ -33,5 +45,5 @@ function isPublished(name, version) {
 
 function run(command, args) {
   const result = spawnSync(command, args, { cwd: fileURLToPath(new URL("..", import.meta.url)), stdio: "inherit" })
-  if (result.status !== 0) process.exit(result.status ?? 1)
+  if (result.status !== 0) throw new Error(`${command} ${args.join(" ")} failed`)
 }

--- a/packages/opentui/script/release.mjs
+++ b/packages/opentui/script/release.mjs
@@ -1,0 +1,37 @@
+import { readFile } from "node:fs/promises"
+import { spawnSync } from "node:child_process"
+import { fileURLToPath } from "node:url"
+
+const manifest = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"))
+const check = process.argv.includes("--check")
+
+if (check) {
+  run("npm", ["publish", "--dry-run", "--access", "public"])
+  console.log(`validated ${manifest.name}@${manifest.version} release`)
+  process.exit(0)
+}
+
+if (isPublished(manifest.name, manifest.version)) {
+  console.log(`skipping already published ${manifest.name}@${manifest.version}`)
+  process.exit(0)
+}
+
+run("npm", ["publish", "--access", "public", "--provenance"])
+
+function isPublished(name, version) {
+  const result = spawnSync("npm", ["view", `${name}@${version}`, "version", "--json"], {
+    encoding: "utf8",
+  })
+  if (result.status !== 0) return false
+  const published = JSON.parse(result.stdout)
+  const versions = Array.isArray(published) ? published : [published]
+  if (!versions.includes(version)) {
+    throw new Error(`npm returned unexpected version for ${name}@${version}: ${published}`)
+  }
+  return true
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, { cwd: fileURLToPath(new URL("..", import.meta.url)), stdio: "inherit" })
+  if (result.status !== 0) process.exit(result.status ?? 1)
+}

--- a/packages/opentui/src/index.test.ts
+++ b/packages/opentui/src/index.test.ts
@@ -1,0 +1,104 @@
+import { expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { createServer } from "node:net"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { BoxRenderable } from "@opentui/core"
+import { createTestRenderer } from "@opentui/core/testing"
+import { elements, provideTerminalControl, semanticSnapshot } from "./index"
+
+test("discovers the same live interactable elements used by semantic snapshots", async () => {
+  const setup = await createTestRenderer({ width: 20, height: 5 })
+  const button = new BoxRenderable(setup.renderer, {
+    id: "submit",
+    width: 10,
+    height: 3,
+    onMouseDown: () => {},
+  })
+  setup.renderer.root.add(button)
+  await setup.renderOnce()
+
+  expect(elements(setup.renderer)).toEqual([
+    {
+      id: "submit",
+      num: button.num,
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 3,
+      focusable: false,
+      focused: false,
+      clickable: true,
+      editor: false,
+    },
+  ])
+  expect(semanticSnapshot(setup.renderer)).toEqual({
+    format: "termctrl-semantic-snapshot-v1",
+    nodes: [
+      {
+        id: "submit",
+        role: "button",
+        label: "submit",
+        element: button.num,
+        focused: false,
+        disabled: false,
+      },
+    ],
+  })
+  setup.renderer.destroy()
+})
+
+test("provides semantic snapshots over the discovered Terminal Control socket", async () => {
+  const setup = await createTestRenderer({ width: 20, height: 5 })
+  setup.renderer.root.add(
+    new BoxRenderable(setup.renderer, {
+      id: "submit",
+      width: 10,
+      height: 3,
+      onMouseDown: () => {},
+    }),
+  )
+  await setup.renderOnce()
+  const directory = await mkdtemp(join(tmpdir(), "termctrl-opentui-"))
+  const socketPath = join(directory, "semantic.sock")
+  let resolveResult!: (value: unknown) => void
+  const result = new Promise((resolve) => {
+    resolveResult = resolve
+  })
+  const server = createServer((socket) => {
+    socket.setEncoding("utf8")
+    let buffer = ""
+    socket.on("data", (chunk) => {
+      buffer += chunk
+      const lines = buffer.split("\n")
+      buffer = lines.pop() ?? ""
+      for (const line of lines) {
+        const message = JSON.parse(line)
+        if (message.type === "hello") {
+          expect(message.capabilities).toEqual(["semantic.snapshot"])
+          socket.write(`${JSON.stringify({ type: "ready", protocolVersion: 1 })}\n`)
+          socket.write(`${JSON.stringify({ type: "semantic.snapshot", id: 1 })}\n`)
+        }
+        if (message.type === "result") resolveResult(message.value)
+      }
+    })
+  })
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(socketPath, resolve)
+  })
+  const provider = provideTerminalControl(setup.renderer, {
+    application: { name: "fixture", version: "1.0.0" },
+    socketPath,
+  })
+
+  try {
+    expect(await provider.ready).toBe(true)
+    expect(await result).toEqual(semanticSnapshot(setup.renderer))
+  } finally {
+    provider.close()
+    setup.renderer.destroy()
+    await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+    await rm(directory, { recursive: true, force: true })
+  }
+})

--- a/packages/opentui/src/index.ts
+++ b/packages/opentui/src/index.ts
@@ -1,0 +1,120 @@
+import type { CliRenderer, Renderable } from "@opentui/core"
+import { provideSemanticSnapshot, type Provider } from "./provider.js"
+
+export type InteractableElement = {
+  readonly id: string
+  readonly num: number
+  readonly x: number
+  readonly y: number
+  readonly width: number
+  readonly height: number
+  readonly focusable: boolean
+  readonly focused: boolean
+  readonly clickable: boolean
+  readonly editor: boolean
+}
+
+export type SemanticNode = {
+  readonly id: string
+  readonly role: string
+  readonly label?: string
+  readonly element: number
+  readonly focused: boolean
+  readonly disabled: boolean
+}
+
+export type SemanticSnapshot = {
+  readonly format: "termctrl-semantic-snapshot-v1"
+  readonly nodes: ReadonlyArray<SemanticNode>
+}
+
+function children(renderable: Renderable) {
+  return renderable.getChildren().filter((child): child is Renderable => "num" in child)
+}
+
+function all(renderable: Renderable): Renderable[] {
+  return [renderable, ...children(renderable).flatMap(all)]
+}
+
+function hasMouseListeners(renderable: Renderable) {
+  const listener = Reflect.get(renderable, "_mouseListener")
+  const listeners = Reflect.get(renderable, "_mouseListeners")
+  return Boolean(listener) || (isRecord(listeners) && Object.keys(listeners).length > 0)
+}
+
+function receivesClick(renderer: CliRenderer, renderable: Renderable) {
+  if (renderable.width <= 0 || renderable.height <= 0) return false
+  const x = Math.floor(renderable.screenX + renderable.width / 2)
+  const y = Math.floor(renderable.screenY + renderable.height / 2)
+  const target = renderer.hitTest(x, y)
+  return all(renderable).some((item) => item.num === target)
+}
+
+export function elements(renderer: CliRenderer): InteractableElement[] {
+  return all(renderer.root)
+    .filter((renderable) => renderable.visible && !renderable.isDestroyed)
+    .map((renderable) => ({
+      id: renderable.id,
+      num: renderable.num,
+      x: renderable.screenX,
+      y: renderable.screenY,
+      width: renderable.width,
+      height: renderable.height,
+      focusable: renderable.focusable,
+      focused: renderable.focused,
+      clickable: hasMouseListeners(renderable) && receivesClick(renderer, renderable),
+      editor: renderer.currentFocusedEditor === renderable,
+    }))
+    .filter((element) => element.focusable || element.clickable || element.editor)
+}
+
+export function semanticSnapshot(renderer: CliRenderer): SemanticSnapshot {
+  const renderables = new Map(all(renderer.root).map((renderable) => [renderable.num, renderable]))
+  const ids = new Set<string>()
+  return {
+    format: "termctrl-semantic-snapshot-v1",
+    nodes: elements(renderer).map((element) => {
+      const preferred = element.id || `renderable-${element.num}`
+      const id = ids.has(preferred) ? `${preferred}-${element.num}` : preferred
+      ids.add(id)
+      return {
+        id,
+        role: element.editor ? "textbox" : element.clickable ? "button" : "control",
+        label: label(renderables.get(element.num), element),
+        element: element.num,
+        focused: element.focused || element.editor,
+        disabled: false,
+      }
+    }),
+  }
+}
+
+export function provideTerminalControl(
+  renderer: CliRenderer,
+  options: {
+    readonly application: { readonly name: string; readonly version?: string }
+    readonly socketPath?: string
+    readonly onError?: (error: unknown) => void
+  },
+): Provider {
+  return provideSemanticSnapshot({
+    ...options,
+    snapshot: async () => {
+      renderer.requestRender()
+      await renderer.idle()
+      return semanticSnapshot(renderer)
+    },
+  })
+}
+
+function label(renderable: Renderable | undefined, element: InteractableElement) {
+  if (!renderable || element.editor) return element.id || undefined
+  const text = all(renderable)
+    .map((item) => Reflect.get(item, "plainText"))
+    .find((value): value is string => typeof value === "string" && value.trim().length > 0)
+  return text?.replaceAll(/\s+/g, " ").trim() || element.id || undefined
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/packages/opentui/src/provider.ts
+++ b/packages/opentui/src/provider.ts
@@ -1,0 +1,115 @@
+import { createConnection } from "node:net"
+
+export type Provider = {
+  readonly enabled: boolean
+  readonly ready: Promise<boolean>
+  close(): void
+}
+
+export function provideSemanticSnapshot(options: {
+  readonly application: { readonly name: string; readonly version?: string }
+  readonly snapshot: () => unknown | Promise<unknown>
+  readonly socketPath?: string
+  readonly onError?: (error: unknown) => void
+}): Provider {
+  if (!options.application.name) throw new TypeError("application.name is required")
+  const socketPath = options.socketPath ?? process.env.TERMCTRL_SEMANTIC_SOCKET
+  if (!socketPath) return { enabled: false, ready: Promise.resolve(false), close() {} }
+
+  let buffer = ""
+  let protocolReady = false
+  let readySettled = false
+  let resolveReady!: (value: boolean) => void
+  const ready = new Promise<boolean>((resolve) => {
+    resolveReady = resolve
+  })
+  const settleReady = (value: boolean) => {
+    if (readySettled) return
+    readySettled = true
+    resolveReady(value)
+  }
+  const socket = createConnection(socketPath)
+  socket.setEncoding("utf8")
+  const handshakeTimer = setTimeout(() => fail(new Error("Terminal Control semantic handshake timed out")), 5_000)
+  handshakeTimer.unref()
+
+  socket.once("connect", () =>
+    send({
+      type: "hello",
+      protocolVersion: 1,
+      application: options.application,
+      capabilities: ["semantic.snapshot"],
+    }),
+  )
+  socket.on("data", (chunk) => {
+    buffer += chunk
+    const lines = buffer.split("\n")
+    buffer = lines.pop() ?? ""
+    for (const line of lines) {
+      if (!line) return fail(new Error("Terminal Control sent an empty semantic message"))
+      try {
+        receive(JSON.parse(line))
+      } catch (error) {
+        return fail(error)
+      }
+    }
+  })
+  socket.once("error", fail)
+  socket.once("close", () => {
+    clearTimeout(handshakeTimer)
+    settleReady(false)
+  })
+
+  function receive(message: unknown) {
+    if (!isRecord(message)) throw new Error("Terminal Control sent an invalid semantic message")
+    if (message.type === "ready" && message.protocolVersion === 1 && !protocolReady) {
+      protocolReady = true
+      clearTimeout(handshakeTimer)
+      settleReady(true)
+      return
+    }
+    if (message.type !== "semantic.snapshot" || !protocolReady || !Number.isSafeInteger(message.id)) {
+      throw new Error("Terminal Control sent an invalid semantic snapshot request")
+    }
+    const id = message.id as number
+    Promise.resolve()
+      .then(options.snapshot)
+      .then((value) => send({ type: "result", id, value }))
+      .catch((error) =>
+        sendError(
+          id,
+          isRecord(error) && typeof error.code === "string" ? error.code : "SNAPSHOT_FAILED",
+          error instanceof Error ? error.message : String(error),
+        ),
+      )
+  }
+
+  function sendError(id: number, code: string, message: string) {
+    send({ type: "error", id, error: { code, message } })
+  }
+
+  function send(message: unknown) {
+    if (!socket.destroyed) socket.write(`${JSON.stringify(message)}\n`)
+  }
+
+  function fail(error: unknown) {
+    clearTimeout(handshakeTimer)
+    settleReady(false)
+    options.onError?.(error)
+    socket.destroy()
+  }
+
+  return {
+    enabled: true,
+    ready,
+    close() {
+      clearTimeout(handshakeTimer)
+      settleReady(false)
+      socket.destroy()
+    },
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/packages/opentui/tsconfig.build.json
+++ b/packages/opentui/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node"]
+  },
+  "include": ["src/index.ts", "src/provider.ts"]
+}

--- a/packages/opentui/tsconfig.json
+++ b/packages/opentui/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "skipLibCheck": true,
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/scripts/release-packages.mjs
+++ b/scripts/release-packages.mjs
@@ -1,0 +1,12 @@
+import { spawnSync } from "node:child_process"
+import { resolve } from "node:path"
+
+const repository = resolve(import.meta.dirname, "..")
+
+run(process.execPath, [resolve(import.meta.dirname, "publish-npm-tarballs.mjs"), "npm-artifacts"])
+run(process.execPath, [resolve(repository, "packages/opentui/script/release.mjs")])
+
+function run(command, args) {
+  const result = spawnSync(command, args, { cwd: repository, stdio: "inherit" })
+  if (result.status !== 0) process.exit(result.status ?? 1)
+}

--- a/skills/terminal-control/SKILL.md
+++ b/skills/terminal-control/SKILL.md
@@ -102,7 +102,8 @@ transition needs quiet-output settling.
 The `show` command takes an option `--format semantic` which returns a semantic tree representing the
 interactable UI elements. This requires direct support from the application to work; once the app is ready
 you can run this and see if it returns anything. If it does not, never try again for that session.
-The full command is `termctrl show app --format semantic`.
+The application must be launched with `--host opentui`; the full read command is
+`termctrl show app --format semantic`.
 
 Attempt to use the semantic UI tree if you need to discover available UI elements.
 

--- a/skills/terminal-control/SKILL.md
+++ b/skills/terminal-control/SKILL.md
@@ -97,6 +97,15 @@ transition needs quiet-output settling.
 `wait` defaults to a five-second maximum and returns as soon as its text appears. Do not pass
 `--timeout 5000`; omit it. Set `--timeout` only when intentionally choosing a different limit.
 
+## Semantic UI tree
+
+The `show` command takes an option `--format semantic` which returns a semantic tree representing the
+interactable UI elements. This requires direct support from the application to work; once the app is ready
+you can run this and see if it returns anything. If it does not, never try again for that session.
+The full command is `termctrl show app --format semantic`.
+
+Attempt to use the semantic UI tree if you need to discover available UI elements.
+
 ## Drive Input Precisely
 
 Send plain text with `text:<value>` and named keys as separate input atoms:

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -258,7 +258,7 @@ impl ManagedSession {
         let (started_send, started_receive) = mpsc::sync_channel(1);
         let session_recording = recording.clone();
         let worker = thread::spawn(move || {
-            let mut session = match Session::start(
+            let mut session = match Session::start_without_semantics(
                 &command,
                 cwd.as_deref(),
                 session_recording.as_deref(),
@@ -681,7 +681,7 @@ mod tests {
     fn driver_launch_can_clear_and_supply_environment() {
         unsafe { std::env::set_var("TERMCTRL_PARENT_ONLY", "leak") };
         let requests = concat!(
-            r#"{"id":1,"method":"launch","sessionId":"app","params":{"command":["/bin/sh","-c","printf '%s:%s' \"${TERMCTRL_PARENT_ONLY-unset}\" \"$VISIBLE\""],"inheritEnv":false,"env":{"VISIBLE":"set"}}}"#,
+            r#"{"id":1,"method":"launch","sessionId":"app","params":{"command":["/bin/sh","-c","printf '%s:%s:%s' \"${TERMCTRL_PARENT_ONLY-unset}\" \"$VISIBLE\" \"${TERMCTRL_SEMANTIC_SOCKET-unset}\""],"inheritEnv":false,"env":{"VISIBLE":"set"}}}"#,
             "\n",
             r#"{"id":2,"method":"capture","sessionId":"app","params":{"settleMs":10,"deadlineMs":2000}}"#,
             "\n",
@@ -701,7 +701,7 @@ mod tests {
             .lines()
             .map(|line| serde_json::from_str::<Value>(line).unwrap())
             .collect::<Vec<_>>();
-        assert_eq!(messages[2]["result"]["shot"]["text"], "unset:set");
+        assert_eq!(messages[2]["result"]["shot"]["text"], "unset:set:unset");
     }
 
     #[cfg(unix)]

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -681,7 +681,7 @@ mod tests {
     fn driver_launch_can_clear_and_supply_environment() {
         unsafe { std::env::set_var("TERMCTRL_PARENT_ONLY", "leak") };
         let requests = concat!(
-            r#"{"id":1,"method":"launch","sessionId":"app","params":{"command":["/bin/sh","-c","printf '%s:%s' \"${TERMCTRL_PARENT_ONLY-unset}\" \"$VISIBLE\""],"inheritEnv":false,"env":{"VISIBLE":"set"}}}"#,
+            r#"{"id":1,"method":"launch","sessionId":"app","params":{"command":["/bin/sh","-c","printf '%s:%s:%s' \"${TERMCTRL_PARENT_ONLY-unset}\" \"$VISIBLE\" \"${TERMCTRL_SEMANTIC_SOCKET-unset}\""],"inheritEnv":false,"env":{"VISIBLE":"set"}}}"#,
             "\n",
             r#"{"id":2,"method":"capture","sessionId":"app","params":{"settleMs":10,"deadlineMs":2000}}"#,
             "\n",
@@ -701,7 +701,7 @@ mod tests {
             .lines()
             .map(|line| serde_json::from_str::<Value>(line).unwrap())
             .collect::<Vec<_>>();
-        assert_eq!(messages[2]["result"]["shot"]["text"], "unset:set");
+        assert_eq!(messages[2]["result"]["shot"]["text"], "unset:set:unset");
     }
 
     #[cfg(unix)]

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -258,7 +258,7 @@ impl ManagedSession {
         let (started_send, started_receive) = mpsc::sync_channel(1);
         let session_recording = recording.clone();
         let worker = thread::spawn(move || {
-            let mut session = match Session::start_without_semantics(
+            let mut session = match Session::start(
                 &command,
                 cwd.as_deref(),
                 session_recording.as_deref(),
@@ -681,7 +681,7 @@ mod tests {
     fn driver_launch_can_clear_and_supply_environment() {
         unsafe { std::env::set_var("TERMCTRL_PARENT_ONLY", "leak") };
         let requests = concat!(
-            r#"{"id":1,"method":"launch","sessionId":"app","params":{"command":["/bin/sh","-c","printf '%s:%s:%s' \"${TERMCTRL_PARENT_ONLY-unset}\" \"$VISIBLE\" \"${TERMCTRL_SEMANTIC_SOCKET-unset}\""],"inheritEnv":false,"env":{"VISIBLE":"set"}}}"#,
+            r#"{"id":1,"method":"launch","sessionId":"app","params":{"command":["/bin/sh","-c","printf '%s:%s' \"${TERMCTRL_PARENT_ONLY-unset}\" \"$VISIBLE\""],"inheritEnv":false,"env":{"VISIBLE":"set"}}}"#,
             "\n",
             r#"{"id":2,"method":"capture","sessionId":"app","params":{"settleMs":10,"deadlineMs":2000}}"#,
             "\n",
@@ -701,7 +701,7 @@ mod tests {
             .lines()
             .map(|line| serde_json::from_str::<Value>(line).unwrap())
             .collect::<Vec<_>>();
-        assert_eq!(messages[2]["result"]["shot"]["text"], "unset:set:unset");
+        assert_eq!(messages[2]["result"]["shot"]["text"], "unset:set");
     }
 
     #[cfg(unix)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@ pub mod frame;
 pub mod mcp;
 pub mod recording;
 pub mod render;
+mod runtime;
+mod semantic;
 pub mod session;
 pub mod shot;
 mod terminal_core;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ Examples:
   termctrl attach workspace
   termctrl wait demo '/connect' && termctrl send demo text:/connect enter
   termctrl show demo
+  termctrl show demo --format semantic
   termctrl save demo --format png --out captures/provider.png
   termctrl logs demo
   termctrl restart demo
@@ -35,7 +36,8 @@ Sources:
   termctrl show --input FILE            Read ANSI/VT bytes from FILE, or use - for stdin.
   termctrl show --recording FILE        Replay the final screen of a .termctrl recording.
 
-Use --format json, --format ansi, or --format svg for another stdout-readable representation.
+Use --format json, --format ansi, or --format svg for another terminal representation. Use
+`--format semantic` with a named target for optional application-provided UI semantics.
 Use `--at-marker NAME` or `--at-ms MS` with --recording to inspect an exact moment. Use `save`
 to write files.";
 
@@ -362,7 +364,7 @@ struct ShowArgs {
     render: RenderArgs,
     #[command(flatten)]
     source: SourceArgs,
-    /// Standard-output representation of the visible screen.
+    /// Standard-output representation of the visible screen or application semantics.
     #[arg(long, value_enum, default_value = "txt")]
     format: ShotFormat,
 }
@@ -919,6 +921,8 @@ enum ShotFormat {
     Json,
     /// Original ANSI/VT terminal stream.
     Ansi,
+    /// Application-provided semantic UI snapshot.
+    Semantic,
 }
 
 impl From<ColorMode> for shot_engine::ColorMode {
@@ -1119,6 +1123,9 @@ fn main() -> Result<()> {
 }
 
 fn show(args: ShowArgs) -> Result<()> {
+    if args.format == ShotFormat::Semantic {
+        return show_semantic(&args);
+    }
     if args.format == ShotFormat::Png {
         bail!("show does not support PNG output; use save --format png --out PATH");
     }
@@ -1127,8 +1134,48 @@ fn show(args: ShowArgs) -> Result<()> {
 }
 
 fn save(args: SaveArgs) -> Result<()> {
+    if args.formats.contains(&ShotFormat::Semantic) {
+        bail!("save does not support semantic output; use show NAME --format semantic");
+    }
     let captured = read_source(&args.source, &args.render)?;
     write_outputs(&captured, &args.render, &args.out, &args.formats)
+}
+
+fn show_semantic(args: &ShowArgs) -> Result<()> {
+    let source = &args.source;
+    let name = source
+        .name
+        .as_deref()
+        .context("semantic output requires a named session or workspace")?;
+    if source.pipe
+        || source.input.is_some()
+        || source.recording.is_some()
+        || source.at_marker.is_some()
+        || source.at_ms.is_some()
+        || source.cols.is_some()
+        || source.rows.is_some()
+        || source.color.is_some()
+        || source.settle_ms.is_some()
+        || source.initial_delay_ms.is_some()
+        || source.wait_for.is_some()
+        || source.max_bytes.is_some()
+        || source.cwd.is_some()
+        || source.host.is_some()
+        || !source.send.is_empty()
+        || !source.command.is_empty()
+    {
+        bail!(
+            "semantic output supports a named target, --window or --pane, and --deadline-ms only"
+        );
+    }
+    let timeout = Duration::from_millis(source.deadline_ms.unwrap_or(1000));
+    if timeout.is_zero() {
+        bail!("--deadline-ms must be greater than zero for semantic output");
+    }
+    let snapshot =
+        session::semantic_snapshot_in(name, source.window.clone(), source.pane, timeout)?;
+    println!("{}", serde_json::to_string_pretty(&snapshot)?);
+    Ok(())
 }
 
 fn read_source(args: &SourceArgs, render: &RenderArgs) -> Result<shot_engine::Shot> {
@@ -1802,6 +1849,7 @@ fn write_stdout(captured: &shot_engine::Shot, args: &RenderArgs, format: ShotFor
         ShotFormat::Ansi => captured.ansi.clone(),
         ShotFormat::Svg => rendered_svg(captured, args).into_bytes(),
         ShotFormat::Png => unreachable!("show validates PNG before reading source"),
+        ShotFormat::Semantic => unreachable!("show handles semantic output before reading source"),
     };
     io::stdout()
         .write_all(&bytes)
@@ -2066,6 +2114,7 @@ mod tests {
             Cli::try_parse_from(["termctrl", "show", "workspace", "--window", "editor"]).is_ok()
         );
         assert!(Cli::try_parse_from(["termctrl", "status", "demo", "--json"]).is_ok());
+        assert!(Cli::try_parse_from(["termctrl", "show", "demo", "--format", "semantic"]).is_ok());
         assert!(Cli::try_parse_from(["termctrl", "list"]).is_ok());
         assert!(Cli::try_parse_from(["termctrl", "list", "--all", "--json"]).is_ok());
         assert!(Cli::try_parse_from(["termctrl", "prune", "--dry-run"]).is_ok());
@@ -2083,6 +2132,18 @@ mod tests {
         assert!(
             Cli::try_parse_from(["termctrl", "wait", "demo", "ready", "--timeout", "5"]).is_ok()
         );
+    }
+
+    #[test]
+    fn parses_semantic_show_format() {
+        let cli =
+            Cli::try_parse_from(["termctrl", "show", "demo", "--format", "semantic"]).unwrap();
+        let Command::Show(args) = cli.command else {
+            panic!("expected show command");
+        };
+
+        assert_eq!(args.source.name.as_deref(), Some("demo"));
+        assert_eq!(args.format, ShotFormat::Semantic);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1147,27 +1147,6 @@ fn show_semantic(args: &ShowArgs) -> Result<()> {
         .name
         .as_deref()
         .context("semantic output requires a named session or workspace")?;
-    if source.pipe
-        || source.input.is_some()
-        || source.recording.is_some()
-        || source.at_marker.is_some()
-        || source.at_ms.is_some()
-        || source.cols.is_some()
-        || source.rows.is_some()
-        || source.color.is_some()
-        || source.settle_ms.is_some()
-        || source.initial_delay_ms.is_some()
-        || source.wait_for.is_some()
-        || source.max_bytes.is_some()
-        || source.cwd.is_some()
-        || source.host.is_some()
-        || !source.send.is_empty()
-        || !source.command.is_empty()
-    {
-        bail!(
-            "semantic output supports a named target, --window or --pane, and --deadline-ms only"
-        );
-    }
     let timeout = Duration::from_millis(source.deadline_ms.unwrap_or(1000));
     if timeout.is_zero() {
         bail!("--deadline-ms must be greater than zero for semantic output");

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -18,10 +18,17 @@ mod implementation {
         match fs::symlink_metadata(&path) {
             Ok(metadata) => require_private_directory(&path, &metadata)?,
             Err(error) if error.kind() == ErrorKind::NotFound => {
-                fs::DirBuilder::new()
-                    .mode(0o700)
-                    .create(&path)
-                    .with_context(|| format!("create {}", path.display()))?;
+                match fs::DirBuilder::new().mode(0o700).create(&path) {
+                    Ok(()) => {}
+                    Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+                        let metadata = fs::symlink_metadata(&path)
+                            .with_context(|| format!("inspect {}", path.display()))?;
+                        require_private_directory(&path, &metadata)?;
+                    }
+                    Err(error) => {
+                        return Err(error).with_context(|| format!("create {}", path.display()));
+                    }
+                }
             }
             Err(error) => {
                 return Err(error).with_context(|| format!("inspect {}", path.display()));

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,73 @@
+#[cfg(unix)]
+mod implementation {
+    use std::fs;
+    use std::io::ErrorKind;
+    use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
+    use std::path::{Path, PathBuf};
+
+    use anyhow::{Context, Result, bail};
+
+    const MAX_SOCKET_PATH_BYTES: usize = 100;
+
+    pub(crate) fn directory() -> Result<PathBuf> {
+        let path = std::env::var_os("TERMCTRL_RUNTIME_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| {
+                PathBuf::from(format!("/tmp/termctrl-{}", unsafe { libc::geteuid() }))
+            });
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) => require_private_directory(&path, &metadata)?,
+            Err(error) if error.kind() == ErrorKind::NotFound => {
+                fs::DirBuilder::new()
+                    .mode(0o700)
+                    .create(&path)
+                    .with_context(|| format!("create {}", path.display()))?;
+            }
+            Err(error) => {
+                return Err(error).with_context(|| format!("inspect {}", path.display()));
+            }
+        }
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("secure {}", path.display()))?;
+        Ok(path)
+    }
+
+    pub(crate) fn ensure_socket_path(path: &Path, kind: &str) -> Result<()> {
+        if path.as_os_str().as_encoded_bytes().len() >= MAX_SOCKET_PATH_BYTES {
+            bail!(
+                "{kind} path is too long for portable Unix sockets: {}; set TERMCTRL_RUNTIME_DIR to a shorter directory",
+                path.display()
+            );
+        }
+        Ok(())
+    }
+
+    fn require_private_directory(path: &Path, metadata: &fs::Metadata) -> Result<()> {
+        if !metadata.file_type().is_dir() || metadata.file_type().is_symlink() {
+            bail!(
+                "session runtime path must be a real directory: {}",
+                path.display()
+            );
+        }
+        if metadata.uid() != unsafe { libc::geteuid() } {
+            bail!(
+                "session runtime directory is not owned by the current user: {}",
+                path.display()
+            );
+        }
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+pub(crate) use implementation::{directory, ensure_socket_path};
+
+#[cfg(not(unix))]
+pub(crate) fn directory() -> anyhow::Result<std::path::PathBuf> {
+    anyhow::bail!("application semantic sockets require Unix sockets")
+}
+
+#[cfg(not(unix))]
+pub(crate) fn ensure_socket_path(_: &std::path::Path, _: &str) -> anyhow::Result<()> {
+    anyhow::bail!("application semantic sockets require Unix sockets")
+}

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -1,0 +1,1109 @@
+pub(crate) const SOCKET_ENV: &str = "TERMCTRL_SEMANTIC_SOCKET";
+
+pub(crate) fn empty_semantic_snapshot() -> serde_json::Value {
+    serde_json::json!({
+        "format": "termctrl-semantic-snapshot-v1",
+        "nodes": []
+    })
+}
+
+pub(crate) fn deadline_unix_ms(timeout: std::time::Duration) -> anyhow::Result<u64> {
+    if timeout.is_zero() {
+        anyhow::bail!("semantic timeout must be greater than zero");
+    }
+    Ok(unix_time_ms()?.saturating_add(timeout.as_millis() as u64))
+}
+
+pub(crate) fn remaining(deadline_unix_ms: u64) -> anyhow::Result<std::time::Duration> {
+    let timeout_ms = deadline_unix_ms.saturating_sub(unix_time_ms()?);
+    if timeout_ms == 0 {
+        anyhow::bail!("application semantic timed out before it was handled");
+    }
+    Ok(std::time::Duration::from_millis(timeout_ms))
+}
+
+fn unix_time_ms() -> anyhow::Result<u64> {
+    Ok(std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|error| anyhow::anyhow!("read system time: {error}"))?
+        .as_millis() as u64)
+}
+
+#[cfg(unix)]
+mod implementation {
+    use std::collections::BTreeSet;
+    use std::fs;
+    use std::io::{ErrorKind, Read, Write};
+    use std::os::fd::{AsRawFd, FromRawFd, RawFd};
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::net::{UnixListener, UnixStream};
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    use anyhow::{Context, Result, anyhow, bail};
+    use serde::de::DeserializeOwned;
+    use serde::{Deserialize, Serialize};
+    use serde_json::Value;
+
+    const PROTOCOL_VERSION: u8 = 1;
+    const MAX_MESSAGE_BYTES: usize = 8 * 1024 * 1024;
+    const MAX_SESSION_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
+    const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+    const HANDSHAKE_WRITE_TIMEOUT: Duration = Duration::from_secs(2);
+    static NEXT_SOCKET_ID: AtomicU64 = AtomicU64::new(0);
+
+    pub(crate) struct Host {
+        listener: UnixListener,
+        path: PathBuf,
+        pending: Option<PendingConnection>,
+        connection: Option<Connection>,
+        failure: Option<String>,
+    }
+
+    struct PendingConnection {
+        stream: UnixStream,
+        input: Vec<u8>,
+        accepted_at: Instant,
+    }
+
+    struct Connection {
+        stream: UnixStream,
+        input: Vec<u8>,
+        application: Application,
+        capabilities: BTreeSet<String>,
+        next_id: u64,
+        pending_id: Option<u64>,
+    }
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Hello {
+        #[serde(rename = "type")]
+        kind: String,
+        protocol_version: u8,
+        application: Application,
+        capabilities: Vec<String>,
+    }
+
+    #[derive(Deserialize)]
+    struct Application {
+        name: String,
+        version: Option<String>,
+    }
+
+    impl Application {
+        fn identity(&self) -> String {
+            self.version.as_ref().map_or_else(
+                || self.name.clone(),
+                |version| format!("{} {version}", self.name),
+            )
+        }
+    }
+
+    #[derive(Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct SnapshotRequest {
+        #[serde(rename = "type")]
+        kind: &'static str,
+        id: u64,
+    }
+
+    #[derive(Deserialize)]
+    #[serde(tag = "type", rename_all = "lowercase")]
+    enum SnapshotReply {
+        Result { id: u64, value: Value },
+        Error { id: u64, error: SnapshotError },
+    }
+
+    #[derive(Deserialize)]
+    struct SnapshotError {
+        code: String,
+        message: String,
+    }
+
+    enum HandshakeRead {
+        Pending,
+        Closed,
+        Hello(Hello),
+    }
+
+    enum SnapshotPoll {
+        Pending,
+        Result(Value),
+        Error { code: String, message: String },
+    }
+
+    impl Host {
+        pub(crate) fn bind() -> Result<Self> {
+            let runtime = crate::runtime::directory()?;
+            for _ in 0..100 {
+                let id = NEXT_SOCKET_ID.fetch_add(1, Ordering::Relaxed);
+                let path = runtime.join(format!("semantic-{}-{id}.semantic", std::process::id()));
+                crate::runtime::ensure_socket_path(&path, "application semantic socket")?;
+                let listener = match UnixListener::bind(&path) {
+                    Ok(listener) => listener,
+                    Err(error) if error.kind() == ErrorKind::AddrInUse => continue,
+                    Err(error) => {
+                        return Err(error).with_context(|| format!("bind {}", path.display()));
+                    }
+                };
+                if let Err(error) = fs::set_permissions(&path, fs::Permissions::from_mode(0o600)) {
+                    let _ = fs::remove_file(&path);
+                    return Err(error).with_context(|| format!("secure {}", path.display()));
+                }
+                if let Err(error) = listener.set_nonblocking(true) {
+                    let _ = fs::remove_file(&path);
+                    return Err(error).context("set application semantic socket nonblocking");
+                }
+                return Ok(Self {
+                    listener,
+                    path,
+                    pending: None,
+                    connection: None,
+                    failure: None,
+                });
+            }
+            bail!("could not allocate a unique application semantic socket")
+        }
+
+        pub(crate) fn path(&self) -> Option<&Path> {
+            Some(&self.path)
+        }
+
+        pub(crate) fn pump(&mut self) {
+            if let Some(connection) = &self.connection {
+                let mut byte = [0_u8; 1];
+                let read = unsafe {
+                    libc::recv(
+                        connection.stream.as_raw_fd(),
+                        byte.as_mut_ptr().cast(),
+                        byte.len(),
+                        libc::MSG_PEEK,
+                    )
+                };
+                if read == 0 {
+                    self.connection = None;
+                    self.failure = Some("application semantic provider disconnected".to_owned());
+                } else if read > 0 {
+                    return;
+                } else {
+                    let error = std::io::Error::last_os_error();
+                    if error.kind() == ErrorKind::WouldBlock {
+                        return;
+                    }
+                    self.connection = None;
+                    self.failure = Some(format!("inspect application semantic provider: {error}"));
+                }
+            }
+            loop {
+                match self.listener.accept() {
+                    Ok((stream, _)) => {
+                        if let Err(error) = stream.set_nonblocking(true) {
+                            self.failure = Some(format!(
+                                "configure application semantic connection: {error}"
+                            ));
+                            return;
+                        }
+                        self.pending = Some(PendingConnection {
+                            stream,
+                            input: Vec::new(),
+                            accepted_at: Instant::now(),
+                        });
+                    }
+                    Err(error) if error.kind() == ErrorKind::WouldBlock => break,
+                    Err(error) => {
+                        self.failure =
+                            Some(format!("accept application semantic connection: {error}"));
+                        return;
+                    }
+                }
+            }
+            if self.pending.is_none() {
+                return;
+            }
+
+            let read = read_handshake(self.pending.as_mut().expect("pending connection exists"));
+            match read {
+                Ok(HandshakeRead::Pending) => {}
+                Ok(HandshakeRead::Closed) => {
+                    self.pending = None;
+                    self.failure = Some(
+                        "application disconnected before completing the semantic handshake"
+                            .to_owned(),
+                    );
+                }
+                Ok(HandshakeRead::Hello(hello)) => {
+                    if let Err(error) = self.finish_handshake(hello) {
+                        self.pending = None;
+                        self.failure = Some(format!("{error:#}"));
+                    }
+                }
+                Err(error) => {
+                    self.pending = None;
+                    self.failure = Some(format!("{error:#}"));
+                }
+            }
+        }
+
+        pub(crate) fn snapshot(
+            &mut self,
+            timeout: Duration,
+            mut pump_session: impl FnMut() -> Result<bool>,
+        ) -> Result<Option<Value>> {
+            if timeout.is_zero() {
+                bail!("semantic snapshot timeout must be greater than zero");
+            }
+            self.pump();
+            if !self.is_ready() && self.pending.is_none() {
+                return Ok(None);
+            }
+            let deadline = Instant::now() + timeout;
+            loop {
+                self.pump();
+                if pump_session()? {
+                    bail!("session ended before its application semantic provider became ready");
+                }
+                if Instant::now() >= deadline {
+                    let detail = self
+                        .failure()
+                        .map(|failure| format!(": {failure}"))
+                        .unwrap_or_default();
+                    let message =
+                        format!("timed out waiting for application semantic provider{detail}");
+                    self.abort_snapshot(&message);
+                    bail!(message);
+                }
+                if self.is_ready() {
+                    break;
+                }
+                sleep_until(deadline, Duration::from_millis(10));
+            }
+
+            if !self.supports_snapshot() {
+                return Ok(None);
+            }
+
+            let id = self.start_snapshot(deadline)?;
+            loop {
+                if Instant::now() >= deadline {
+                    let message = "application semantic snapshot timed out".to_owned();
+                    self.abort_snapshot(&message);
+                    bail!(message);
+                }
+                match self.poll_snapshot(id, deadline)? {
+                    SnapshotPoll::Pending => {}
+                    SnapshotPoll::Result(value) => return Ok(Some(value)),
+                    SnapshotPoll::Error { code, message } => {
+                        bail!("application semantic snapshot failed ({code}): {message}");
+                    }
+                }
+                if pump_session()? {
+                    return match self.poll_snapshot(id, deadline)? {
+                        SnapshotPoll::Result(value) => Ok(Some(value)),
+                        SnapshotPoll::Error { code, message } => {
+                            bail!("application semantic snapshot failed ({code}): {message}")
+                        }
+                        SnapshotPoll::Pending => {
+                            bail!("session ended while answering application semantic snapshot")
+                        }
+                    };
+                }
+                sleep_until(deadline, Duration::from_millis(10));
+            }
+        }
+
+        fn is_ready(&self) -> bool {
+            self.connection.is_some()
+        }
+
+        fn failure(&self) -> Option<&str> {
+            self.failure.as_deref()
+        }
+
+        fn supports_snapshot(&self) -> bool {
+            self.connection
+                .as_ref()
+                .is_some_and(|connection| connection.capabilities.contains("semantic.snapshot"))
+        }
+
+        fn start_snapshot(&mut self, deadline: Instant) -> Result<u64> {
+            if Instant::now() >= deadline {
+                bail!("application semantic snapshot timed out");
+            }
+            let connection = self.connection.as_mut().ok_or_else(|| {
+                anyhow!(
+                    "application semantic provider is not ready{}",
+                    self.failure
+                        .as_deref()
+                        .map(|failure| format!(": {failure}"))
+                        .unwrap_or_default()
+                )
+            })?;
+            if !connection.capabilities.contains("semantic.snapshot") {
+                bail!(
+                    "application {} does not support semantic snapshots",
+                    connection.application.identity()
+                );
+            }
+            if connection.pending_id.is_some() {
+                bail!("application semantic is already in progress");
+            }
+
+            let id = connection.next_id;
+            connection.next_id = connection.next_id.wrapping_add(1);
+            let result = start_snapshot(connection, id, deadline);
+            if let Err(error) = &result {
+                self.failure = Some(error.to_string());
+                self.connection = None;
+            }
+            result
+        }
+
+        fn poll_snapshot(&mut self, id: u64, deadline: Instant) -> Result<SnapshotPoll> {
+            let connection = self
+                .connection
+                .as_mut()
+                .context("application semantic provider disconnected")?;
+            let result = poll_snapshot(connection, id, deadline);
+            if let Err(error) = &result {
+                self.failure = Some(error.to_string());
+                self.connection = None;
+            }
+            result
+        }
+
+        fn abort_snapshot(&mut self, message: &str) {
+            self.failure = Some(message.to_owned());
+            self.pending = None;
+            self.connection = None;
+        }
+
+        fn finish_handshake(&mut self, hello: Hello) -> Result<()> {
+            if hello.kind != "hello" {
+                bail!("first application semantic message must be a hello");
+            }
+            if hello.protocol_version != PROTOCOL_VERSION {
+                bail!(
+                    "unsupported application semantic protocol version {}",
+                    hello.protocol_version
+                );
+            }
+            if hello.application.name.is_empty() {
+                bail!("application semantic hello requires a nonempty application name");
+            }
+            if hello.capabilities.iter().any(String::is_empty) {
+                bail!("application semantic capabilities must not be empty");
+            }
+            let capabilities = hello.capabilities.into_iter().collect::<BTreeSet<_>>();
+            let mut pending = self.pending.take().expect("pending connection exists");
+            pending
+                .stream
+                .set_nonblocking(false)
+                .context("set application semantic connection blocking")?;
+            pending
+                .stream
+                .set_write_timeout(Some(HANDSHAKE_WRITE_TIMEOUT))
+                .context("set application semantic handshake timeout")?;
+            write_json_line(
+                &mut pending.stream,
+                &serde_json::json!({
+                    "type": "ready",
+                    "protocolVersion": PROTOCOL_VERSION
+                }),
+            )?;
+            pending
+                .stream
+                .set_nonblocking(true)
+                .context("set application semantic connection nonblocking")?;
+            self.connection = Some(Connection {
+                stream: pending.stream,
+                input: Vec::new(),
+                application: hello.application,
+                capabilities,
+                next_id: 1,
+                pending_id: None,
+            });
+            self.failure = None;
+            Ok(())
+        }
+    }
+
+    impl Drop for Host {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+
+    fn read_handshake(pending: &mut PendingConnection) -> Result<HandshakeRead> {
+        if pending.accepted_at.elapsed() >= HANDSHAKE_TIMEOUT {
+            bail!("application semantic handshake timed out");
+        }
+        let mut chunk = [0_u8; 4096];
+        loop {
+            match pending.stream.read(&mut chunk) {
+                Ok(0) => return Ok(HandshakeRead::Closed),
+                Ok(length) => {
+                    pending.input.extend_from_slice(&chunk[..length]);
+                    if pending.input.len() > MAX_MESSAGE_BYTES {
+                        bail!("application semantic hello exceeds {MAX_MESSAGE_BYTES} bytes");
+                    }
+                    if let Some(newline) = pending.input.iter().position(|byte| *byte == b'\n') {
+                        if pending.input[newline + 1..]
+                            .iter()
+                            .any(|byte| !byte.is_ascii_whitespace())
+                        {
+                            bail!("application sent semantic data before the handshake completed");
+                        }
+                        let hello = serde_json::from_slice(&pending.input[..newline])
+                            .context("parse application semantic hello")?;
+                        return Ok(HandshakeRead::Hello(hello));
+                    }
+                }
+                Err(error) if error.kind() == ErrorKind::WouldBlock => {
+                    return Ok(HandshakeRead::Pending);
+                }
+                Err(error) => return Err(error).context("read application semantic hello"),
+            }
+        }
+    }
+
+    fn start_snapshot(connection: &mut Connection, id: u64, deadline: Instant) -> Result<u64> {
+        write_json_line_until(
+            &mut connection.stream,
+            &SnapshotRequest {
+                kind: "semantic.snapshot",
+                id,
+            },
+            deadline,
+        )?;
+        connection.pending_id = Some(id);
+        Ok(id)
+    }
+
+    fn poll_snapshot(
+        connection: &mut Connection,
+        id: u64,
+        deadline: Instant,
+    ) -> Result<SnapshotPoll> {
+        if connection.pending_id != Some(id) {
+            bail!("application semantic snapshot {id} is not in progress");
+        }
+        let mut chunk = [0_u8; 4096];
+        loop {
+            if Instant::now() >= deadline {
+                bail!("application semantic snapshot {id} timed out");
+            }
+            match connection.stream.read(&mut chunk) {
+                Ok(0) => bail!("application disconnected while answering semantic {id}"),
+                Ok(length) => {
+                    connection.input.extend_from_slice(&chunk[..length]);
+                    if connection.input.len() > MAX_MESSAGE_BYTES {
+                        bail!("application semantic response exceeds {MAX_MESSAGE_BYTES} bytes");
+                    }
+                    if connection.input.contains(&b'\n') {
+                        break;
+                    }
+                }
+                Err(error) if error.kind() == ErrorKind::WouldBlock => break,
+                Err(error) => return Err(error).context("read application semantic response"),
+            }
+        }
+        let Some(newline) = connection.input.iter().position(|byte| *byte == b'\n') else {
+            return Ok(SnapshotPoll::Pending);
+        };
+        if Instant::now() >= deadline {
+            bail!("application semantic snapshot {id} timed out");
+        }
+        if connection.input[newline + 1..]
+            .iter()
+            .any(|byte| !byte.is_ascii_whitespace())
+        {
+            bail!("application sent more than one semantic response");
+        }
+        if newline + 1 > MAX_MESSAGE_BYTES {
+            bail!("application semantic response exceeds {MAX_MESSAGE_BYTES} bytes");
+        }
+        let reply: SnapshotReply = serde_json::from_slice(&connection.input[..newline])
+            .context("parse application semantic response")?;
+        if Instant::now() >= deadline {
+            bail!("application semantic snapshot {id} timed out");
+        }
+        connection.input.clear();
+        connection.pending_id = None;
+        let result = match reply {
+            SnapshotReply::Result {
+                id: response_id,
+                value,
+            } if response_id == id => SnapshotPoll::Result(value),
+            SnapshotReply::Error {
+                id: response_id,
+                error,
+            } if response_id == id => SnapshotPoll::Error {
+                code: error.code,
+                message: error.message,
+            },
+            SnapshotReply::Result {
+                id: response_id, ..
+            }
+            | SnapshotReply::Error {
+                id: response_id, ..
+            } => {
+                bail!(
+                    "application semantic response id {response_id} does not match request id {id}"
+                )
+            }
+        };
+        Ok(result)
+    }
+
+    fn write_json_line(writer: &mut impl Write, message: &impl Serialize) -> Result<()> {
+        serde_json::to_writer(&mut *writer, message)
+            .context("write application semantic message")?;
+        writer
+            .write_all(b"\n")
+            .context("write application semantic newline")?;
+        writer.flush().context("flush application semantic message")
+    }
+
+    fn write_json_line_until(
+        stream: &mut UnixStream,
+        message: &impl Serialize,
+        deadline: Instant,
+    ) -> Result<()> {
+        let mut bytes =
+            serde_json::to_vec(message).context("encode application semantic message")?;
+        bytes.push(b'\n');
+        let mut written = 0;
+        while written < bytes.len() {
+            if Instant::now() >= deadline {
+                bail!("timed out writing application semantic request");
+            }
+            match stream.write(&bytes[written..]) {
+                Ok(0) => bail!("application disconnected while writing semantic request"),
+                Ok(length) => written += length,
+                Err(error) if error.kind() == ErrorKind::WouldBlock => {
+                    std::thread::sleep(
+                        deadline
+                            .saturating_duration_since(Instant::now())
+                            .min(Duration::from_millis(1)),
+                    );
+                }
+                Err(error) => return Err(error).context("write application semantic request"),
+            }
+        }
+        Ok(())
+    }
+
+    fn sleep_until(deadline: Instant, interval: Duration) {
+        thread::sleep(
+            deadline
+                .saturating_duration_since(Instant::now())
+                .min(interval),
+        );
+    }
+
+    pub(crate) fn request_snapshot<Request, Response>(
+        socket: &Path,
+        request: &Request,
+        timeout: Duration,
+    ) -> Result<Response>
+    where
+        Request: Serialize,
+        Response: DeserializeOwned,
+    {
+        crate::runtime::ensure_socket_path(socket, "session socket")?;
+        let deadline = Instant::now() + timeout;
+        let mut stream = connect_until(socket, deadline).with_context(|| {
+            format!("connect to session at {}; is it running?", socket.display())
+        })?;
+        let request = serde_json::to_vec(request).context("encode session semantic request")?;
+        write_until(&mut stream, &request, deadline)?;
+        stream
+            .shutdown(std::net::Shutdown::Write)
+            .context("finish session semantic request")?;
+        let bytes = read_until_close(&mut stream, deadline)?;
+        let response = serde_json::from_slice(&bytes).context("read session semantic response")?;
+        if Instant::now() >= deadline {
+            bail!("timed out parsing session semantic response");
+        }
+        Ok(response)
+    }
+
+    fn write_until(stream: &mut UnixStream, bytes: &[u8], deadline: Instant) -> Result<()> {
+        let mut written = 0;
+        while written < bytes.len() {
+            if Instant::now() >= deadline {
+                bail!("timed out writing session semantic request");
+            }
+            match stream.write(&bytes[written..]) {
+                Ok(0) => bail!("session closed while writing semantic request"),
+                Ok(length) => written += length,
+                Err(error) if error.kind() == ErrorKind::WouldBlock => sleep_until_io(deadline),
+                Err(error) => return Err(error).context("write session semantic request"),
+            }
+        }
+        Ok(())
+    }
+
+    fn read_until_close(stream: &mut UnixStream, deadline: Instant) -> Result<Vec<u8>> {
+        let mut bytes = Vec::new();
+        let mut chunk = [0_u8; 4096];
+        loop {
+            if Instant::now() >= deadline {
+                bail!("timed out waiting for session semantic response");
+            }
+            match stream.read(&mut chunk) {
+                Ok(0) => return Ok(bytes),
+                Ok(length) => {
+                    bytes.extend_from_slice(&chunk[..length]);
+                    if bytes.len() > MAX_SESSION_RESPONSE_BYTES {
+                        bail!("session response exceeds {MAX_SESSION_RESPONSE_BYTES} bytes");
+                    }
+                }
+                Err(error) if error.kind() == ErrorKind::WouldBlock => sleep_until_io(deadline),
+                Err(error) => return Err(error).context("read session semantic response"),
+            }
+        }
+    }
+
+    fn sleep_until_io(deadline: Instant) {
+        thread::sleep(
+            deadline
+                .saturating_duration_since(Instant::now())
+                .min(Duration::from_millis(5)),
+        );
+    }
+
+    fn connect_until(path: &Path, deadline: Instant) -> Result<UnixStream> {
+        let path_bytes = path.as_os_str().as_bytes();
+        let mut address = unsafe { std::mem::zeroed::<libc::sockaddr_un>() };
+        if path_bytes.len() >= address.sun_path.len() {
+            bail!("session socket path is too long: {}", path.display());
+        }
+        address.sun_family = libc::AF_UNIX as _;
+        for (target, source) in address.sun_path.iter_mut().zip(path_bytes) {
+            *target = *source as libc::c_char;
+        }
+        let address_len = (std::mem::offset_of!(libc::sockaddr_un, sun_path) + path_bytes.len() + 1)
+            as libc::socklen_t;
+        #[cfg(any(
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "freebsd",
+            target_os = "openbsd",
+            target_os = "netbsd",
+            target_os = "dragonfly"
+        ))]
+        {
+            address.sun_len = address_len as u8;
+        }
+
+        let fd = unsafe { libc::socket(libc::AF_UNIX, libc::SOCK_STREAM, 0) };
+        if fd < 0 {
+            return Err(std::io::Error::last_os_error()).context("create session semantic socket");
+        }
+        let mut fd = OwnedFd(fd);
+        let flags = unsafe { libc::fcntl(fd.0, libc::F_GETFL) };
+        if flags < 0
+            || unsafe { libc::fcntl(fd.0, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0
+            || unsafe { libc::fcntl(fd.0, libc::F_SETFD, libc::FD_CLOEXEC) } < 0
+        {
+            return Err(std::io::Error::last_os_error())
+                .context("configure session semantic socket");
+        }
+        let connected = unsafe {
+            libc::connect(
+                fd.0,
+                (&raw const address).cast::<libc::sockaddr>(),
+                address_len,
+            )
+        };
+        if connected != 0 {
+            let error = std::io::Error::last_os_error();
+            if error.raw_os_error() != Some(libc::EINPROGRESS)
+                && error.raw_os_error() != Some(libc::EAGAIN)
+            {
+                return Err(error).context("connect session semantic socket");
+            }
+            wait_for_connect(fd.0, deadline)?;
+        }
+        let fd = fd.take();
+        Ok(unsafe { UnixStream::from_raw_fd(fd) })
+    }
+
+    fn wait_for_connect(fd: RawFd, deadline: Instant) -> Result<()> {
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                bail!("timed out connecting to session");
+            }
+            let timeout_ms = remaining.as_millis().clamp(1, i32::MAX as u128) as i32;
+            let mut poll = libc::pollfd {
+                fd,
+                events: libc::POLLOUT,
+                revents: 0,
+            };
+            let result = unsafe { libc::poll(&mut poll, 1, timeout_ms) };
+            if result == 0 {
+                bail!("timed out connecting to session");
+            }
+            if result < 0 {
+                let error = std::io::Error::last_os_error();
+                if error.kind() == ErrorKind::Interrupted {
+                    continue;
+                }
+                return Err(error).context("wait for session semantic connection");
+            }
+            let mut socket_error = 0_i32;
+            let mut length = std::mem::size_of::<i32>() as libc::socklen_t;
+            if unsafe {
+                libc::getsockopt(
+                    fd,
+                    libc::SOL_SOCKET,
+                    libc::SO_ERROR,
+                    (&raw mut socket_error).cast(),
+                    &mut length,
+                )
+            } != 0
+            {
+                return Err(std::io::Error::last_os_error())
+                    .context("inspect session semantic connection");
+            }
+            if socket_error != 0 {
+                return Err(std::io::Error::from_raw_os_error(socket_error))
+                    .context("connect session semantic socket");
+            }
+            return Ok(());
+        }
+    }
+
+    struct OwnedFd(RawFd);
+
+    impl OwnedFd {
+        fn take(&mut self) -> RawFd {
+            std::mem::replace(&mut self.0, -1)
+        }
+    }
+
+    impl Drop for OwnedFd {
+        fn drop(&mut self) {
+            if self.0 >= 0 {
+                unsafe {
+                    libc::close(self.0);
+                }
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use std::io::{BufRead, BufReader};
+        use std::os::unix::fs::{FileTypeExt, PermissionsExt};
+        use std::thread;
+        use std::time::Instant;
+
+        use super::*;
+
+        #[test]
+        fn socket_reads_an_advertised_semantic_snapshot() {
+            let mut socket = Host::bind().unwrap();
+            let path = socket.path().unwrap().to_owned();
+            let metadata = fs::metadata(&path).unwrap();
+            assert!(metadata.file_type().is_socket());
+            assert_eq!(metadata.permissions().mode() & 0o777, 0o600);
+            assert_eq!(
+                path.extension().and_then(|value| value.to_str()),
+                Some("semantic")
+            );
+
+            let application = thread::spawn(move || {
+                let mut stream = UnixStream::connect(path).unwrap();
+                write_json_line(
+                    &mut stream,
+                    &serde_json::json!({
+                        "type": "hello",
+                        "protocolVersion": 1,
+                        "application": { "name": "fixture", "version": "1.0.0" },
+                        "capabilities": ["semantic.snapshot"]
+                    }),
+                )
+                .unwrap();
+                let mut stream = BufReader::new(stream);
+                let mut line = String::new();
+                stream.read_line(&mut line).unwrap();
+                assert_eq!(
+                    serde_json::from_str::<Value>(&line).unwrap(),
+                    serde_json::json!({ "type": "ready", "protocolVersion": 1 })
+                );
+                for sequence in 1..=2 {
+                    line.clear();
+                    stream.read_line(&mut line).unwrap();
+                    let request = serde_json::from_str::<Value>(&line).unwrap();
+                    assert_eq!(request["type"], "semantic.snapshot");
+                    let response = if sequence == 1 {
+                        serde_json::json!({
+                            "type": "error",
+                            "id": request["id"],
+                            "error": { "code": "NOT_READY", "message": "try again" }
+                        })
+                    } else {
+                        serde_json::json!({
+                            "type": "result",
+                            "id": request["id"],
+                            "value": {
+                                "format": "termctrl-semantic-snapshot-v1",
+                                "sequence": sequence,
+                                "nodes": []
+                            }
+                        })
+                    };
+                    write_json_line(stream.get_mut(), &response).unwrap();
+                }
+            });
+
+            let deadline = Instant::now() + Duration::from_secs(2);
+            while !socket.is_ready() {
+                socket.pump();
+                assert!(
+                    Instant::now() < deadline,
+                    "semantic provider did not become ready"
+                );
+                thread::sleep(Duration::from_millis(1));
+            }
+            let first = socket
+                .snapshot(Duration::from_secs(2), || Ok(false))
+                .unwrap_err();
+            assert!(first.to_string().contains("NOT_READY"));
+            let second = socket
+                .snapshot(Duration::from_secs(2), || Ok(false))
+                .unwrap()
+                .unwrap();
+            assert_eq!(second["format"], "termctrl-semantic-snapshot-v1");
+            assert_eq!(second["sequence"], 2);
+            application.join().unwrap();
+            let path = socket.path().unwrap().to_owned();
+            drop(socket);
+            assert!(!path.exists());
+        }
+
+        #[test]
+        fn socket_returns_none_without_the_semantic_capability() {
+            let mut socket = Host::bind().unwrap();
+            let path = socket.path().unwrap().to_owned();
+            let application = thread::spawn(move || {
+                let mut stream = UnixStream::connect(path).unwrap();
+                write_json_line(
+                    &mut stream,
+                    &serde_json::json!({
+                        "type": "hello",
+                        "protocolVersion": 1,
+                        "application": { "name": "fixture" },
+                        "capabilities": []
+                    }),
+                )
+                .unwrap();
+                let mut ready = String::new();
+                let mut stream = BufReader::new(stream);
+                stream.read_line(&mut ready).unwrap();
+                thread::sleep(Duration::from_millis(100));
+            });
+            let deadline = Instant::now() + Duration::from_secs(2);
+            while !socket.is_ready() {
+                socket.pump();
+                assert!(
+                    Instant::now() < deadline,
+                    "semantic provider did not become ready"
+                );
+                thread::sleep(Duration::from_millis(1));
+            }
+
+            assert!(
+                socket
+                    .snapshot(Duration::from_secs(1), || Ok(false))
+                    .unwrap()
+                    .is_none()
+            );
+            application.join().unwrap();
+        }
+
+        #[test]
+        fn newer_provider_replaces_an_incomplete_handshake() {
+            let mut socket = Host::bind().unwrap();
+            let path = socket.path().unwrap().to_owned();
+            let _silent = UnixStream::connect(&path).unwrap();
+            socket.pump();
+            let application = thread::spawn(move || {
+                let mut stream = UnixStream::connect(path).unwrap();
+                write_json_line(
+                    &mut stream,
+                    &serde_json::json!({
+                        "type": "hello",
+                        "protocolVersion": 1,
+                        "application": { "name": "fixture" },
+                        "capabilities": ["semantic.snapshot"]
+                    }),
+                )
+                .unwrap();
+                let mut ready = String::new();
+                BufReader::new(stream).read_line(&mut ready).unwrap();
+                assert!(ready.contains("\"type\":\"ready\""));
+            });
+            let deadline = Instant::now() + Duration::from_secs(2);
+
+            while !socket.is_ready() {
+                socket.pump();
+                assert!(
+                    Instant::now() < deadline,
+                    "valid semantic provider was blocked by an incomplete handshake"
+                );
+                thread::sleep(Duration::from_millis(1));
+            }
+
+            application.join().unwrap();
+        }
+
+        #[test]
+        fn provider_can_reconnect_after_a_clean_disconnect() {
+            let mut socket = Host::bind().unwrap();
+            let path = socket.path().unwrap().to_owned();
+            let first = connect_provider(path.clone(), "first");
+            wait_until_ready(&mut socket);
+            first.join().unwrap();
+
+            let deadline = Instant::now() + Duration::from_secs(2);
+            while socket.is_ready() {
+                socket.pump();
+                assert!(
+                    Instant::now() < deadline,
+                    "disconnected semantic provider remained ready"
+                );
+                thread::sleep(Duration::from_millis(1));
+            }
+
+            let second = connect_provider(path, "second");
+            wait_until_ready(&mut socket);
+            assert!(socket.is_ready());
+            second.join().unwrap();
+        }
+
+        #[test]
+        fn named_semantic_request_enforces_one_absolute_response_deadline() {
+            let path = std::env::temp_dir().join(format!(
+                "termctrl-semantic-timeout-test-{}.sock",
+                std::process::id()
+            ));
+            let _ = fs::remove_file(&path);
+            let listener = UnixListener::bind(&path).unwrap();
+            let peer = thread::spawn(move || {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut request = Vec::new();
+                stream.read_to_end(&mut request).unwrap();
+                for byte in b"{\"ok\":true}" {
+                    if stream.write_all(&[*byte]).is_err() {
+                        break;
+                    }
+                    thread::sleep(Duration::from_millis(20));
+                }
+            });
+            let started = Instant::now();
+
+            let result = request_snapshot::<Value, Value>(
+                &path,
+                &serde_json::json!({ "semantic": "snapshot" }),
+                Duration::from_millis(50),
+            );
+
+            assert!(result.unwrap_err().to_string().contains("timed out"));
+            assert!(started.elapsed() < Duration::from_millis(200));
+            peer.join().unwrap();
+            let _ = fs::remove_file(path);
+        }
+
+        #[test]
+        fn semantic_snapshot_is_none_without_a_connected_provider() {
+            let mut host = Host::bind().unwrap();
+            let started = Instant::now();
+
+            assert!(
+                host.snapshot(Duration::from_secs(1), || Ok(false))
+                    .unwrap()
+                    .is_none()
+            );
+            assert!(started.elapsed() < Duration::from_millis(50));
+        }
+
+        fn connect_provider(path: PathBuf, name: &'static str) -> thread::JoinHandle<()> {
+            thread::spawn(move || {
+                let mut stream = UnixStream::connect(path).unwrap();
+                write_json_line(
+                    &mut stream,
+                    &serde_json::json!({
+                        "type": "hello",
+                        "protocolVersion": 1,
+                        "application": { "name": name },
+                        "capabilities": ["semantic.snapshot"]
+                    }),
+                )
+                .unwrap();
+                let mut ready = String::new();
+                BufReader::new(stream).read_line(&mut ready).unwrap();
+                assert!(ready.contains("\"type\":\"ready\""));
+            })
+        }
+
+        fn wait_until_ready(socket: &mut Host) {
+            let deadline = Instant::now() + Duration::from_secs(2);
+            while !socket.is_ready() {
+                socket.pump();
+                assert!(
+                    Instant::now() < deadline,
+                    "semantic provider did not become ready"
+                );
+                thread::sleep(Duration::from_millis(1));
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+pub(crate) use implementation::{Host, request_snapshot};
+
+#[cfg(not(unix))]
+pub(crate) struct Host;
+
+#[cfg(not(unix))]
+impl Host {
+    pub(crate) fn bind() -> anyhow::Result<Self> {
+        Ok(Self)
+    }
+
+    pub(crate) fn path(&self) -> Option<&std::path::Path> {
+        None
+    }
+
+    pub(crate) fn pump(&mut self) {}
+
+    pub(crate) fn snapshot(
+        &mut self,
+        _: std::time::Duration,
+        _: impl FnMut() -> anyhow::Result<bool>,
+    ) -> anyhow::Result<Option<serde_json::Value>> {
+        Ok(None)
+    }
+}
+
+#[cfg(not(unix))]
+pub(crate) fn request_snapshot<Request, Response>(
+    _: &std::path::Path,
+    _: &Request,
+    _: std::time::Duration,
+) -> anyhow::Result<Response>
+where
+    Request: serde::Serialize,
+    Response: serde::de::DeserializeOwned,
+{
+    anyhow::bail!("application semantic snapshots require Unix sockets")
+}

--- a/src/session.rs
+++ b/src/session.rs
@@ -238,11 +238,14 @@ impl Session {
                 pixel_height: options.cell_height,
             })
             .context("open session pseudo-terminal")?;
-        let semantic = semantic::Host::bind()?;
+        let semantic = options
+            .opentui_host
+            .then(semantic::Host::bind)
+            .transpose()?;
         let mut builder = CommandBuilder::new(&command[0]);
         builder.args(&command[1..]);
         shot::configure_pty_environment(&mut builder, options);
-        if let Some(path) = semantic.path() {
+        if let Some(path) = semantic.as_ref().and_then(semantic::Host::path) {
             builder.env(semantic::SOCKET_ENV, path);
         }
         builder.cwd(&cwd);
@@ -325,7 +328,7 @@ impl Session {
                 color: options.color,
             },
             mirror: None,
-            semantic: Some(semantic),
+            semantic,
         })
     }
 
@@ -3976,7 +3979,10 @@ mod tests {
             ],
             None,
             None,
-            &Options::default(),
+            &Options {
+                opentui_host: true,
+                ..Options::default()
+            },
         )
         .unwrap();
         let path = session
@@ -4005,7 +4011,10 @@ mod tests {
             &["sh".to_owned(), "-c".to_owned(), "sleep 10".to_owned()],
             None,
             None,
-            &Options::default(),
+            &Options {
+                opentui_host: true,
+                ..Options::default()
+            },
         )
         .unwrap();
         let path = session

--- a/src/session.rs
+++ b/src/session.rs
@@ -191,30 +191,7 @@ impl Session {
         record: Option<&Path>,
         options: &Options,
     ) -> Result<Self> {
-        Self::start_internal(
-            command,
-            cwd,
-            record,
-            options,
-            TerminalTheme::default(),
-            true,
-        )
-    }
-
-    pub(crate) fn start_without_semantics(
-        command: &[String],
-        cwd: Option<&Path>,
-        record: Option<&Path>,
-        options: &Options,
-    ) -> Result<Self> {
-        Self::start_internal(
-            command,
-            cwd,
-            record,
-            options,
-            TerminalTheme::default(),
-            false,
-        )
+        Self::start_with_theme(command, cwd, record, options, TerminalTheme::default())
     }
 
     pub(crate) fn start_with_theme(
@@ -223,17 +200,6 @@ impl Session {
         record: Option<&Path>,
         options: &Options,
         theme: TerminalTheme,
-    ) -> Result<Self> {
-        Self::start_internal(command, cwd, record, options, theme, true)
-    }
-
-    fn start_internal(
-        command: &[String],
-        cwd: Option<&Path>,
-        record: Option<&Path>,
-        options: &Options,
-        theme: TerminalTheme,
-        semantic: bool,
     ) -> Result<Self> {
         if command.is_empty() {
             bail!("provide a command after --");
@@ -272,11 +238,11 @@ impl Session {
                 pixel_height: options.cell_height,
             })
             .context("open session pseudo-terminal")?;
-        let semantic = semantic.then(semantic::Host::bind).transpose()?;
+        let semantic = semantic::Host::bind()?;
         let mut builder = CommandBuilder::new(&command[0]);
         builder.args(&command[1..]);
         shot::configure_pty_environment(&mut builder, options);
-        if let Some(path) = semantic.as_ref().and_then(semantic::Host::path) {
+        if let Some(path) = semantic.path() {
             builder.env(semantic::SOCKET_ENV, path);
         }
         builder.cwd(&cwd);
@@ -359,7 +325,7 @@ impl Session {
                 color: options.color,
             },
             mirror: None,
-            semantic,
+            semantic: Some(semantic),
         })
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -191,7 +191,30 @@ impl Session {
         record: Option<&Path>,
         options: &Options,
     ) -> Result<Self> {
-        Self::start_with_theme(command, cwd, record, options, TerminalTheme::default())
+        Self::start_internal(
+            command,
+            cwd,
+            record,
+            options,
+            TerminalTheme::default(),
+            true,
+        )
+    }
+
+    pub(crate) fn start_without_semantics(
+        command: &[String],
+        cwd: Option<&Path>,
+        record: Option<&Path>,
+        options: &Options,
+    ) -> Result<Self> {
+        Self::start_internal(
+            command,
+            cwd,
+            record,
+            options,
+            TerminalTheme::default(),
+            false,
+        )
     }
 
     pub(crate) fn start_with_theme(
@@ -200,6 +223,17 @@ impl Session {
         record: Option<&Path>,
         options: &Options,
         theme: TerminalTheme,
+    ) -> Result<Self> {
+        Self::start_internal(command, cwd, record, options, theme, true)
+    }
+
+    fn start_internal(
+        command: &[String],
+        cwd: Option<&Path>,
+        record: Option<&Path>,
+        options: &Options,
+        theme: TerminalTheme,
+        semantic: bool,
     ) -> Result<Self> {
         if command.is_empty() {
             bail!("provide a command after --");
@@ -238,11 +272,11 @@ impl Session {
                 pixel_height: options.cell_height,
             })
             .context("open session pseudo-terminal")?;
-        let semantic = semantic::Host::bind()?;
+        let semantic = semantic.then(semantic::Host::bind).transpose()?;
         let mut builder = CommandBuilder::new(&command[0]);
         builder.args(&command[1..]);
         shot::configure_pty_environment(&mut builder, options);
-        if let Some(path) = semantic.path() {
+        if let Some(path) = semantic.as_ref().and_then(semantic::Host::path) {
             builder.env(semantic::SOCKET_ENV, path);
         }
         builder.cwd(&cwd);
@@ -325,7 +359,7 @@ impl Session {
                 color: options.color,
             },
             mirror: None,
-            semantic: Some(semantic),
+            semantic,
         })
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -1843,7 +1843,7 @@ mod implementation {
     use std::io::{ErrorKind, Read, Write};
     use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
     use std::os::unix::ffi::OsStrExt;
-    use std::os::unix::fs::{DirBuilderExt, FileTypeExt, MetadataExt, PermissionsExt};
+    use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
     use std::os::unix::net::{UnixListener, UnixStream};
     use std::os::unix::process::CommandExt;
     use std::path::{Path, PathBuf};
@@ -1977,40 +1977,7 @@ mod implementation {
         }
     }
     pub fn runtime_dir() -> Result<PathBuf> {
-        let path = std::env::var_os("TERMCTRL_RUNTIME_DIR")
-            .map(PathBuf::from)
-            .unwrap_or_else(|| {
-                PathBuf::from(format!("/tmp/termctrl-{}", unsafe { libc::geteuid() }))
-            });
-        match fs::symlink_metadata(&path) {
-            Ok(metadata) => require_private_runtime_dir(&path, &metadata)?,
-            Err(error) if error.kind() == ErrorKind::NotFound => {
-                fs::DirBuilder::new()
-                    .mode(0o700)
-                    .create(&path)
-                    .with_context(|| format!("create {}", path.display()))?;
-            }
-            Err(error) => return Err(error).with_context(|| format!("inspect {}", path.display())),
-        }
-        fs::set_permissions(&path, fs::Permissions::from_mode(0o700))
-            .with_context(|| format!("secure {}", path.display()))?;
-        Ok(path)
-    }
-
-    fn require_private_runtime_dir(path: &Path, metadata: &fs::Metadata) -> Result<()> {
-        if !metadata.file_type().is_dir() || metadata.file_type().is_symlink() {
-            bail!(
-                "session runtime path must be a real directory: {}",
-                path.display()
-            );
-        }
-        if metadata.uid() != unsafe { libc::geteuid() } {
-            bail!(
-                "session runtime directory is not owned by the current user: {}",
-                path.display()
-            );
-        }
-        Ok(())
+        crate::runtime::directory()
     }
 
     pub fn start(

--- a/src/session.rs
+++ b/src/session.rs
@@ -7,12 +7,14 @@ use std::time::{Duration, Instant};
 
 use crate::frame::Frame;
 use crate::recording::{self, InputOrigin};
+use crate::semantic;
 use crate::shot::{self, Host, Options, Shot, respond_to_output};
 use crate::terminal_core::{InputModes, SCROLLBACK_ROWS, TerminalCore};
 use crate::terminal_theme::TerminalTheme;
 use anyhow::{Context, Result, bail};
 use portable_pty::{Child, CommandBuilder, ExitStatus, MasterPty, PtySize, native_pty_system};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 pub use crate::workspace::{ActivityKind, WorkspaceContext};
 pub use crate::workspace::{Direction as PaneDirection, PaneStatus, TabPosition, WindowStatus};
@@ -26,7 +28,8 @@ const ATTACH_PROTOCOL_VERSION: u8 = 2;
 const WINDOW_PROTOCOL_VERSION: u8 = 3;
 const LAYOUT_COMMAND_PROTOCOL_VERSION: u8 = 4;
 const WORKSPACE_CONTROL_PROTOCOL_VERSION: u8 = 5;
-const CURRENT_PROTOCOL_VERSION: u8 = WORKSPACE_CONTROL_PROTOCOL_VERSION;
+const SEMANTIC_PROTOCOL_VERSION: u8 = 6;
+const CURRENT_PROTOCOL_VERSION: u8 = SEMANTIC_PROTOCOL_VERSION;
 const ATTACHED_TERMINAL_ERROR: &str = "workspace already has an attached terminal";
 
 fn attachment_rejection(name: &str, error: &str) -> anyhow::Error {
@@ -80,6 +83,7 @@ pub struct Session {
     cell_height: u16,
     launch: SessionLaunch,
     mirror: Option<Box<dyn Write + Send>>,
+    semantic: Option<semantic::Host>,
 }
 
 /// Lifecycle state of a running or completed session.
@@ -234,9 +238,13 @@ impl Session {
                 pixel_height: options.cell_height,
             })
             .context("open session pseudo-terminal")?;
+        let semantic = semantic::Host::bind()?;
         let mut builder = CommandBuilder::new(&command[0]);
         builder.args(&command[1..]);
         shot::configure_pty_environment(&mut builder, options);
+        if let Some(path) = semantic.path() {
+            builder.env(semantic::SOCKET_ENV, path);
+        }
         builder.cwd(&cwd);
         let mut reader = pair
             .master
@@ -317,6 +325,7 @@ impl Session {
                 color: options.color,
             },
             mirror: None,
+            semantic: Some(semantic),
         })
     }
 
@@ -518,6 +527,23 @@ impl Session {
         self.terminal.scrollback_text()
     }
 
+    /// Return the application's semantic UI snapshot, or an empty snapshot when unavailable.
+    pub fn semantic_snapshot(&mut self, timeout: Duration) -> Result<Value> {
+        let Some(mut semantic) = self.semantic.take() else {
+            return Ok(semantic::empty_semantic_snapshot());
+        };
+        let result = semantic
+            .snapshot(timeout, || {
+                self.consume_output_batch()?;
+                Ok(self.has_exited()? || self.stopped)
+            })
+            .map(|snapshot| snapshot.unwrap_or_else(semantic::empty_semantic_snapshot));
+        if self.exit.is_none() && !self.stopped {
+            self.semantic = Some(semantic);
+        }
+        result
+    }
+
     /// Resize the PTY and reflow subsequent terminal parsing at the new dimensions.
     pub fn resize(
         &mut self,
@@ -621,6 +647,13 @@ impl Session {
     }
 
     fn consume_batch(&mut self) -> Result<()> {
+        if let Some(semantic) = &mut self.semantic {
+            semantic.pump();
+        }
+        self.consume_output_batch()
+    }
+
+    fn consume_output_batch(&mut self) -> Result<()> {
         let mut outputs = Vec::new();
         for _ in 0..OUTPUT_BATCH {
             match self.receive.try_recv() {
@@ -750,6 +783,7 @@ impl Session {
         self.output_closed = true;
         self.stopped = true;
         self.exit_ready = self.exit.is_some();
+        self.semantic.take();
     }
 
     fn finish_exited_output(&mut self) -> Result<()> {
@@ -792,6 +826,7 @@ impl Session {
             self.process_group.take();
         }
         self.exit_ready = true;
+        self.semantic.take();
         Ok(())
     }
 
@@ -994,6 +1029,13 @@ enum Request {
         cell_width: u16,
         cell_height: u16,
     },
+    SemanticSnapshot {
+        deadline_unix_ms: u64,
+        #[serde(default)]
+        pane: Option<crate::workspace::PaneId>,
+        #[serde(default)]
+        window: Option<String>,
+    },
     Stop,
 }
 
@@ -1004,6 +1046,7 @@ enum ProtocolCapability {
     Window,
     LayoutCommand,
     WorkspaceControl,
+    Semantic,
 }
 
 impl ProtocolCapability {
@@ -1014,6 +1057,7 @@ impl ProtocolCapability {
             Self::Window => WINDOW_PROTOCOL_VERSION,
             Self::LayoutCommand => LAYOUT_COMMAND_PROTOCOL_VERSION,
             Self::WorkspaceControl => WORKSPACE_CONTROL_PROTOCOL_VERSION,
+            Self::Semantic => SEMANTIC_PROTOCOL_VERSION,
         }
     }
 
@@ -1033,6 +1077,9 @@ impl ProtocolCapability {
             }
             Self::WorkspaceControl => {
                 "running workspace predates runtime workspace controls; restart it with the current termctrl"
+            }
+            Self::Semantic => {
+                "running session predates semantic snapshots; restart it with the current termctrl"
             }
         }
     }
@@ -1084,6 +1131,7 @@ impl Request {
             | Self::FocusPane { .. }
             | Self::ClosePane { .. } => ProtocolCapability::Pane,
             Self::Attach { .. } | Self::ResizeAttachment { .. } => ProtocolCapability::Attachment,
+            Self::SemanticSnapshot { .. } => ProtocolCapability::Semantic,
             Self::Ping
             | Self::Status
             | Self::Wait { pane: None, .. }
@@ -1120,6 +1168,8 @@ struct Response {
     windows: Option<Vec<crate::workspace::WindowStatus>>,
     #[serde(default)]
     context: Option<WorkspaceContext>,
+    #[serde(default)]
+    semantic_snapshot: Option<SemanticSnapshotResult>,
 }
 
 impl Default for Response {
@@ -1133,8 +1183,14 @@ impl Default for Response {
             panes: None,
             windows: None,
             context: None,
+            semantic_snapshot: None,
         }
     }
+}
+
+#[derive(Serialize, Deserialize)]
+struct SemanticSnapshotResult {
+    value: Value,
 }
 
 impl Response {
@@ -1383,6 +1439,38 @@ pub fn show_in(
     deadline: Duration,
 ) -> Result<Shot> {
     show_target(name, terminal_target(window, pane)?, settle, deadline)
+}
+
+#[doc(hidden)]
+pub fn semantic_snapshot_in(
+    name: &str,
+    window: Option<String>,
+    pane: Option<crate::workspace::PaneId>,
+    timeout: Duration,
+) -> Result<Value> {
+    validate_name(name)?;
+    let (window, pane) = match terminal_target(window, pane)? {
+        TerminalTarget::Selected => (None, None),
+        TerminalTarget::Window(window) => (Some(window), None),
+        TerminalTarget::Pane(pane) => (None, Some(pane)),
+    };
+    let response = semantic::request_snapshot(
+        &socket_path(name)?,
+        &Request::SemanticSnapshot {
+            deadline_unix_ms: semantic::deadline_unix_ms(timeout)?,
+            pane,
+            window,
+        },
+        timeout,
+    )?;
+    ProtocolCapability::Semantic.require(&response)?;
+    if let Some(error) = response.error {
+        bail!(error);
+    }
+    response
+        .semantic_snapshot
+        .map(|snapshot| snapshot.value)
+        .context("session did not return a semantic snapshot")
 }
 
 #[doc(hidden)]
@@ -1769,7 +1857,7 @@ mod implementation {
 
     use super::{
         ATTACHED_TERMINAL_ERROR, NamedSessionStatus, ProtocolCapability, PruneKind, Request,
-        Response, Session, SessionState, TabPosition, UnavailableReason,
+        Response, SemanticSnapshotResult, Session, SessionState, TabPosition, UnavailableReason,
     };
     use crate::shot::{self, Options};
     use crate::workspace::{Workspace, WorkspaceAttachmentOptions, WorkspaceTerminal};
@@ -2988,6 +3076,22 @@ mod implementation {
                 )?;
             }
             Request::Mark { name } => session.mark(&name)?,
+            Request::SemanticSnapshot {
+                deadline_unix_ms,
+                pane,
+                window,
+            } => {
+                if window.is_some() {
+                    bail!("only workspaces support named windows");
+                }
+                if pane.is_some_and(|pane| pane != 0) {
+                    bail!("single sessions only contain pane 0");
+                }
+                response.semantic_snapshot = Some(SemanticSnapshotResult {
+                    value: session
+                        .semantic_snapshot(crate::semantic::remaining(deadline_unix_ms)?)?,
+                });
+            }
             Request::Windows
             | Request::WorkspaceContext { .. }
             | Request::SetTabPosition { .. }
@@ -3087,6 +3191,19 @@ mod implementation {
                 bail!("visible workspace dimensions are owned by the attached terminal")
             }
             Request::Mark { name } => workspace.mark_recording(&name)?,
+            Request::SemanticSnapshot {
+                deadline_unix_ms,
+                pane,
+                window,
+            } => {
+                response.semantic_snapshot = Some(SemanticSnapshotResult {
+                    value: workspace.semantic_snapshot_in(
+                        window.as_deref(),
+                        pane,
+                        crate::semantic::remaining(deadline_unix_ms)?,
+                    )?,
+                });
+            }
             Request::Windows => response.windows = Some(workspace.windows()),
             Request::WorkspaceContext { pane } => {
                 response.context = Some(workspace.context(pane)?);
@@ -3636,7 +3753,11 @@ mod tests {
                 .require(&version_four)
                 .is_err()
         );
-        assert_eq!(Response::default().protocol_version, 5);
+        assert!(ProtocolCapability::Semantic.require(&version_four).is_err());
+        assert_eq!(
+            Response::default().protocol_version,
+            SEMANTIC_PROTOCOL_VERSION
+        );
     }
 
     #[test]
@@ -3680,6 +3801,15 @@ mod tests {
                     position: TabPosition::Top,
                 },
                 Some(ProtocolCapability::WorkspaceControl),
+                false,
+            ),
+            (
+                Request::SemanticSnapshot {
+                    deadline_unix_ms: 1,
+                    pane: None,
+                    window: None,
+                },
+                Some(ProtocolCapability::Semantic),
                 false,
             ),
             (Request::Status, None, false),
@@ -3766,6 +3896,11 @@ mod tests {
                 cell_width: 9,
                 cell_height: 18,
             },
+            Request::SemanticSnapshot {
+                deadline_unix_ms: 1,
+                pane: Some(3),
+                window: None,
+            },
         ] {
             let encoded = serde_json::to_vec(&request).unwrap();
             let decoded: Request = serde_json::from_slice(&encoded).unwrap();
@@ -3774,6 +3909,18 @@ mod tests {
                 serde_json::to_value(request).unwrap()
             );
         }
+    }
+
+    #[test]
+    fn named_session_response_preserves_a_null_semantic_snapshot() {
+        let encoded = serde_json::to_vec(&Response {
+            semantic_snapshot: Some(SemanticSnapshotResult { value: Value::Null }),
+            ..Response::default()
+        })
+        .unwrap();
+        let decoded: Response = serde_json::from_slice(&encoded).unwrap();
+
+        assert_eq!(decoded.semantic_snapshot.unwrap().value, Value::Null);
     }
 
     #[cfg(target_os = "macos")]
@@ -3846,6 +3993,94 @@ mod tests {
         session.stop().unwrap();
         assert_eq!(session.status().unwrap().state, SessionState::Exited);
         assert!(session.capture(Duration::ZERO, Duration::ZERO).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn embedded_session_advertises_and_cleans_up_the_application_semantic_socket() {
+        let mut session = Session::start(
+            &[
+                "sh".to_owned(),
+                "-c".to_owned(),
+                format!(
+                    "if [ -S \"${}\" ]; then printf semantic-ready; else printf semantic-missing; fi; sleep 10",
+                    semantic::SOCKET_ENV
+                ),
+            ],
+            None,
+            None,
+            &Options::default(),
+        )
+        .unwrap();
+        let path = session
+            .semantic
+            .as_ref()
+            .unwrap()
+            .path()
+            .unwrap()
+            .to_owned();
+
+        session
+            .wait_for_text("semantic-ready", Duration::from_secs(2))
+            .unwrap();
+        assert!(path.exists());
+        session.stop().unwrap();
+        assert!(!path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn embedded_session_reads_its_application_semantic_snapshot() {
+        use std::io::{BufRead, BufReader};
+        use std::os::unix::net::UnixStream;
+
+        let mut session = Session::start(
+            &["sh".to_owned(), "-c".to_owned(), "sleep 10".to_owned()],
+            None,
+            None,
+            &Options::default(),
+        )
+        .unwrap();
+        let path = session
+            .semantic
+            .as_ref()
+            .unwrap()
+            .path()
+            .unwrap()
+            .to_owned();
+        let (connected, ready) = mpsc::channel();
+        let application = thread::spawn(move || {
+            let mut stream = UnixStream::connect(path).unwrap();
+            stream
+                .write_all(
+                    b"{\"type\":\"hello\",\"protocolVersion\":1,\"application\":{\"name\":\"fixture\"},\"capabilities\":[\"semantic.snapshot\"]}\n",
+                )
+                .unwrap();
+            connected.send(()).unwrap();
+            let mut stream = BufReader::new(stream);
+            let mut line = String::new();
+            stream.read_line(&mut line).unwrap();
+            assert!(line.contains("\"type\":\"ready\""));
+            line.clear();
+            stream.read_line(&mut line).unwrap();
+            let request: Value = serde_json::from_str(&line).unwrap();
+            assert_eq!(request["type"], "semantic.snapshot");
+            let response = serde_json::json!({
+                "type": "result",
+                "id": request["id"],
+                "value": { "format": "termctrl-semantic-snapshot-v1", "nodes": [] }
+            });
+            serde_json::to_writer(stream.get_mut(), &response).unwrap();
+            stream.get_mut().write_all(b"\n").unwrap();
+            stream.get_mut().flush().unwrap();
+        });
+        ready.recv().unwrap();
+
+        let result = session.semantic_snapshot(Duration::from_secs(2)).unwrap();
+
+        assert_eq!(result["format"], "termctrl-semantic-snapshot-v1");
+        session.stop().unwrap();
+        application.join().unwrap();
     }
 
     #[cfg(unix)]

--- a/src/shot.rs
+++ b/src/shot.rs
@@ -13,6 +13,8 @@ use anyhow::{Context, Result, bail};
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 use serde::{Deserialize, Serialize};
 
+use crate::semantic;
+
 const OPENTUI_QUERY: &[u8] = b"\x1b]10;?\x07\x1b]11;?\x07";
 #[cfg(test)]
 const PALETTE_QUERY: &[u8] = b"\x1b]4;0;?\x07";
@@ -104,9 +106,13 @@ pub fn from_command(command: &[String], cwd: Option<&Path>, options: &Options) -
             pixel_height: options.cell_height,
         })
         .context("open pseudo-terminal")?;
+    let mut semantic = semantic::Host::bind()?;
     let mut builder = CommandBuilder::new(&command[0]);
     builder.args(&command[1..]);
     configure_pty_environment(&mut builder, options);
+    if let Some(path) = semantic.path() {
+        builder.env(semantic::SOCKET_ENV, path);
+    }
     if let Some(cwd) = cwd {
         builder.cwd(cwd);
     }
@@ -150,6 +156,7 @@ pub fn from_command(command: &[String], cwd: Option<&Path>, options: &Options) -
             &mut terminal,
             &mut ansi,
             &mut host,
+            &mut semantic,
             options,
             &mut clock,
         )?;
@@ -169,6 +176,7 @@ pub fn from_command(command: &[String], cwd: Option<&Path>, options: &Options) -
                 &mut terminal,
                 &mut ansi,
                 &mut host,
+                &mut semantic,
                 options,
                 &mut clock,
             )?;
@@ -208,6 +216,7 @@ pub fn from_pipe_command(
         bail!("provide a command after --");
     }
     validate_geometry(options.rows, options.cols)?;
+    let mut semantic = semantic::Host::bind()?;
     let mut builder = ProcessCommand::new(&command[0]);
     builder
         .args(&command[1..])
@@ -220,6 +229,9 @@ pub fn from_pipe_command(
         builder.process_group(0);
     }
     configure_process_environment(&mut builder, options);
+    if let Some(path) = semantic.path() {
+        builder.env(semantic::SOCKET_ENV, path);
+    }
     if let Some(cwd) = cwd {
         builder.current_dir(cwd);
     }
@@ -242,6 +254,7 @@ pub fn from_pipe_command(
         let mut open_streams = 2_usize;
         let mut exited = false;
         while open_streams > 0 || !exited {
+            semantic.pump();
             let timeout = deadline
                 .saturating_duration_since(Instant::now())
                 .min(Duration::from_millis(20));
@@ -389,6 +402,7 @@ fn consume_until_ready(
     terminal: &mut TerminalCore,
     ansi: &mut Vec<u8>,
     host: &mut Host,
+    semantic: &mut semantic::Host,
     options: &Options,
     clock: &mut Clock,
 ) -> Result<bool> {
@@ -396,14 +410,30 @@ fn consume_until_ready(
     let delay_end = (clock.started + options.initial_delay).min(clock.deadline);
     while !closed && Instant::now() < delay_end {
         closed = matches!(
-            receive_chunk(receive, terminal, ansi, host, options.max_bytes, clock)?,
+            receive_chunk(
+                receive,
+                terminal,
+                ansi,
+                host,
+                semantic,
+                options.max_bytes,
+                clock,
+            )?,
             Chunk::Closed
         );
     }
     if let Some(pattern) = &options.wait_for {
         while !closed && Instant::now() < clock.deadline && !terminal.text()?.contains(pattern) {
             closed = matches!(
-                receive_chunk(receive, terminal, ansi, host, options.max_bytes, clock)?,
+                receive_chunk(
+                    receive,
+                    terminal,
+                    ansi,
+                    host,
+                    semantic,
+                    options.max_bytes,
+                    clock,
+                )?,
                 Chunk::Closed
             );
         }
@@ -415,7 +445,7 @@ fn consume_until_ready(
     {
         return Ok(false);
     }
-    consume_until_settled(receive, terminal, ansi, host, options, clock)
+    consume_until_settled(receive, terminal, ansi, host, semantic, options, clock)
 }
 
 enum Chunk {
@@ -435,9 +465,11 @@ fn receive_chunk(
     terminal: &mut TerminalCore,
     ansi: &mut Vec<u8>,
     host: &mut Host,
+    semantic: &mut semantic::Host,
     max_bytes: usize,
     clock: &mut Clock,
 ) -> Result<Chunk> {
+    semantic.pump();
     let timeout = clock
         .deadline
         .saturating_duration_since(Instant::now())
@@ -478,11 +510,20 @@ fn consume_until_settled(
     terminal: &mut TerminalCore,
     ansi: &mut Vec<u8>,
     host: &mut Host,
+    semantic: &mut semantic::Host,
     options: &Options,
     clock: &mut Clock,
 ) -> Result<bool> {
     loop {
-        match receive_chunk(receive, terminal, ansi, host, options.max_bytes, clock)? {
+        match receive_chunk(
+            receive,
+            terminal,
+            ansi,
+            host,
+            semantic,
+            options.max_bytes,
+            clock,
+        )? {
             Chunk::Output => {}
             Chunk::Closed => return Ok(true),
             Chunk::Timeout => {
@@ -796,6 +837,42 @@ mod tests {
 
         assert_eq!(captured.frame.text(), "one\ntwo");
         assert!(captured.ansi.windows(2).any(|window| window == b"\r\n"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn launched_commands_receive_the_application_semantic_socket() {
+        let command = [
+            "sh".to_owned(),
+            "-c".to_owned(),
+            format!(
+                "if [ -S \"${}\" ]; then printf semantic-ready; else printf semantic-missing; fi",
+                semantic::SOCKET_ENV
+            ),
+        ];
+
+        let pty = from_command(
+            &command,
+            None,
+            &Options {
+                settle: Duration::from_millis(10),
+                deadline: Duration::from_secs(2),
+                ..Options::default()
+            },
+        )
+        .unwrap();
+        let pipe = from_pipe_command(
+            &command,
+            None,
+            &Options {
+                deadline: Duration::from_secs(2),
+                ..Options::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(pty.frame.text(), "semantic-ready");
+        assert_eq!(pipe.frame.text(), "semantic-ready");
     }
 
     #[cfg(unix)]

--- a/src/shot.rs
+++ b/src/shot.rs
@@ -106,11 +106,14 @@ pub fn from_command(command: &[String], cwd: Option<&Path>, options: &Options) -
             pixel_height: options.cell_height,
         })
         .context("open pseudo-terminal")?;
-    let mut semantic = semantic::Host::bind()?;
+    let mut semantic = options
+        .opentui_host
+        .then(semantic::Host::bind)
+        .transpose()?;
     let mut builder = CommandBuilder::new(&command[0]);
     builder.args(&command[1..]);
     configure_pty_environment(&mut builder, options);
-    if let Some(path) = semantic.path() {
+    if let Some(path) = semantic.as_ref().and_then(semantic::Host::path) {
         builder.env(semantic::SOCKET_ENV, path);
     }
     if let Some(cwd) = cwd {
@@ -216,7 +219,10 @@ pub fn from_pipe_command(
         bail!("provide a command after --");
     }
     validate_geometry(options.rows, options.cols)?;
-    let mut semantic = semantic::Host::bind()?;
+    let mut semantic = options
+        .opentui_host
+        .then(semantic::Host::bind)
+        .transpose()?;
     let mut builder = ProcessCommand::new(&command[0]);
     builder
         .args(&command[1..])
@@ -229,7 +235,7 @@ pub fn from_pipe_command(
         builder.process_group(0);
     }
     configure_process_environment(&mut builder, options);
-    if let Some(path) = semantic.path() {
+    if let Some(path) = semantic.as_ref().and_then(semantic::Host::path) {
         builder.env(semantic::SOCKET_ENV, path);
     }
     if let Some(cwd) = cwd {
@@ -254,7 +260,9 @@ pub fn from_pipe_command(
         let mut open_streams = 2_usize;
         let mut exited = false;
         while open_streams > 0 || !exited {
-            semantic.pump();
+            if let Some(semantic) = &mut semantic {
+                semantic.pump();
+            }
             let timeout = deadline
                 .saturating_duration_since(Instant::now())
                 .min(Duration::from_millis(20));
@@ -402,7 +410,7 @@ fn consume_until_ready(
     terminal: &mut TerminalCore,
     ansi: &mut Vec<u8>,
     host: &mut Host,
-    semantic: &mut semantic::Host,
+    semantic: &mut Option<semantic::Host>,
     options: &Options,
     clock: &mut Clock,
 ) -> Result<bool> {
@@ -465,11 +473,13 @@ fn receive_chunk(
     terminal: &mut TerminalCore,
     ansi: &mut Vec<u8>,
     host: &mut Host,
-    semantic: &mut semantic::Host,
+    semantic: &mut Option<semantic::Host>,
     max_bytes: usize,
     clock: &mut Clock,
 ) -> Result<Chunk> {
-    semantic.pump();
+    if let Some(semantic) = semantic {
+        semantic.pump();
+    }
     let timeout = clock
         .deadline
         .saturating_duration_since(Instant::now())
@@ -510,7 +520,7 @@ fn consume_until_settled(
     terminal: &mut TerminalCore,
     ansi: &mut Vec<u8>,
     host: &mut Host,
-    semantic: &mut semantic::Host,
+    semantic: &mut Option<semantic::Host>,
     options: &Options,
     clock: &mut Clock,
 ) -> Result<bool> {
@@ -841,7 +851,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn launched_commands_receive_the_application_semantic_socket() {
+    fn only_opentui_host_commands_receive_the_application_semantic_socket() {
         let command = [
             "sh".to_owned(),
             "-c".to_owned(),
@@ -851,7 +861,7 @@ mod tests {
             ),
         ];
 
-        let pty = from_command(
+        let plain_pty = from_command(
             &command,
             None,
             &Options {
@@ -861,7 +871,7 @@ mod tests {
             },
         )
         .unwrap();
-        let pipe = from_pipe_command(
+        let plain_pipe = from_pipe_command(
             &command,
             None,
             &Options {
@@ -870,9 +880,32 @@ mod tests {
             },
         )
         .unwrap();
+        let opentui_pty = from_command(
+            &command,
+            None,
+            &Options {
+                settle: Duration::from_millis(10),
+                deadline: Duration::from_secs(2),
+                opentui_host: true,
+                ..Options::default()
+            },
+        )
+        .unwrap();
+        let opentui_pipe = from_pipe_command(
+            &command,
+            None,
+            &Options {
+                deadline: Duration::from_secs(2),
+                opentui_host: true,
+                ..Options::default()
+            },
+        )
+        .unwrap();
 
-        assert_eq!(pty.frame.text(), "semantic-ready");
-        assert_eq!(pipe.frame.text(), "semantic-ready");
+        assert_eq!(plain_pty.frame.text(), "semantic-missing");
+        assert_eq!(plain_pipe.frame.text(), "semantic-missing");
+        assert_eq!(opentui_pty.frame.text(), "semantic-ready");
+        assert_eq!(opentui_pipe.frame.text(), "semantic-ready");
     }
 
     #[cfg(unix)]

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -783,6 +783,30 @@ impl Workspace {
         self.windows[index].active_logs(ansi)
     }
 
+    pub(crate) fn semantic_snapshot_in(
+        &mut self,
+        name: Option<&str>,
+        pane: Option<PaneId>,
+        timeout: Duration,
+    ) -> Result<serde_json::Value> {
+        if name.is_some() && pane.is_some() {
+            bail!("window and pane cannot be combined; pane ids are already globally stable");
+        }
+        let index = pane
+            .and_then(|pane| self.pane_window_index(pane))
+            .map_or_else(|| self.window_index_or_active(name), Ok)?;
+        let pane = pane
+            .or(self.windows[index].active)
+            .context("workspace target has no active pane")?;
+        self.windows[index]
+            .panes
+            .iter_mut()
+            .find(|candidate| candidate.id == pane)
+            .with_context(|| format!("workspace has no pane {pane}"))?
+            .session
+            .semantic_snapshot(timeout)
+    }
+
     pub(crate) fn create_window(
         &mut self,
         name: Option<&str>,
@@ -5337,6 +5361,26 @@ mod tests {
                 && cell.width == 6
                 && cell.background == crate::frame::Color { r: 1, g: 2, b: 3 }
         }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn workspace_semantic_snapshot_is_empty_without_a_provider() {
+        let mut workspace = Workspace::start(
+            &["sh".to_owned(), "-c".to_owned(), "sleep 10".to_owned()],
+            None,
+            None,
+            &Options::default(),
+        )
+        .unwrap();
+
+        let snapshot = workspace
+            .semantic_snapshot_in(None, None, Duration::from_secs(1))
+            .unwrap();
+
+        assert_eq!(snapshot["format"], "termctrl-semantic-snapshot-v1");
+        assert_eq!(snapshot["nodes"], serde_json::json!([]));
+        workspace.stop();
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary
- add `TERMCTRL_SEMANTIC_SOCKET` and `termctrl show NAME --format semantic`
- support semantic snapshots for sessions and workspace pane/window targets through additive protocol capability version 6
- publish `@kitlangton/terminal-control-opentui` with `@opentui/core` as a peer dependency and shared interactable discovery
- return an empty snapshot when no semantic provider is connected
- release the OpenTUI adapter through its own Node `npm publish` script after the native/client tarballs
- keep the adapter in the fixed Changesets group and have its release script align the checked-in `0.0.0` sentinel to the Terminal Control client version automatically

## Validation
- `bun install --frozen-lockfile`
- `cargo fmt --all -- --check`
- `cargo test --all-targets` (147 passed, 1 ignored; 17 CLI tests passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release`
- `bun run test:npm`
- `bun run build:npm`
- `bun run validate:npm`
- `cargo package --list`
- `cargo package`
- OpenTUI package `release:check`
- end-to-end Monet semantic snapshot after rebasing onto workspace-enabled main