### PR TITLE
chore: release terminal-control 0.5.0

### DIFF
--- a/.changeset/fuzzy-panes-run.md
+++ b/.changeset/fuzzy-panes-run.md
@@ -1,8 +1,0 @@
----
-"@kitlangton/terminal-control": minor
----
-
-Add persistent, reattachable workspaces with named windows, reorderable tabs, movable split panes, pane
-zoom, a command palette, and workspace-wide pane IDs that remain stable for the workspace lifetime.
-Agents can inspect and control hidden windows and panes through typed CLI and MCP operations, capture
-pane/window/workspace PNGs, record the composed workspace, and discover their current pane context.

--- a/.changeset/quiet-ghosts-reflow.md
+++ b/.changeset/quiet-ghosts-reflow.md
@@ -1,5 +1,0 @@
----
-"@kitlangton/terminal-control": patch
----
-
-Replace the terminal state engine with Ghostty for accurate reflow, Unicode, attributes, and PTY responses.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "terminal-control"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminal-control"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.93"
 description = "Control and test terminal applications through stable visible state"

--- a/bun.lock
+++ b/bun.lock
@@ -10,35 +10,35 @@
     },
     "packages/darwin-arm64": {
       "name": "@kitlangton/terminal-control-darwin-arm64",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "bin": {
         "termctrl": "bin/termctrl",
       },
     },
     "packages/darwin-x64": {
       "name": "@kitlangton/terminal-control-darwin-x64",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "bin": {
         "termctrl": "bin/termctrl",
       },
     },
     "packages/linux-arm64-gnu": {
       "name": "@kitlangton/terminal-control-linux-arm64-gnu",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "bin": {
         "termctrl": "bin/termctrl",
       },
     },
     "packages/linux-x64-gnu": {
       "name": "@kitlangton/terminal-control-linux-x64-gnu",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "bin": {
         "termctrl": "bin/termctrl",
       },
     },
     "packages/test": {
       "name": "@kitlangton/terminal-control",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "devDependencies": {
         "@types/bun": "^1.3.0",
         "@types/node": "^24.0.0",
@@ -46,10 +46,10 @@
         "vitest": "^3.2.4",
       },
       "optionalDependencies": {
-        "@kitlangton/terminal-control-darwin-arm64": "0.4.1",
-        "@kitlangton/terminal-control-darwin-x64": "0.4.1",
-        "@kitlangton/terminal-control-linux-arm64-gnu": "0.4.1",
-        "@kitlangton/terminal-control-linux-x64-gnu": "0.4.1",
+        "@kitlangton/terminal-control-darwin-arm64": "0.5.0",
+        "@kitlangton/terminal-control-darwin-x64": "0.5.0",
+        "@kitlangton/terminal-control-linux-arm64-gnu": "0.5.0",
+        "@kitlangton/terminal-control-linux-x64-gnu": "0.5.0",
       },
       "peerDependencies": {
         "vitest": ">=3.0.0",

--- a/packages/darwin-arm64/CHANGELOG.md
+++ b/packages/darwin-arm64/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @kitlangton/terminal-control-darwin-arm64
 
+## 0.5.0
+
 ## 0.4.1
 
 ## 0.4.0

--- a/packages/darwin-arm64/package.json
+++ b/packages/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control-darwin-arm64",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Native termctrl binary for Terminal Control on macOS arm64",
   "license": "MIT",
   "repository": "https://github.com/anomalyco/terminal-control",

--- a/packages/darwin-x64/CHANGELOG.md
+++ b/packages/darwin-x64/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @kitlangton/terminal-control-darwin-x64
 
+## 0.5.0
+
 ## 0.4.1
 
 ## 0.4.0

--- a/packages/darwin-x64/package.json
+++ b/packages/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control-darwin-x64",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Native termctrl binary for Terminal Control on macOS x64",
   "license": "MIT",
   "repository": "https://github.com/anomalyco/terminal-control",

--- a/packages/linux-arm64-gnu/CHANGELOG.md
+++ b/packages/linux-arm64-gnu/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @kitlangton/terminal-control-linux-arm64-gnu
 
+## 0.5.0
+
 ## 0.4.1
 
 ## 0.4.0

--- a/packages/linux-arm64-gnu/package.json
+++ b/packages/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control-linux-arm64-gnu",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Native termctrl binary for Terminal Control on Linux arm64 GNU",
   "license": "MIT",
   "repository": "https://github.com/anomalyco/terminal-control",

--- a/packages/linux-x64-gnu/CHANGELOG.md
+++ b/packages/linux-x64-gnu/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @kitlangton/terminal-control-linux-x64-gnu
 
+## 0.5.0
+
 ## 0.4.1
 
 ## 0.4.0

--- a/packages/linux-x64-gnu/package.json
+++ b/packages/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control-linux-x64-gnu",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Native termctrl binary for Terminal Control on Linux x64 GNU",
   "license": "MIT",
   "repository": "https://github.com/anomalyco/terminal-control",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @kitlangton/terminal-control
 
+## 0.5.0
+
+### Minor Changes
+
+- cc0be0e: Add persistent, reattachable workspaces with named windows, reorderable tabs, movable split panes, pane
+  zoom, a command palette, and workspace-wide pane IDs that remain stable for the workspace lifetime.
+  Agents can inspect and control hidden windows and panes through typed CLI and MCP operations, capture
+  pane/window/workspace PNGs, record the composed workspace, and discover their current pane context.
+
+### Patch Changes
+
+- 033f0d7: Replace the terminal state engine with Ghostty for accurate reflow, Unicode, attributes, and PTY responses.
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Typed terminal application control and testing with snapshots, recordings, and failure artifacts",
   "license": "MIT",
   "repository": {
@@ -38,10 +38,10 @@
     "prepack": "bun run build"
   },
   "optionalDependencies": {
-    "@kitlangton/terminal-control-darwin-arm64": "0.4.1",
-    "@kitlangton/terminal-control-darwin-x64": "0.4.1",
-    "@kitlangton/terminal-control-linux-arm64-gnu": "0.4.1",
-    "@kitlangton/terminal-control-linux-x64-gnu": "0.4.1"
+    "@kitlangton/terminal-control-darwin-arm64": "0.5.0",
+    "@kitlangton/terminal-control-darwin-x64": "0.5.0",
+    "@kitlangton/terminal-control-linux-arm64-gnu": "0.5.0",
+    "@kitlangton/terminal-control-linux-x64-gnu": "0.5.0"
   },
   "peerDependencies": {
     "vitest": ">=3.0.0"


### PR DESCRIPTION
## What

Prepare the aligned Terminal Control `0.5.0` release across crates.io, the TypeScript client, and all four native npm packages.

## How

- Consume the Ghostty engine and persistent-workspace Changesets.
- Set `Cargo.toml`, `Cargo.lock`, all npm manifests, native optional dependencies, and `bun.lock` to `0.5.0`.
- Generate package changelogs for the minor release.

## Scope

This PR prepares and validates release metadata only. Public crates.io/npm publication and the GitHub tag occur after this commit merges and the no-publish artifact workflow passes.

## Testing

- `bun install --frozen-lockfile`
- `cargo fmt --all -- --check`
- `cargo test --all-targets`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release`
- `bun run test:npm`
- `bun run build:npm`
- `bun run validate:npm`
- `cargo package --list`
- `cargo package`
- `cargo publish --dry-run --locked --allow-dirty`

The native package validator confirmed the packed `0.5.0` npm package contains a `termctrl 0.5.0` binary and installs successfully in a clean consumer.