### PR TITLE
fix: harden semantic snapshot release

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -61,9 +61,28 @@ jobs:
           name: npm-test
           path: npm-artifacts/*.tgz
 
+  opentui:
+    name: OpenTUI adapter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - run: bun run --cwd packages/opentui typecheck
+      - run: bun run --cwd packages/opentui test
+      - run: mkdir -p npm-artifacts && npm pack ./packages/opentui --pack-destination npm-artifacts
+      - run: node scripts/validate-opentui-package.mjs npm-artifacts
+      - uses: actions/upload-artifact@v7
+        with:
+          name: npm-opentui
+          path: npm-artifacts/*.tgz
+
   validate:
     name: Validate publishable install
-    needs: [native, client]
+    needs: [native, client, opentui]
     strategy:
       matrix:
         include:
@@ -105,8 +124,6 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
       - run: npm install --global npm@latest
-      - run: npm install --ignore-scripts --no-package-lock --workspaces=false
-        working-directory: packages/opentui
       - uses: actions/download-artifact@v8
         with:
           pattern: npm-*

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The second command writes `captures/model.png` and `captures/model.txt`. Raw ANS
 Use a named session when several interactions target the same running application:
 
 ```bash
-termctrl start demo --cols 112 --rows 34 -- my-terminal-app
+termctrl start demo --host opentui --cols 112 --rows 34 -- my-terminal-app
 termctrl wait demo "Ready"
 termctrl send demo text:help enter
 termctrl show demo

--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ const semanticProvider = provideTerminalControl(renderer, {
 renderer.once("destroy", () => semanticProvider.close())
 ```
 
+See [docs/semantic-protocol.md](docs/semantic-protocol.md) for the versioned handshake, snapshot
+messages, limits, timeout behavior, and output contract.
+
 ## Enter A Shared Workspace
 
 `run` creates a persistent workspace when its name is absent and attaches the current terminal. Running the same name later reattaches to the existing panes. `attach` is the strict attach-only form:
@@ -324,6 +327,7 @@ See [docs/typescript-client.md](docs/typescript-client.md) for artifacts, record
 
 - [docs/rust-library.md](docs/rust-library.md) — embed the shot engine and sessions in Rust, plus versioned JSON schemas.
 - [docs/driver-protocol.md](docs/driver-protocol.md) — the `termctrl driver` JSON Lines protocol for external tooling.
+- [docs/semantic-protocol.md](docs/semantic-protocol.md) — the application semantic socket handshake and snapshot contract.
 - [docs/typescript-client.md](docs/typescript-client.md) — the npm test client in full.
 - [docs/releasing.md](docs/releasing.md) — aligned crates.io, npm, and GitHub release process.
 

--- a/bun.lock
+++ b/bun.lock
@@ -46,7 +46,7 @@
         "typescript": "^5.9.0",
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.4.0 <1",
+        "@opentui/core": ">=0.4.1 <0.5.0",
       },
     },
     "packages/test": {

--- a/docs/driver-protocol.md
+++ b/docs/driver-protocol.md
@@ -32,7 +32,8 @@ increment `protocolVersion`; clients reject unsupported versions rather than gue
 ```
 
 Set launch `host` to `"opentui"` for OpenTUI startup probe responses and the private
-`TERMCTRL_SEMANTIC_SOCKET` used by compatible semantic snapshot adapters.
+`TERMCTRL_SEMANTIC_SOCKET` used by compatible semantic snapshot adapters. The socket's separate
+application protocol is documented in [semantic-protocol.md](semantic-protocol.md).
 
 ## Capture Semantics
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -2,9 +2,9 @@
 
 Terminal Control releases one aligned version across the public `terminal-control` crate, the
 `@kitlangton/terminal-control` client, the `@kitlangton/terminal-control-opentui` adapter, and four native npm
-packages. The adapter publishes from its package-local Node release script while the fixed native
-tarball set keeps its existing publisher. npm packages are published by the manual
-`npm-release.yml` workflow; crates.io publication and the GitHub release are separate explicit steps.
+packages. The manual `npm-release.yml` workflow builds and validates the complete aligned tarball
+set, then publishes those exact artifacts. crates.io publication and the GitHub release are separate
+explicit steps.
 
 ## Prepare The Version
 
@@ -21,9 +21,8 @@ have Changesets.
    `main` through CI.
 
 Native packaging rejects a Rust executable whose `termctrl --version` differs from its npm package
-manifest. The OpenTUI release script reads the TypeScript client version and updates its package
-manifest to match before publishing. Do not bypass the native checks or publish package formats at
-different versions.
+manifest. The OpenTUI manifest must already match the TypeScript client before publishing. Do not
+bypass the package-set checks or publish package formats at different versions.
 
 ## Validate The Release
 
@@ -42,8 +41,8 @@ gh workflow run npm-release.yml --ref main -f publish=false
 
 Confirm the workflow run targets the intended release commit. Its matrix builds macOS and Linux
 binaries for arm64 and x64, verifies the complete fixed-version tarball set, and installs the packed
-client from clean Bun and Node/Vitest consumers. The OpenTUI adapter validates independently with
-`bun run --cwd packages/opentui release:check`.
+client from clean Bun and Node/Vitest consumers. It also installs the packed OpenTUI adapter into
+clean consumers against the oldest and newest supported OpenTUI versions.
 
 ## Publish
 
@@ -54,10 +53,10 @@ cargo publish --locked
 gh workflow run npm-release.yml --ref main -f publish=true
 ```
 
-The npm workflow runs `node scripts/release-packages.mjs`, which publishes the fixed native/client
-tarball set and then invokes the OpenTUI package's normal `npm publish`. Both publishers are
-retry-safe and skip an exact package version already present in npm. crates.io publication requires
-Cargo credentials for an owner of `terminal-control`; do not add registry tokens to the repository.
+The npm workflow runs `node scripts/release-packages.mjs`, which publishes the validated aligned
+tarball set. The publisher is retry-safe and skips an exact package version already present in npm.
+crates.io publication requires Cargo credentials for an owner of `terminal-control`; do not add
+registry tokens to the repository.
 
 After both registries report the new version, create the matching tag and GitHub release:
 
@@ -79,3 +78,8 @@ Install the released package in a clean consumer and confirm `termctrl --version
 Each npm package, including the OpenTUI adapter, must configure `anomalyco/terminal-control` and
 workflow `npm-release.yml` as its trusted publisher. The publish job uses Node 24, current npm, and
 `id-token: write`; it does not use a long-lived npm token.
+
+npm cannot configure a trusted publisher before a package exists. For the adapter's first release,
+publish its already validated tarball once with a short-lived bootstrap credential, configure the
+trusted publisher on npmjs.com with a security key, then revoke the credential before running the
+normal OIDC workflow. Do not publish a separately rebuilt package directory for the bootstrap.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -44,6 +44,17 @@ binaries for arm64 and x64, verifies the complete fixed-version tarball set, and
 client from clean Bun and Node/Vitest consumers. It also installs the packed OpenTUI adapter into
 clean consumers against the oldest and newest supported OpenTUI versions.
 
+## Bootstrap A New npm Package
+
+npm cannot configure a trusted publisher before a package exists. Before the adapter's first normal
+release workflow, download its already validated tarball, publish that exact artifact once with a
+short-lived bootstrap credential, configure `anomalyco/terminal-control` and `npm-release.yml` as its
+trusted publisher with a security key, then revoke the credential. Do not publish a separately
+rebuilt package directory.
+
+The aligned publisher checks or publishes the adapter before the established packages, so a missing
+bootstrap or OIDC binding fails before it can partially publish the fixed group.
+
 ## Publish
 
 Publishing is an irreversible public release. From the validated release commit:
@@ -78,8 +89,3 @@ Install the released package in a clean consumer and confirm `termctrl --version
 Each npm package, including the OpenTUI adapter, must configure `anomalyco/terminal-control` and
 workflow `npm-release.yml` as its trusted publisher. The publish job uses Node 24, current npm, and
 `id-token: write`; it does not use a long-lived npm token.
-
-npm cannot configure a trusted publisher before a package exists. For the adapter's first release,
-publish its already validated tarball once with a short-lived bootstrap credential, configure the
-trusted publisher on npmjs.com with a security key, then revoke the credential before running the
-normal OIDC workflow. Do not publish a separately rebuilt package directory for the bootstrap.

--- a/docs/rust-library.md
+++ b/docs/rust-library.md
@@ -35,6 +35,26 @@ session.stop()?;
 
 `session::Session` is the embedded lifecycle interface; the flat named-session CLI commands and the external driver are adapters over the same implementation.
 
+To request optional application semantics, enable the OpenTUI host profile before launch and read
+the provider with the same embedded session:
+
+```rust
+use std::time::Duration;
+
+let mut options = terminal_control::shot::Options::default();
+options.opentui_host = true;
+let mut session = terminal_control::session::Session::start(
+    &["my-opentui-app".to_owned()],
+    None,
+    None,
+    &options,
+)?;
+let semantics = session.semantic_snapshot(Duration::from_secs(1))?;
+```
+
+No connected provider returns `termctrl-semantic-snapshot-v1` with an empty `nodes` array. See
+[semantic-protocol.md](semantic-protocol.md) for the application-side wire contract.
+
 ## Versioned Structured Output
 
 - A `save --format json` capture is a `Frame` object with `version: 1`, described by `schemas/frame-v1.schema.json`.

--- a/docs/semantic-protocol.md
+++ b/docs/semantic-protocol.md
@@ -1,0 +1,64 @@
+# Application Semantic Protocol
+
+Terminal Control can read optional structured UI state from a cooperating application. The
+application protocol is separate from terminal output and is available only to commands launched
+with the OpenTUI host profile.
+
+## Transport
+
+Terminal Control creates an owner-only Unix stream socket and passes its absolute path to the child
+as `TERMCTRL_SEMANTIC_SOCKET`. The variable is reserved: ordinary and nested launches remove any
+inherited value, while each `--host opentui` launch receives a fresh socket.
+
+Messages are UTF-8 JSON followed by `\n`. A message may contain at most 8 MiB. The application must
+connect and send its handshake within five seconds of the socket being accepted:
+
+```json
+{"type":"hello","protocolVersion":1,"application":{"name":"my-tui","version":"1.0.0"},"capabilities":["semantic.snapshot"]}
+```
+
+`application.name` is required and nonempty. `application.version` is optional. Terminal Control
+accepts protocol version 1 and responds:
+
+```json
+{"type":"ready","protocolVersion":1}
+```
+
+An incompatible or malformed provider is an error. An application that never connects is treated as
+having no semantic provider and produces the empty snapshot.
+
+## Snapshots
+
+Terminal Control sends at most one request at a time on a provider connection:
+
+```json
+{"type":"semantic.snapshot","id":1}
+```
+
+The application returns the same safe-integer request ID with either a JSON value:
+
+```json
+{"type":"result","id":1,"value":{"format":"termctrl-semantic-snapshot-v1","nodes":[]}}
+```
+
+or an application error:
+
+```json
+{"type":"error","id":1,"error":{"code":"NOT_READY","message":"the UI is still mounting"}}
+```
+
+`error.code` and `error.message` must be strings. Terminal Control preserves the provider's JSON
+value without imposing an application-specific schema. The official OpenTUI adapter emits
+`termctrl-semantic-snapshot-v1`, whose `nodes` contain unique `id`, `role`, optional `label`, numeric
+`element`, `focused`, and `disabled` fields.
+
+`termctrl show NAME --format semantic` uses `--deadline-ms` as one absolute deadline across the named
+session request and application response; the default is 1000 ms. A timeout closes the provider
+connection so a late reply cannot be mistaken for a later request. Providers should reconnect after
+an established connection closes. The official OpenTUI adapter does this automatically.
+
+## Security
+
+The socket and its runtime directory are readable only by the current Unix user. Semantic snapshots
+are application output and must be treated as untrusted JSON. They may contain sensitive UI state;
+do not persist or publish them without the same care as terminal captures and recordings.

--- a/packages/opentui/README.md
+++ b/packages/opentui/README.md
@@ -33,11 +33,5 @@ numeric element handles without requiring every application to maintain its own 
 `elements(renderer)` and `semanticSnapshot(renderer)` are also exported for tests and custom
 integrations.
 
-Publish the package directly from this directory:
-
-```bash
-npm publish --access public
-```
-
-The repository-level `npm run release-packages` command calls this package's retry-safe `release`
-script after publishing the native Terminal Control package set.
+This package is released with Terminal Control's fixed-version package group. See the repository's
+`docs/releasing.md` process rather than publishing this directory directly.

--- a/packages/opentui/package.json
+++ b/packages/opentui/package.json
@@ -36,7 +36,7 @@
     "release:check": "node script/release.mjs --check"
   },
   "peerDependencies": {
-    "@opentui/core": ">=0.4.0 <1"
+    "@opentui/core": ">=0.4.1 <0.5.0"
   },
   "devDependencies": {
     "@opentui/core": "^0.4.5",

--- a/packages/opentui/script/release.mjs
+++ b/packages/opentui/script/release.mjs
@@ -11,6 +11,11 @@ const terminalControl = JSON.parse(
 const check = process.argv.includes("--check")
 
 const aligned = manifest.version !== terminalControl.version
+if (aligned && !check) {
+  throw new Error(
+    `${manifest.name} is ${manifest.version}, but ${terminalControl.name} is ${terminalControl.version}; prepare the aligned release versions before publishing`,
+  )
+}
 if (aligned) {
   console.log(`aligning ${manifest.name} from ${manifest.version} to ${terminalControl.version}`)
   manifest.version = terminalControl.version

--- a/packages/opentui/src/index.test.ts
+++ b/packages/opentui/src/index.test.ts
@@ -78,6 +78,9 @@ test("excludes hidden descendants from labels and reports clipped geometry", asy
   const secret = new BoxRenderable(setup.renderer, { visible: false, width: 5, height: 1 })
   Reflect.set(secret, "plainText", "secret")
   button.add(secret)
+  const faded = new BoxRenderable(setup.renderer, { opacity: 0, width: 5, height: 1 })
+  Reflect.set(faded, "plainText", "faded secret")
+  button.add(faded)
   const clipped = new BoxRenderable(setup.renderer, { id: "clip", overflow: "hidden", width: 5, height: 1 })
   const partial = new BoxRenderable(setup.renderer, {
     id: "partial",
@@ -94,6 +97,50 @@ test("excludes hidden descendants from labels and reports clipped geometry", asy
 
   expect(semanticSnapshot(setup.renderer).nodes.find((node) => node.id === "button")?.label).toBe("button")
   expect(elements(setup.renderer).find((element) => element.id === "partial")).toMatchObject({ x: 4, width: 1 })
+  setup.renderer.destroy()
+})
+
+test("omits controls with zero effective opacity", async () => {
+  const setup = await createTestRenderer({ width: 20, height: 5 })
+  const transparent = new BoxRenderable(setup.renderer, {
+    id: "transparent",
+    focusable: true,
+    opacity: 0,
+    width: 5,
+    height: 1,
+  })
+  const parent = new BoxRenderable(setup.renderer, { id: "transparent-parent", opacity: 0, width: 5, height: 1 })
+  parent.add(new BoxRenderable(setup.renderer, { id: "transparent-child", focusable: true, width: 5, height: 1 }))
+  setup.renderer.root.add(transparent)
+  setup.renderer.root.add(parent)
+  await setup.renderOnce()
+
+  expect(semanticSnapshot(setup.renderer).nodes).toEqual([])
+  setup.renderer.destroy()
+})
+
+test("keeps mouse controls reachable outside an occluded midpoint", async () => {
+  const setup = await createTestRenderer({ width: 20, height: 5 })
+  const button = new BoxRenderable(setup.renderer, {
+    id: "wide-button",
+    width: 10,
+    height: 1,
+    onMouseDown: () => {},
+  })
+  const overlay = new BoxRenderable(setup.renderer, {
+    id: "overlay",
+    position: "absolute",
+    left: 4,
+    width: 2,
+    height: 1,
+    zIndex: 1,
+    onMouseDown: () => {},
+  })
+  setup.renderer.root.add(button)
+  setup.renderer.root.add(overlay)
+  await setup.renderOnce()
+
+  expect(elements(setup.renderer).find((element) => element.id === "wide-button")?.clickable).toBe(true)
   setup.renderer.destroy()
 })
 

--- a/packages/opentui/src/index.test.ts
+++ b/packages/opentui/src/index.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path"
 import { BoxRenderable } from "@opentui/core"
 import { createTestRenderer } from "@opentui/core/testing"
 import { elements, provideTerminalControl, semanticSnapshot } from "./index"
+import { provideSemanticSnapshot } from "./provider"
 
 test("discovers the same live interactable elements used by semantic snapshots", async () => {
   const setup = await createTestRenderer({ width: 20, height: 5 })
@@ -45,6 +46,72 @@ test("discovers the same live interactable elements used by semantic snapshots",
       },
     ],
   })
+  setup.renderer.destroy()
+})
+
+test("omits controls hidden or clipped by their ancestors", async () => {
+  const setup = await createTestRenderer({ width: 20, height: 5 })
+  const hidden = new BoxRenderable(setup.renderer, { id: "hidden", visible: false })
+  hidden.add(new BoxRenderable(setup.renderer, { id: "hidden-child", focusable: true, width: 5, height: 1 }))
+  const clipped = new BoxRenderable(setup.renderer, { id: "clipped", overflow: "scroll", width: 5, height: 1 })
+  clipped.add(
+    new BoxRenderable(setup.renderer, {
+      id: "clipped-child",
+      focusable: true,
+      position: "absolute",
+      left: 10,
+      width: 5,
+      height: 1,
+    }),
+  )
+  setup.renderer.root.add(hidden)
+  setup.renderer.root.add(clipped)
+  await setup.renderOnce()
+
+  expect(semanticSnapshot(setup.renderer).nodes).toEqual([])
+  setup.renderer.destroy()
+})
+
+test("excludes hidden descendants from labels and reports clipped geometry", async () => {
+  const setup = await createTestRenderer({ width: 20, height: 5 })
+  const button = new BoxRenderable(setup.renderer, { id: "button", focusable: true, width: 5, height: 1 })
+  const secret = new BoxRenderable(setup.renderer, { visible: false, width: 5, height: 1 })
+  Reflect.set(secret, "plainText", "secret")
+  button.add(secret)
+  const clipped = new BoxRenderable(setup.renderer, { id: "clip", overflow: "hidden", width: 5, height: 1 })
+  const partial = new BoxRenderable(setup.renderer, {
+    id: "partial",
+    focusable: true,
+    position: "absolute",
+    left: 4,
+    width: 5,
+    height: 1,
+  })
+  clipped.add(partial)
+  setup.renderer.root.add(button)
+  setup.renderer.root.add(clipped)
+  await setup.renderOnce()
+
+  expect(semanticSnapshot(setup.renderer).nodes.find((node) => node.id === "button")?.label).toBe("button")
+  expect(elements(setup.renderer).find((element) => element.id === "partial")).toMatchObject({ x: 4, width: 1 })
+  setup.renderer.destroy()
+})
+
+test("keeps generated semantic node ids unique", async () => {
+  const setup = await createTestRenderer({ width: 20, height: 5 })
+  const first = new BoxRenderable(setup.renderer, { focusable: true, width: 1, height: 1 })
+  const second = new BoxRenderable(setup.renderer, { focusable: true, width: 1, height: 1 })
+  const third = new BoxRenderable(setup.renderer, { focusable: true, width: 1, height: 1 })
+  first.id = `same-${third.num}`
+  second.id = "same"
+  third.id = "same"
+  setup.renderer.root.add(first)
+  setup.renderer.root.add(second)
+  setup.renderer.root.add(third)
+  await setup.renderOnce()
+
+  const ids = semanticSnapshot(setup.renderer).nodes.map((node) => node.id)
+  expect(new Set(ids).size).toBe(ids.length)
   setup.renderer.destroy()
 })
 
@@ -99,6 +166,138 @@ test("provides semantic snapshots over the discovered Terminal Control socket", 
     provider.close()
     setup.renderer.destroy()
     await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+test("reconnects after an established Terminal Control connection closes", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "termctrl-opentui-reconnect-"))
+  const socketPath = join(directory, "semantic.sock")
+  let connections = 0
+  let resolveResult!: (value: unknown) => void
+  const result = new Promise((resolve) => {
+    resolveResult = resolve
+  })
+  const server = createServer((socket) => {
+    connections++
+    const connection = connections
+    socket.setEncoding("utf8")
+    let buffer = ""
+    socket.on("data", (chunk) => {
+      buffer += chunk
+      const lines = buffer.split("\n")
+      buffer = lines.pop() ?? ""
+      for (const line of lines) {
+        const message = JSON.parse(line)
+        if (message.type === "hello") {
+          socket.write(`${JSON.stringify({ type: "ready", protocolVersion: 1 })}\n`)
+          if (connection === 1) setTimeout(() => socket.destroy(), 10)
+          else socket.write(`${JSON.stringify({ type: "semantic.snapshot", id: 2 })}\n`)
+        }
+        if (message.type === "result") resolveResult(message.value)
+      }
+    })
+  })
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(socketPath, resolve)
+  })
+  const provider = provideSemanticSnapshot({
+    application: { name: "fixture" },
+    socketPath,
+    snapshot: () => ({ format: "termctrl-semantic-snapshot-v1", nodes: [] }),
+  })
+
+  try {
+    expect(await provider.ready).toBe(true)
+    expect(
+      await Promise.race([
+        result,
+        Bun.sleep(2_000).then(() => {
+          throw new Error("provider did not reconnect")
+        }),
+      ]),
+    ).toEqual({ format: "termctrl-semantic-snapshot-v1", nodes: [] })
+    expect(connections).toBe(2)
+  } finally {
+    provider.close()
+    await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+test("keeps retrying when the first reconnect attempt fails", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "termctrl-opentui-retry-"))
+  const socketPath = join(directory, "semantic.sock")
+  let firstSocket: import("node:net").Socket | undefined
+  let resolveFailedRetry!: () => void
+  const failedRetry = new Promise<void>((resolve) => {
+    resolveFailedRetry = resolve
+  })
+  const firstServer = createServer((socket) => {
+    firstSocket = socket
+    socket.setEncoding("utf8")
+    socket.once("data", () => socket.write(`${JSON.stringify({ type: "ready", protocolVersion: 1 })}\n`))
+  })
+  await new Promise<void>((resolve, reject) => {
+    firstServer.once("error", reject)
+    firstServer.listen(socketPath, resolve)
+  })
+  const provider = provideSemanticSnapshot({
+    application: { name: "fixture" },
+    socketPath,
+    snapshot: () => ({ recovered: true }),
+    onError: () => resolveFailedRetry(),
+  })
+
+  try {
+    expect(await provider.ready).toBe(true)
+    firstSocket?.destroy()
+    await new Promise<void>((resolve, reject) => firstServer.close((error) => (error ? reject(error) : resolve())))
+    await failedRetry
+
+    let resolveResult!: (value: unknown) => void
+    const result = new Promise((resolve) => {
+      resolveResult = resolve
+    })
+    const secondServer = createServer((socket) => {
+      socket.setEncoding("utf8")
+      let buffer = ""
+      socket.on("data", (chunk) => {
+        buffer += chunk
+        const lines = buffer.split("\n")
+        buffer = lines.pop() ?? ""
+        for (const line of lines) {
+          const message = JSON.parse(line)
+          if (message.type === "hello") {
+            socket.write(`${JSON.stringify({ type: "ready", protocolVersion: 1 })}\n`)
+            socket.write(`${JSON.stringify({ type: "semantic.snapshot", id: 3 })}\n`)
+          }
+          if (message.type === "result") resolveResult(message.value)
+        }
+      })
+    })
+    await new Promise<void>((resolve, reject) => {
+      secondServer.once("error", reject)
+      secondServer.listen(socketPath, resolve)
+    })
+    try {
+      expect(
+        await Promise.race([
+          result,
+          Bun.sleep(2_000).then(() => {
+            throw new Error("provider stopped retrying")
+          }),
+        ]),
+      ).toEqual({ recovered: true })
+    } finally {
+      provider.close()
+      await new Promise<void>((resolve, reject) =>
+        secondServer.close((error) => (error ? reject(error) : resolve())),
+      )
+    }
+  } finally {
+    provider.close()
     await rm(directory, { recursive: true, force: true })
   }
 })

--- a/packages/opentui/src/index.ts
+++ b/packages/opentui/src/index.ts
@@ -45,10 +45,13 @@ function hasMouseListeners(renderable: Renderable) {
 function receivesClick(renderer: CliRenderer, renderable: Renderable) {
   const bounds = visibleBounds(renderer, renderable)
   if (!bounds) return false
-  const x = Math.floor(bounds.x + bounds.width / 2)
-  const y = Math.floor(bounds.y + bounds.height / 2)
-  const target = renderer.hitTest(x, y)
-  return all(renderable).some((item) => item.num === target)
+  const targets = new Set(all(renderable).map((item) => item.num))
+  for (let y = Math.floor(bounds.y); y < Math.ceil(bounds.y + bounds.height); y++) {
+    for (let x = Math.floor(bounds.x); x < Math.ceil(bounds.x + bounds.width); x++) {
+      if (targets.has(renderer.hitTest(x, y))) return true
+    }
+  }
+  return false
 }
 
 export function elements(renderer: CliRenderer): InteractableElement[] {
@@ -94,7 +97,13 @@ export function semanticSnapshot(renderer: CliRenderer): SemanticSnapshot {
 }
 
 function visibleBounds(renderer: CliRenderer, renderable: Renderable) {
-  if (renderable.isDestroyed || !renderable.visible || renderable.width <= 0 || renderable.height <= 0) {
+  if (
+    renderable.isDestroyed ||
+    !renderable.visible ||
+    renderable.opacity <= 0 ||
+    renderable.width <= 0 ||
+    renderable.height <= 0
+  ) {
     return undefined
   }
   let left = Math.max(0, renderable.screenX)
@@ -102,7 +111,7 @@ function visibleBounds(renderer: CliRenderer, renderable: Renderable) {
   let right = Math.min(renderer.width, renderable.screenX + renderable.width)
   let bottom = Math.min(renderer.height, renderable.screenY + renderable.height)
   for (let parent = renderable.parent; parent; parent = parent.parent) {
-    if (parent.isDestroyed || !parent.visible) return undefined
+    if (parent.isDestroyed || !parent.visible || parent.opacity <= 0) return undefined
     if (parent.overflow !== "visible") {
       left = Math.max(left, parent.screenX)
       top = Math.max(top, parent.screenY)

--- a/packages/opentui/src/index.ts
+++ b/packages/opentui/src/index.ts
@@ -43,28 +43,31 @@ function hasMouseListeners(renderable: Renderable) {
 }
 
 function receivesClick(renderer: CliRenderer, renderable: Renderable) {
-  if (renderable.width <= 0 || renderable.height <= 0) return false
-  const x = Math.floor(renderable.screenX + renderable.width / 2)
-  const y = Math.floor(renderable.screenY + renderable.height / 2)
+  const bounds = visibleBounds(renderer, renderable)
+  if (!bounds) return false
+  const x = Math.floor(bounds.x + bounds.width / 2)
+  const y = Math.floor(bounds.y + bounds.height / 2)
   const target = renderer.hitTest(x, y)
   return all(renderable).some((item) => item.num === target)
 }
 
 export function elements(renderer: CliRenderer): InteractableElement[] {
   return all(renderer.root)
-    .filter((renderable) => renderable.visible && !renderable.isDestroyed)
-    .map((renderable) => ({
-      id: renderable.id,
-      num: renderable.num,
-      x: renderable.screenX,
-      y: renderable.screenY,
-      width: renderable.width,
-      height: renderable.height,
-      focusable: renderable.focusable,
-      focused: renderable.focused,
-      clickable: hasMouseListeners(renderable) && receivesClick(renderer, renderable),
-      editor: renderer.currentFocusedEditor === renderable,
-    }))
+    .flatMap((renderable) => {
+      const bounds = visibleBounds(renderer, renderable)
+      if (!bounds) return []
+      return [
+        {
+          id: renderable.id,
+          num: renderable.num,
+          ...bounds,
+          focusable: renderable.focusable,
+          focused: renderable.focused,
+          clickable: hasMouseListeners(renderable) && receivesClick(renderer, renderable),
+          editor: renderer.currentFocusedEditor === renderable,
+        },
+      ]
+    })
     .filter((element) => element.focusable || element.clickable || element.editor)
 }
 
@@ -75,18 +78,40 @@ export function semanticSnapshot(renderer: CliRenderer): SemanticSnapshot {
     format: "termctrl-semantic-snapshot-v1",
     nodes: elements(renderer).map((element) => {
       const preferred = element.id || `renderable-${element.num}`
-      const id = ids.has(preferred) ? `${preferred}-${element.num}` : preferred
+      let id = preferred
+      for (let suffix = element.num; ids.has(id); suffix++) id = `${preferred}-${suffix}`
       ids.add(id)
       return {
         id,
         role: element.editor ? "textbox" : element.clickable ? "button" : "control",
-        label: label(renderables.get(element.num), element),
+        label: label(renderer, renderables.get(element.num), element),
         element: element.num,
         focused: element.focused || element.editor,
         disabled: false,
       }
     }),
   }
+}
+
+function visibleBounds(renderer: CliRenderer, renderable: Renderable) {
+  if (renderable.isDestroyed || !renderable.visible || renderable.width <= 0 || renderable.height <= 0) {
+    return undefined
+  }
+  let left = Math.max(0, renderable.screenX)
+  let top = Math.max(0, renderable.screenY)
+  let right = Math.min(renderer.width, renderable.screenX + renderable.width)
+  let bottom = Math.min(renderer.height, renderable.screenY + renderable.height)
+  for (let parent = renderable.parent; parent; parent = parent.parent) {
+    if (parent.isDestroyed || !parent.visible) return undefined
+    if (parent.overflow !== "visible") {
+      left = Math.max(left, parent.screenX)
+      top = Math.max(top, parent.screenY)
+      right = Math.min(right, parent.screenX + parent.width)
+      bottom = Math.min(bottom, parent.screenY + parent.height)
+    }
+  }
+  if (right <= left || bottom <= top) return undefined
+  return { x: left, y: top, width: right - left, height: bottom - top }
 }
 
 export function provideTerminalControl(
@@ -107,9 +132,10 @@ export function provideTerminalControl(
   })
 }
 
-function label(renderable: Renderable | undefined, element: InteractableElement) {
+function label(renderer: CliRenderer, renderable: Renderable | undefined, element: InteractableElement) {
   if (!renderable || element.editor) return element.id || undefined
   const text = all(renderable)
+    .filter((item) => visibleBounds(renderer, item) !== undefined)
     .map((item) => Reflect.get(item, "plainText"))
     .find((value): value is string => typeof value === "string" && value.trim().length > 0)
   return text?.replaceAll(/\s+/g, " ").trim() || element.id || undefined

--- a/packages/opentui/src/provider.ts
+++ b/packages/opentui/src/provider.ts
@@ -1,4 +1,4 @@
-import { createConnection } from "node:net"
+import { createConnection, type Socket } from "node:net"
 
 export type Provider = {
   readonly enabled: boolean
@@ -15,10 +15,14 @@ export function provideSemanticSnapshot(options: {
   if (!options.application.name) throw new TypeError("application.name is required")
   const socketPath = options.socketPath ?? process.env.TERMCTRL_SEMANTIC_SOCKET
   if (!socketPath) return { enabled: false, ready: Promise.resolve(false), close() {} }
+  const semanticSocketPath = socketPath
 
-  let buffer = ""
-  let protocolReady = false
   let readySettled = false
+  let connectedOnce = false
+  let closed = false
+  let socket: Socket | undefined
+  let reconnectTimer: ReturnType<typeof setTimeout> | undefined
+  let reconnectDelay = 25
   let resolveReady!: (value: boolean) => void
   const ready = new Promise<boolean>((resolve) => {
     resolveReady = resolve
@@ -28,84 +32,102 @@ export function provideSemanticSnapshot(options: {
     readySettled = true
     resolveReady(value)
   }
-  const socket = createConnection(socketPath)
-  socket.setEncoding("utf8")
-  const handshakeTimer = setTimeout(() => fail(new Error("Terminal Control semantic handshake timed out")), 5_000)
-  handshakeTimer.unref()
+  connect()
 
-  socket.once("connect", () =>
-    send({
-      type: "hello",
-      protocolVersion: 1,
-      application: options.application,
-      capabilities: ["semantic.snapshot"],
-    }),
-  )
-  socket.on("data", (chunk) => {
-    buffer += chunk
-    const lines = buffer.split("\n")
-    buffer = lines.pop() ?? ""
-    for (const line of lines) {
-      if (!line) return fail(new Error("Terminal Control sent an empty semantic message"))
-      try {
-        receive(JSON.parse(line))
-      } catch (error) {
-        return fail(error)
+  function connect() {
+    let buffer = ""
+    let protocolReady = false
+    const connection = createConnection(semanticSocketPath)
+    socket = connection
+    connection.setEncoding("utf8")
+    const handshakeTimer = setTimeout(
+      () => fail(new Error("Terminal Control semantic handshake timed out")),
+      5_000,
+    )
+    handshakeTimer.unref()
+
+    connection.once("connect", () =>
+      send({
+        type: "hello",
+        protocolVersion: 1,
+        application: options.application,
+        capabilities: ["semantic.snapshot"],
+      }),
+    )
+    connection.on("data", (chunk) => {
+      buffer += chunk
+      const lines = buffer.split("\n")
+      buffer = lines.pop() ?? ""
+      for (const line of lines) {
+        if (!line) return fail(new Error("Terminal Control sent an empty semantic message"))
+        try {
+          receive(JSON.parse(line))
+        } catch (error) {
+          return fail(error)
+        }
       }
-    }
-  })
-  socket.once("error", fail)
-  socket.once("close", () => {
-    clearTimeout(handshakeTimer)
-    settleReady(false)
-  })
-
-  function receive(message: unknown) {
-    if (!isRecord(message)) throw new Error("Terminal Control sent an invalid semantic message")
-    if (message.type === "ready" && message.protocolVersion === 1 && !protocolReady) {
-      protocolReady = true
+    })
+    connection.once("error", fail)
+    connection.once("close", () => {
       clearTimeout(handshakeTimer)
-      settleReady(true)
-      return
+      if (socket === connection) socket = undefined
+      settleReady(false)
+      if (!closed && connectedOnce) {
+        reconnectTimer = setTimeout(connect, reconnectDelay)
+        reconnectTimer.unref()
+        reconnectDelay = Math.min(reconnectDelay * 2, 1_000)
+      }
+    })
+
+    function receive(message: unknown) {
+      if (!isRecord(message)) throw new Error("Terminal Control sent an invalid semantic message")
+      if (message.type === "ready" && message.protocolVersion === 1 && !protocolReady) {
+        protocolReady = true
+        connectedOnce = true
+        reconnectDelay = 25
+        clearTimeout(handshakeTimer)
+        settleReady(true)
+        return
+      }
+      if (message.type !== "semantic.snapshot" || !protocolReady || !Number.isSafeInteger(message.id)) {
+        throw new Error("Terminal Control sent an invalid semantic snapshot request")
+      }
+      const id = message.id as number
+      Promise.resolve()
+        .then(options.snapshot)
+        .then((value) => send({ type: "result", id, value }))
+        .catch((error) =>
+          send({
+            type: "error",
+            id,
+            error: {
+              code: isRecord(error) && typeof error.code === "string" ? error.code : "SNAPSHOT_FAILED",
+              message: error instanceof Error ? error.message : String(error),
+            },
+          }),
+        )
     }
-    if (message.type !== "semantic.snapshot" || !protocolReady || !Number.isSafeInteger(message.id)) {
-      throw new Error("Terminal Control sent an invalid semantic snapshot request")
+
+    function send(message: unknown) {
+      if (!connection.destroyed) connection.write(`${JSON.stringify(message)}\n`)
     }
-    const id = message.id as number
-    Promise.resolve()
-      .then(options.snapshot)
-      .then((value) => send({ type: "result", id, value }))
-      .catch((error) =>
-        sendError(
-          id,
-          isRecord(error) && typeof error.code === "string" ? error.code : "SNAPSHOT_FAILED",
-          error instanceof Error ? error.message : String(error),
-        ),
-      )
-  }
 
-  function sendError(id: number, code: string, message: string) {
-    send({ type: "error", id, error: { code, message } })
-  }
-
-  function send(message: unknown) {
-    if (!socket.destroyed) socket.write(`${JSON.stringify(message)}\n`)
-  }
-
-  function fail(error: unknown) {
-    clearTimeout(handshakeTimer)
-    settleReady(false)
-    options.onError?.(error)
-    socket.destroy()
+    function fail(error: unknown) {
+      clearTimeout(handshakeTimer)
+      if (!connectedOnce) settleReady(false)
+      options.onError?.(error)
+      connection.destroy()
+    }
   }
 
   return {
     enabled: true,
     ready,
     close() {
-      clearTimeout(handshakeTimer)
+      closed = true
+      if (reconnectTimer) clearTimeout(reconnectTimer)
       settleReady(false)
-      socket.destroy()
+      socket?.destroy()
     },
   }
 }

--- a/scripts/publish-npm-tarballs.mjs
+++ b/scripts/publish-npm-tarballs.mjs
@@ -27,7 +27,9 @@ const versions = new Set([...tarballs.values()].map(({ version }) => version))
 if (versions.size !== 1) {
   throw new Error(`npm package versions are not aligned: ${[...versions].join(", ")}`)
 }
-for (const name of [...nativePackages.map((entry) => entry.name), clientPackage, opentuiPackage]) {
+// Publish the new adapter first so a missing first-release OIDC binding cannot partially publish
+// the established fixed group. Exact versions already present are skipped on retries.
+for (const name of [opentuiPackage, ...nativePackages.map((entry) => entry.name), clientPackage]) {
   const { file, version } = tarballs.get(name)
   if (!checkOnly && !isPublished(name, version)) publish(resolve(directory, file))
 }

--- a/scripts/publish-npm-tarballs.mjs
+++ b/scripts/publish-npm-tarballs.mjs
@@ -7,7 +7,8 @@ const directory = resolve(process.argv[2] ?? "npm-artifacts")
 const checkOnly = process.argv.includes("--check")
 const files = (await readdir(directory)).filter((file) => file.endsWith(".tgz"))
 const clientPackage = "@kitlangton/terminal-control"
-const expected = [clientPackage, ...nativePackages.map((entry) => entry.name)]
+const opentuiPackage = "@kitlangton/terminal-control-opentui"
+const expected = [clientPackage, opentuiPackage, ...nativePackages.map((entry) => entry.name)]
 const tarballs = new Map()
 for (const file of files) {
   const manifest = manifestOf(resolve(directory, file))
@@ -26,7 +27,7 @@ const versions = new Set([...tarballs.values()].map(({ version }) => version))
 if (versions.size !== 1) {
   throw new Error(`npm package versions are not aligned: ${[...versions].join(", ")}`)
 }
-for (const name of [...nativePackages.map((entry) => entry.name), clientPackage]) {
+for (const name of [...nativePackages.map((entry) => entry.name), clientPackage, opentuiPackage]) {
   const { file, version } = tarballs.get(name)
   if (!checkOnly && !isPublished(name, version)) publish(resolve(directory, file))
 }

--- a/scripts/release-packages.mjs
+++ b/scripts/release-packages.mjs
@@ -4,7 +4,6 @@ import { resolve } from "node:path"
 const repository = resolve(import.meta.dirname, "..")
 
 run(process.execPath, [resolve(import.meta.dirname, "publish-npm-tarballs.mjs"), "npm-artifacts"])
-run(process.execPath, [resolve(repository, "packages/opentui/script/release.mjs")])
 
 function run(command, args) {
   const result = spawnSync(command, args, { cwd: repository, stdio: "inherit" })

--- a/scripts/validate-opentui-package.mjs
+++ b/scripts/validate-opentui-package.mjs
@@ -1,0 +1,84 @@
+import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { basename, join, resolve } from "node:path"
+import { spawnSync } from "node:child_process"
+
+const input = resolve(process.argv[2] ?? "npm-artifacts")
+const files = await readdir(input)
+const matches = files.filter(
+  (file) => file.startsWith("kitlangton-terminal-control-opentui-") && file.endsWith(".tgz"),
+)
+if (matches.length !== 1) {
+  throw new Error(`expected one OpenTUI adapter tarball in ${input}, found ${matches.length}`)
+}
+const tarball = join(input, matches[0])
+const manifest = JSON.parse(run("tar", ["-xOf", tarball, "package/package.json"]))
+if (manifest.name !== "@kitlangton/terminal-control-opentui") {
+  throw new Error(`unexpected OpenTUI adapter package name ${manifest.name}`)
+}
+
+const temp = await mkdtemp(join(tmpdir(), "termctrl-opentui-validation-"))
+try {
+  for (const opentuiVersion of ["0.4.1", "0.4.5"]) {
+    const consumer = join(temp, `opentui-${opentuiVersion}`)
+    await mkdir(consumer, { recursive: true })
+    await writeFile(
+      join(consumer, "package.json"),
+      `${JSON.stringify(
+        {
+          private: true,
+          type: "module",
+          dependencies: {
+            "@kitlangton/terminal-control-opentui": `file:${tarball}`,
+            "@opentui/core": opentuiVersion,
+            "@types/node": "^24.0.0",
+            typescript: "^5.9.0",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    )
+    await writeFile(
+      join(consumer, "tsconfig.json"),
+      `${JSON.stringify(
+        {
+          compilerOptions: {
+            strict: true,
+            noEmit: true,
+            target: "ESNext",
+            module: "NodeNext",
+            moduleResolution: "NodeNext",
+            skipLibCheck: true,
+            types: ["node"],
+          },
+          include: ["consumer.ts"],
+        },
+        null,
+        2,
+      )}\n`,
+    )
+    await writeFile(
+      join(consumer, "consumer.ts"),
+      `import { elements, provideTerminalControl, semanticSnapshot } from "@kitlangton/terminal-control-opentui"\nvoid elements\nvoid provideTerminalControl\nvoid semanticSnapshot\n`,
+    )
+    await writeFile(
+      join(consumer, "consumer.mjs"),
+      `import { elements, provideTerminalControl, semanticSnapshot } from "@kitlangton/terminal-control-opentui"\nfor (const value of [elements, provideTerminalControl, semanticSnapshot]) {\n  if (typeof value !== "function") throw new Error("missing OpenTUI adapter export")\n}\n`,
+    )
+    run("npm", ["install", "--ignore-scripts"], consumer)
+    run("npm", ["exec", "--", "tsc", "--noEmit"], consumer)
+    run("node", ["consumer.mjs"], consumer)
+  }
+  console.log(`validated ${basename(tarball)} with OpenTUI 0.4.1 and 0.4.5 consumers`)
+} finally {
+  await rm(temp, { recursive: true, force: true })
+}
+
+function run(command, args, cwd) {
+  const result = spawnSync(command, args, { cwd, encoding: "utf8", stdio: "pipe" })
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(" ")} failed:\n${result.stdout}\n${result.stderr}`)
+  }
+  return result.stdout
+}

--- a/skills/terminal-control/SKILL.md
+++ b/skills/terminal-control/SKILL.md
@@ -101,7 +101,10 @@ transition needs quiet-output settling.
 
 The `show` command takes an option `--format semantic` which returns a semantic tree representing the
 interactable UI elements. This requires direct support from the application to work; once the app is ready
-you can run this and see if it returns anything. If it does not, never try again for that session.
+you can run this and see if it returns anything. An empty tree means no provider was connected at that
+moment. If the application is still starting, wait for visible readiness and retry once; otherwise use
+the visible screen instead. Treat protocol and provider errors as actionable failures rather than retrying
+them blindly.
 The application must be launched with `--host opentui`; the full read command is
 `termctrl show app --format semantic`.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1143,6 +1143,32 @@ fn save(args: SaveArgs) -> Result<()> {
 
 fn show_semantic(args: &ShowArgs) -> Result<()> {
     let source = &args.source;
+    let render = &args.render;
+    if source.recording.is_some()
+        || source.at_marker.is_some()
+        || source.at_ms.is_some()
+        || source.cols.is_some()
+        || source.rows.is_some()
+        || source.pipe
+        || source.input.is_some()
+        || source.color.is_some()
+        || source.settle_ms.is_some()
+        || source.initial_delay_ms.is_some()
+        || source.wait_for.is_some()
+        || source.max_bytes.is_some()
+        || source.cwd.is_some()
+        || source.host.is_some()
+        || !source.send.is_empty()
+        || !source.command.is_empty()
+        || render.cell_width != 9
+        || render.cell_height != 18
+        || render.padding != 18.0
+        || render.font_family != "JetBrains Mono, SFMono-Regular, Menlo, monospace"
+        || render.pixel_ratio != 2.0
+        || render.hide_cursor
+    {
+        bail!("semantic output supports only NAME, --window, --pane, and --deadline-ms");
+    }
     let name = source
         .name
         .as_deref()
@@ -2123,6 +2149,28 @@ mod tests {
 
         assert_eq!(args.source.name.as_deref(), Some("demo"));
         assert_eq!(args.format, ShotFormat::Semantic);
+    }
+
+    #[test]
+    fn semantic_show_rejects_ignored_source_options() {
+        let cli = Cli::try_parse_from([
+            "termctrl",
+            "show",
+            "demo",
+            "--format",
+            "semantic",
+            "--",
+            "ignored-command",
+        ])
+        .unwrap();
+        let Command::Show(args) = cli.command else {
+            panic!("expected show command");
+        };
+
+        assert_eq!(
+            show_semantic(&args).unwrap_err().to_string(),
+            "semantic output supports only NAME, --window, --pane, and --deadline-ms"
+        );
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -15,6 +15,7 @@ mod implementation {
             .unwrap_or_else(|| {
                 PathBuf::from(format!("/tmp/termctrl-{}", unsafe { libc::geteuid() }))
             });
+        require_absolute(&path)?;
         match fs::symlink_metadata(&path) {
             Ok(metadata) => require_private_directory(&path, &metadata)?,
             Err(error) if error.kind() == ErrorKind::NotFound => {
@@ -36,7 +37,7 @@ mod implementation {
         }
         fs::set_permissions(&path, fs::Permissions::from_mode(0o700))
             .with_context(|| format!("secure {}", path.display()))?;
-        Ok(path)
+        fs::canonicalize(&path).with_context(|| format!("resolve {}", path.display()))
     }
 
     pub(crate) fn ensure_socket_path(path: &Path, kind: &str) -> Result<()> {
@@ -63,6 +64,27 @@ mod implementation {
             );
         }
         Ok(())
+    }
+
+    fn require_absolute(path: &Path) -> Result<()> {
+        if !path.is_absolute() {
+            bail!(
+                "TERMCTRL_RUNTIME_DIR must be an absolute path: {}",
+                path.display()
+            );
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn runtime_directory_must_be_absolute() {
+            let error = require_absolute(Path::new("runtime")).unwrap_err();
+            assert!(error.to_string().contains("must be an absolute path"));
+        }
     }
 }
 

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -61,6 +61,7 @@ mod implementation {
         pending: Option<PendingConnection>,
         connection: Option<Connection>,
         failure: Option<String>,
+        recoverable_failure: bool,
     }
 
     struct PendingConnection {
@@ -139,9 +140,16 @@ mod implementation {
     impl Host {
         pub(crate) fn bind() -> Result<Self> {
             let runtime = crate::runtime::directory()?;
+            let nonce = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos() as u64;
             for _ in 0..100 {
                 let id = NEXT_SOCKET_ID.fetch_add(1, Ordering::Relaxed);
-                let path = runtime.join(format!("semantic-{}-{id}.semantic", std::process::id()));
+                let path = runtime.join(format!(
+                    "semantic-{}-{nonce:x}-{id}.semantic",
+                    std::process::id()
+                ));
                 crate::runtime::ensure_socket_path(&path, "application semantic socket")?;
                 let listener = match UnixListener::bind(&path) {
                     Ok(listener) => listener,
@@ -164,6 +172,7 @@ mod implementation {
                     pending: None,
                     connection: None,
                     failure: None,
+                    recoverable_failure: false,
                 });
             }
             bail!("could not allocate a unique application semantic socket")
@@ -187,6 +196,7 @@ mod implementation {
                 if read == 0 {
                     self.connection = None;
                     self.failure = Some("application semantic provider disconnected".to_owned());
+                    self.recoverable_failure = true;
                 } else if read > 0 {
                     return;
                 } else {
@@ -196,6 +206,7 @@ mod implementation {
                     }
                     self.connection = None;
                     self.failure = Some(format!("inspect application semantic provider: {error}"));
+                    self.recoverable_failure = true;
                 }
             }
             loop {
@@ -205,6 +216,7 @@ mod implementation {
                             self.failure = Some(format!(
                                 "configure application semantic connection: {error}"
                             ));
+                            self.recoverable_failure = false;
                             return;
                         }
                         self.pending = Some(PendingConnection {
@@ -217,6 +229,7 @@ mod implementation {
                     Err(error) => {
                         self.failure =
                             Some(format!("accept application semantic connection: {error}"));
+                        self.recoverable_failure = false;
                         return;
                     }
                 }
@@ -234,16 +247,19 @@ mod implementation {
                         "application disconnected before completing the semantic handshake"
                             .to_owned(),
                     );
+                    self.recoverable_failure = false;
                 }
                 Ok(HandshakeRead::Hello(hello)) => {
                     if let Err(error) = self.finish_handshake(hello) {
                         self.pending = None;
                         self.failure = Some(format!("{error:#}"));
+                        self.recoverable_failure = false;
                     }
                 }
                 Err(error) => {
                     self.pending = None;
                     self.failure = Some(format!("{error:#}"));
+                    self.recoverable_failure = false;
                 }
             }
         }
@@ -258,11 +274,25 @@ mod implementation {
             }
             self.pump();
             if !self.is_ready() && self.pending.is_none() {
-                return Ok(None);
+                if !self.recoverable_failure
+                    && let Some(failure) = self.failure()
+                {
+                    bail!("application semantic provider is unavailable: {failure}");
+                }
+                if self.failure().is_none() {
+                    return Ok(None);
+                }
             }
             let deadline = Instant::now() + timeout;
             loop {
                 self.pump();
+                if !self.is_ready()
+                    && self.pending.is_none()
+                    && !self.recoverable_failure
+                    && let Some(failure) = self.failure()
+                {
+                    bail!("application semantic provider is unavailable: {failure}");
+                }
                 if pump_session()? {
                     bail!("session ended before its application semantic provider became ready");
                 }
@@ -357,6 +387,7 @@ mod implementation {
             let result = start_snapshot(connection, id, deadline);
             if let Err(error) = &result {
                 self.failure = Some(error.to_string());
+                self.recoverable_failure = true;
                 self.connection = None;
             }
             result
@@ -370,6 +401,7 @@ mod implementation {
             let result = poll_snapshot(connection, id, deadline);
             if let Err(error) = &result {
                 self.failure = Some(error.to_string());
+                self.recoverable_failure = true;
                 self.connection = None;
             }
             result
@@ -377,6 +409,7 @@ mod implementation {
 
         fn abort_snapshot(&mut self, message: &str) {
             self.failure = Some(message.to_owned());
+            self.recoverable_failure = true;
             self.pending = None;
             self.connection = None;
         }
@@ -427,6 +460,7 @@ mod implementation {
                 pending_id: None,
             });
             self.failure = None;
+            self.recoverable_failure = false;
             Ok(())
         }
     }
@@ -930,6 +964,36 @@ mod implementation {
         }
 
         #[test]
+        fn invalid_provider_handshakes_remain_observable() {
+            let mut socket = Host::bind().unwrap();
+            let path = socket.path().unwrap().to_owned();
+            let application = thread::spawn(move || {
+                let mut stream = UnixStream::connect(path).unwrap();
+                write_json_line(
+                    &mut stream,
+                    &serde_json::json!({
+                        "type": "hello",
+                        "protocolVersion": 2,
+                        "application": { "name": "fixture" },
+                        "capabilities": ["semantic.snapshot"]
+                    }),
+                )
+                .unwrap();
+            });
+            application.join().unwrap();
+
+            let error = socket
+                .snapshot(Duration::from_secs(1), || Ok(false))
+                .unwrap_err();
+
+            assert!(
+                error
+                    .to_string()
+                    .contains("unsupported application semantic protocol")
+            );
+        }
+
+        #[test]
         fn newer_provider_replaces_an_incomplete_handshake() {
             let mut socket = Host::bind().unwrap();
             let path = socket.path().unwrap().to_owned();
@@ -986,6 +1050,56 @@ mod implementation {
             let second = connect_provider(path, "second");
             wait_until_ready(&mut socket);
             assert!(socket.is_ready());
+            second.join().unwrap();
+        }
+
+        #[test]
+        fn snapshot_waits_for_an_established_provider_to_reconnect() {
+            let mut socket = Host::bind().unwrap();
+            let path = socket.path().unwrap().to_owned();
+            let first = connect_provider(path.clone(), "first");
+            wait_until_ready(&mut socket);
+            first.join().unwrap();
+            while socket.is_ready() {
+                socket.pump();
+                thread::sleep(Duration::from_millis(1));
+            }
+            let second = thread::spawn(move || {
+                thread::sleep(Duration::from_millis(50));
+                let mut stream = UnixStream::connect(path).unwrap();
+                write_json_line(
+                    &mut stream,
+                    &serde_json::json!({
+                        "type": "hello",
+                        "protocolVersion": 1,
+                        "application": { "name": "second" },
+                        "capabilities": ["semantic.snapshot"]
+                    }),
+                )
+                .unwrap();
+                let mut stream = BufReader::new(stream);
+                let mut line = String::new();
+                stream.read_line(&mut line).unwrap();
+                line.clear();
+                stream.read_line(&mut line).unwrap();
+                let request = serde_json::from_str::<Value>(&line).unwrap();
+                write_json_line(
+                    stream.get_mut(),
+                    &serde_json::json!({
+                        "type": "result",
+                        "id": request["id"],
+                        "value": { "reconnected": true }
+                    }),
+                )
+                .unwrap();
+            });
+
+            let snapshot = socket
+                .snapshot(Duration::from_secs(1), || Ok(false))
+                .unwrap()
+                .unwrap();
+
+            assert_eq!(snapshot["reconnected"], true);
             second.join().unwrap();
         }
 

--- a/src/shot.rs
+++ b/src/shot.rs
@@ -372,6 +372,9 @@ pub(crate) fn configure_pty_environment(builder: &mut CommandBuilder, options: &
     for (key, value) in &options.env {
         builder.env(key, value);
     }
+    // This endpoint belongs to the immediate Terminal Control host and must never leak
+    // into nested or non-hosted launches. Hosted call sites set their fresh path later.
+    builder.env_remove(semantic::SOCKET_ENV);
 }
 
 fn configure_process_environment(builder: &mut ProcessCommand, options: &Options) {
@@ -396,6 +399,7 @@ fn configure_process_environment(builder: &mut ProcessCommand, options: &Options
         }
     }
     builder.envs(&options.env);
+    builder.env_remove(semantic::SOCKET_ENV);
 }
 
 pub(crate) fn validate_geometry(rows: u16, cols: u16) -> Result<()> {
@@ -852,6 +856,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn only_opentui_host_commands_receive_the_application_semantic_socket() {
+        let inherited_socket = "/tmp/outer-termctrl-semantic.sock";
         let command = [
             "sh".to_owned(),
             "-c".to_owned(),
@@ -867,6 +872,10 @@ mod tests {
             &Options {
                 settle: Duration::from_millis(10),
                 deadline: Duration::from_secs(2),
+                env: BTreeMap::from([(
+                    semantic::SOCKET_ENV.to_owned(),
+                    inherited_socket.to_owned(),
+                )]),
                 ..Options::default()
             },
         )
@@ -876,6 +885,10 @@ mod tests {
             None,
             &Options {
                 deadline: Duration::from_secs(2),
+                env: BTreeMap::from([(
+                    semantic::SOCKET_ENV.to_owned(),
+                    inherited_socket.to_owned(),
+                )]),
                 ..Options::default()
             },
         )
@@ -887,6 +900,10 @@ mod tests {
                 settle: Duration::from_millis(10),
                 deadline: Duration::from_secs(2),
                 opentui_host: true,
+                env: BTreeMap::from([(
+                    semantic::SOCKET_ENV.to_owned(),
+                    inherited_socket.to_owned(),
+                )]),
                 ..Options::default()
             },
         )
@@ -897,6 +914,10 @@ mod tests {
             &Options {
                 deadline: Duration::from_secs(2),
                 opentui_host: true,
+                env: BTreeMap::from([(
+                    semantic::SOCKET_ENV.to_owned(),
+                    inherited_socket.to_owned(),
+                )]),
                 ..Options::default()
             },
         )


### PR DESCRIPTION
## What

Close the release-gate findings from the OpenTUI semantic snapshot review and make the adapter's npm artifact part of the same validated, aligned package set as Terminal Control.

## Before / After

**Before:** A nested plain launch could inherit its parent's semantic socket and register against the wrong session. Invalid providers could look like a valid empty snapshot, provider timeouts permanently disconnected the official adapter, hidden or clipped OpenTUI controls leaked into snapshots, and an unversioned adapter could be rebuilt separately during publishing.

**After:** Semantic endpoints are scoped to the immediate hosted child, terminal provider failures remain observable while recoverable disconnects wait for bounded reconnects, the adapter retries established connections, semantic nodes reflect effective visibility and clipped geometry with unique IDs, and CI validates and publishes one exact aligned tarball set.

## How

- Reserve and scrub `TERMCTRL_SEMANTIC_SOCKET` before child launch, then set only a freshly allocated hosted endpoint.
- Distinguish terminal handshake failures from recoverable established-provider disconnects and wait within the caller's existing deadline.
- Retry adapter reconnects with bounded backoff and cover both normal reconnect and a failed first retry.
- Filter OpenTUI elements and labels by effective ancestor visibility and clipping, emit clipped geometry, and guarantee unique semantic IDs.
- Require absolute runtime directories and add collision-resistant semantic socket names.
- Reject ignored semantic CLI source/rendering options and refuse unaligned adapter publishes.
- Pack, clean-install, and validate the adapter against OpenTUI 0.4.1 and 0.4.5 before publishing that same tarball.
- Document the application semantic protocol and first-release npm/OIDC bootstrap.

## Scope

This does not add semantic snapshots to the MCP or TypeScript test-client APIs. It keeps the existing CLI, embedded Rust, and application socket surfaces from the merged feature.

## Testing

- `bun install --frozen-lockfile`
- `cargo fmt --all -- --check`
- `cargo test --all-targets` (151 passed, 1 ignored; 18 CLI tests passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release`
- `bun run test:npm` (12 client tests; 7 adapter tests)
- `bun run build:npm`
- `bun run validate:npm`
- `node scripts/validate-opentui-package.mjs target/opentui-review-artifacts`
- `cargo package --list`
- `cargo package`
- `cargo publish --dry-run --locked`
- Manual inherited-socket and relative-runtime-path reproductions

## Flow

```mermaid
sequenceDiagram
    participant App as OpenTUI application
    participant Host as Terminal Control host
    participant CLI as termctrl show
    participant CI as npm release workflow
    participant npm as npm registry

    Host->>App: fresh TERMCTRL_SEMANTIC_SOCKET
    App->>Host: hello protocol v1
    Host-->>App: ready
    CLI->>Host: semantic snapshot with deadline
    Host->>App: semantic.snapshot
    App-->>Host: visible semantic nodes
    Host-->>CLI: snapshot JSON
    CI->>CI: pack and clean-install aligned tarballs
    CI->>npm: publish the validated artifacts
```
