### PR TITLE
chore: release terminal-control 0.6.0

### DIFF
--- a/.changeset/semantic-snapshot.md
+++ b/.changeset/semantic-snapshot.md
@@ -1,6 +1,0 @@
----
-"@kitlangton/terminal-control": minor
-"@kitlangton/terminal-control-opentui": minor
----
-
-Create a private application semantic socket for commands launched with the OpenTUI host profile and add `show --format semantic` for optional application-provided UI snapshots.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "terminal-control"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminal-control"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.93"
 description = "Control and test terminal applications through stable visible state"

--- a/bun.lock
+++ b/bun.lock
@@ -10,35 +10,35 @@
     },
     "packages/darwin-arm64": {
       "name": "@kitlangton/terminal-control-darwin-arm64",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "bin": {
         "termctrl": "bin/termctrl",
       },
     },
     "packages/darwin-x64": {
       "name": "@kitlangton/terminal-control-darwin-x64",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "bin": {
         "termctrl": "bin/termctrl",
       },
     },
     "packages/linux-arm64-gnu": {
       "name": "@kitlangton/terminal-control-linux-arm64-gnu",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "bin": {
         "termctrl": "bin/termctrl",
       },
     },
     "packages/linux-x64-gnu": {
       "name": "@kitlangton/terminal-control-linux-x64-gnu",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "bin": {
         "termctrl": "bin/termctrl",
       },
     },
     "packages/opentui": {
       "name": "@kitlangton/terminal-control-opentui",
-      "version": "0.0.0",
+      "version": "0.6.0",
       "devDependencies": {
         "@opentui/core": "^0.4.5",
         "@types/bun": "^1.3.0",
@@ -51,7 +51,7 @@
     },
     "packages/test": {
       "name": "@kitlangton/terminal-control",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "devDependencies": {
         "@types/bun": "^1.3.0",
         "@types/node": "^24.0.0",
@@ -59,10 +59,10 @@
         "vitest": "^3.2.4",
       },
       "optionalDependencies": {
-        "@kitlangton/terminal-control-darwin-arm64": "0.5.0",
-        "@kitlangton/terminal-control-darwin-x64": "0.5.0",
-        "@kitlangton/terminal-control-linux-arm64-gnu": "0.5.0",
-        "@kitlangton/terminal-control-linux-x64-gnu": "0.5.0",
+        "@kitlangton/terminal-control-darwin-arm64": "0.6.0",
+        "@kitlangton/terminal-control-darwin-x64": "0.6.0",
+        "@kitlangton/terminal-control-linux-arm64-gnu": "0.6.0",
+        "@kitlangton/terminal-control-linux-x64-gnu": "0.6.0",
       },
       "peerDependencies": {
         "vitest": ">=3.0.0",

--- a/packages/darwin-arm64/CHANGELOG.md
+++ b/packages/darwin-arm64/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @kitlangton/terminal-control-darwin-arm64
 
+## 0.6.0
+
 ## 0.5.0
 
 ## 0.4.1

--- a/packages/darwin-arm64/package.json
+++ b/packages/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control-darwin-arm64",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Native termctrl binary for Terminal Control on macOS arm64",
   "license": "MIT",
   "repository": "https://github.com/anomalyco/terminal-control",

--- a/packages/darwin-x64/CHANGELOG.md
+++ b/packages/darwin-x64/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @kitlangton/terminal-control-darwin-x64
 
+## 0.6.0
+
 ## 0.5.0
 
 ## 0.4.1

--- a/packages/darwin-x64/package.json
+++ b/packages/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control-darwin-x64",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Native termctrl binary for Terminal Control on macOS x64",
   "license": "MIT",
   "repository": "https://github.com/anomalyco/terminal-control",

--- a/packages/linux-arm64-gnu/CHANGELOG.md
+++ b/packages/linux-arm64-gnu/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @kitlangton/terminal-control-linux-arm64-gnu
 
+## 0.6.0
+
 ## 0.5.0
 
 ## 0.4.1

--- a/packages/linux-arm64-gnu/package.json
+++ b/packages/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control-linux-arm64-gnu",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Native termctrl binary for Terminal Control on Linux arm64 GNU",
   "license": "MIT",
   "repository": "https://github.com/anomalyco/terminal-control",

--- a/packages/linux-x64-gnu/CHANGELOG.md
+++ b/packages/linux-x64-gnu/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @kitlangton/terminal-control-linux-x64-gnu
 
+## 0.6.0
+
 ## 0.5.0
 
 ## 0.4.1

--- a/packages/linux-x64-gnu/package.json
+++ b/packages/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control-linux-x64-gnu",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Native termctrl binary for Terminal Control on Linux x64 GNU",
   "license": "MIT",
   "repository": "https://github.com/anomalyco/terminal-control",

--- a/packages/opentui/CHANGELOG.md
+++ b/packages/opentui/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @kitlangton/terminal-control-opentui
+
+## 0.6.0
+
+### Minor Changes
+
+- 5a0a277: Create a private application semantic socket for commands launched with the OpenTUI host profile and add `show --format semantic` for optional application-provided UI snapshots.

--- a/packages/opentui/package.json
+++ b/packages/opentui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control-opentui",
-  "version": "0.0.0",
+  "version": "0.6.0",
   "description": "Expose consistent OpenTUI semantic snapshots through Terminal Control",
   "license": "MIT",
   "repository": {

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @kitlangton/terminal-control
 
+## 0.6.0
+
+### Minor Changes
+
+- 5a0a277: Create a private application semantic socket for commands launched with the OpenTUI host profile and add `show --format semantic` for optional application-provided UI snapshots.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Typed terminal application control and testing with snapshots, recordings, and failure artifacts",
   "license": "MIT",
   "repository": {
@@ -38,10 +38,10 @@
     "prepack": "bun run build"
   },
   "optionalDependencies": {
-    "@kitlangton/terminal-control-darwin-arm64": "0.5.0",
-    "@kitlangton/terminal-control-darwin-x64": "0.5.0",
-    "@kitlangton/terminal-control-linux-arm64-gnu": "0.5.0",
-    "@kitlangton/terminal-control-linux-x64-gnu": "0.5.0"
+    "@kitlangton/terminal-control-darwin-arm64": "0.6.0",
+    "@kitlangton/terminal-control-darwin-x64": "0.6.0",
+    "@kitlangton/terminal-control-linux-arm64-gnu": "0.6.0",
+    "@kitlangton/terminal-control-linux-x64-gnu": "0.6.0"
   },
   "peerDependencies": {
     "vitest": ">=3.0.0"


### PR DESCRIPTION
## What

Prepare Terminal Control `0.6.0`, including OpenTUI semantic snapshots and the first `@kitlangton/terminal-control-opentui` release.

## How

- Consume the semantic snapshot Changeset.
- Align the Rust crate, TypeScript client, OpenTUI adapter, four native packages, and lockfile workspace metadata at `0.6.0`.
- Update all npm changelogs and native optional dependency versions.

## Scope

This PR contains release metadata only. The implementation and release hardening landed in #10 and #13.

## Testing

- `bun install --frozen-lockfile`
- `cargo fmt --all -- --check`
- `cargo test --all-targets` (151 passed, 1 ignored; 18 CLI tests passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release`
- `bun run test:npm` (12 client tests; 9 adapter tests)
- `bun run build:npm`
- `bun run validate:npm`
- `bun run --cwd packages/opentui release:check`
- Clean adapter consumers against OpenTUI 0.4.1 and 0.4.5
- `cargo package --list`
- `cargo package`
- `cargo publish --dry-run --locked`
- Verified `target/release/termctrl --version` reports `0.6.0`

## Flow

```mermaid
flowchart LR
    Changeset[Semantic snapshot changeset] --> Version[Aligned 0.6.0 manifests]
    Version --> CI[Release validation]
    CI --> Crates[crates.io artifact]
    CI --> Npm[Aligned npm tarball set]
```
