### PR TITLE
fix: distinguish OpenTUI release artifact

### DIFF
--- a/scripts/validate-npm-packages.mjs
+++ b/scripts/validate-npm-packages.mjs
@@ -82,8 +82,10 @@ function required(files, prefix) {
 
 function requiredClient(files) {
   const nativePrefixes = nativePackages.map(({ target }) => `kitlangton-terminal-control-${target}-`)
+  const opentuiPrefix = "kitlangton-terminal-control-opentui-"
   const matches = files.filter((file) => file.startsWith("kitlangton-terminal-control-")
     && file.endsWith(".tgz")
+    && !file.startsWith(opentuiPrefix)
     && !nativePrefixes.some((prefix) => file.startsWith(prefix)))
   if (matches.length !== 1) throw new Error(`expected one Terminal Control client tarball, found ${matches.length}`)
   return matches[0]


### PR DESCRIPTION
## What

Fix the `0.6.0` npm artifact matrix validation after adding the OpenTUI adapter tarball.

## Before / After

**Before:** `requiredClient()` treated both `kitlangton-terminal-control-0.6.0.tgz` and `kitlangton-terminal-control-opentui-0.6.0.tgz` as client artifacts, so every platform validation failed with `expected one Terminal Control client tarball, found 2` after the complete aligned package-set check had passed.

**After:** The OpenTUI adapter prefix is excluded alongside native package prefixes, leaving exactly one TypeScript client tarball for clean-consumer validation.

## Testing

- Replayed `validate-npm-packages.mjs --tarballs` against the client, adapter, and darwin-arm64 artifacts downloaded from failed run `29937747164`.
- `bun run validate:npm`
- `git diff --check`

No packages were published by the failed workflow.
