### PR TITLE
fix: support Windows TUI control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,6 +341,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doctest-file"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,6 +591,19 @@ dependencies = [
  "proc-macro2-diagnostics",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "interprocess"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "798de1433ba514cc6c04c4144c2469af81396e4906195218737c776d47769572"
+dependencies = [
+ "doctest-file",
+ "libc",
+ "recvmsg",
+ "widestring",
+ "windows-sys",
 ]
 
 [[package]]
@@ -867,6 +886,12 @@ checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
@@ -1257,6 +1282,7 @@ dependencies = [
  "anyhow",
  "clap",
  "crossterm",
+ "interprocess",
  "libc",
  "libghostty-vt",
  "portable-pty",
@@ -1561,6 +1587,12 @@ checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,6 @@ tokio = { version = "1.49", features = ["macros", "rt-multi-thread"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+interprocess = "2.4.3"

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ See [docs/typescript-client.md](docs/typescript-client.md) for artifacts, record
 
 ## Notes
 
-- Persistent sessions use owner-only local Unix sockets and are supported on macOS and Linux.
+- Persistent sessions use owner-only Unix sockets on macOS/Linux and Windows named pipes on Windows.
 - `--host opentui` provides `TERMCTRL_SEMANTIC_SOCKET` and answers startup probes needed by current OpenTUI applications.
 - Terminal state and reflow use the statically linked Ghostty terminal core; renderers export PNG, SVG, JSON, text, and raw ANSI artifacts.
 - Run `termctrl <command> --help` for dimensions, timing, color, rendering, and output options.

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,8 +54,8 @@ Examples:
 const START_HELP: &str = "\
 Start creates one background PTY session and returns once its local control socket is available.
 The application stays alive until `termctrl stop NAME`, so later commands interact with the
-same screen and application state. Persistent sessions currently require macOS or Linux. Session
-sockets are local control endpoints protected for the current user; recordings contain terminal
+same screen and application state. Persistent sessions use Unix sockets on macOS/Linux and named
+pipes on Windows. Session endpoints are local control endpoints protected for the current user; recordings contain terminal
 output plus client and automatic host input, so treat them as sensitive artifacts.
 
 Example:

--- a/src/session.rs
+++ b/src/session.rs
@@ -3546,14 +3546,396 @@ mod implementation {
     }
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
 mod implementation {
-    use super::{NamedSessionStatus, Options, PruneKind, Request, Response, TabPosition};
-    use anyhow::{Result, bail};
+    use std::fs;
+    use std::io::{ErrorKind, Read, Write};
     use std::path::{Path, PathBuf};
+    use std::process::{Command, Stdio};
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    use anyhow::{Context, Result, bail};
+    use interprocess::ConnectWaitMode;
+    use interprocess::local_socket::{
+        ConnectOptions, GenericNamespaced, ListenerNonblockingMode, ListenerOptions, ToNsName,
+        prelude::{LocalSocketListener, LocalSocketStream},
+        traits::Listener,
+    };
+
+    use super::{
+        NamedSessionStatus, Options, PruneKind, Request, Response, Session, SessionState,
+        TabPosition, UnavailableReason,
+    };
+    use crate::shot;
+
+    const CONTROL_TIMEOUT: Duration = Duration::from_secs(2);
+    const MAX_REQUEST_BYTES: u64 = 1024 * 1024;
+    const MAX_RESPONSE_BYTES: u64 = 64 * 1024 * 1024;
+
+    fn marker_path(name: &str) -> Result<PathBuf> {
+        Ok(runtime_dir()?.join(format!("{name}.sock")))
+    }
+
+    fn pipe_name(path: &Path) -> Result<interprocess::local_socket::Name<'static>> {
+        let name = path
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("invalid Windows session endpoint {}", path.display()))?
+            .to_owned();
+        Ok(name.to_ns_name::<GenericNamespaced>()?.into_owned())
+    }
+
+    fn stream(path: &Path) -> Result<LocalSocketStream> {
+        let name = pipe_name(path)?;
+        ConnectOptions::new()
+            .name(name)
+            .wait_mode(ConnectWaitMode::Timeout(CONTROL_TIMEOUT))
+            .connect_sync()
+            .context("connect to Windows named pipe")
+    }
+
+    fn listener(path: &Path) -> Result<LocalSocketListener> {
+        let name = pipe_name(path)?;
+        ListenerOptions::new()
+            .name(name)
+            .nonblocking(ListenerNonblockingMode::Accept)
+            .create_sync()
+            .context("create Windows named-pipe listener")
+    }
 
     pub fn runtime_dir() -> Result<PathBuf> {
-        bail!("persistent sessions require Unix sockets")
+        let path = std::env::var_os("TERMCTRL_RUNTIME_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| std::env::temp_dir().join("termctrl"));
+        if !path.is_absolute() {
+            bail!(
+                "TERMCTRL_RUNTIME_DIR must be an absolute path: {}",
+                path.display()
+            );
+        }
+        fs::create_dir_all(&path).with_context(|| {
+            format!(
+                "create Windows session runtime directory {}",
+                path.display()
+            )
+        })?;
+        Ok(path)
+    }
+
+    pub fn start(
+        name: &str,
+        command: &[String],
+        cwd: Option<&Path>,
+        record: Option<&Path>,
+        options: &Options,
+    ) -> Result<()> {
+        if command.is_empty() {
+            bail!("provide a command after --");
+        }
+        let socket = marker_path(name)?;
+        if socket.exists() && request(socket.clone(), &Request::Ping).is_ok() {
+            bail!("session {name:?} is already running");
+        }
+        let _ = fs::remove_file(&socket);
+        let mut daemon =
+            Command::new(std::env::current_exe().context("locate termctrl executable")?);
+        daemon
+            .arg("__serve")
+            .arg("--name")
+            .arg(name)
+            .arg("--socket")
+            .arg(&socket)
+            .arg("--cols")
+            .arg(options.cols.to_string())
+            .arg("--rows")
+            .arg(options.rows.to_string())
+            .arg("--cell-width")
+            .arg(options.cell_width.to_string())
+            .arg("--cell-height")
+            .arg(options.cell_height.to_string())
+            .arg("--max-bytes")
+            .arg(options.max_bytes.to_string());
+        if options.opentui_host {
+            daemon.arg("--opentui-host");
+        }
+        match options.color {
+            shot::ColorMode::Auto => {}
+            shot::ColorMode::Always => {
+                daemon.arg("--color").arg("always");
+            }
+            shot::ColorMode::Never => {
+                daemon.arg("--color").arg("never");
+            }
+        }
+        if let Some(cwd) = cwd {
+            daemon.arg("--cwd").arg(cwd);
+        }
+        if let Some(record) = record {
+            daemon.arg("--record").arg(record);
+        }
+        daemon
+            .arg("--")
+            .args(command)
+            .env_remove("TERMCTRL_WORKSPACE")
+            .env_remove("TERMCTRL_PANE_ID")
+            .env_remove("TERMCTRL_LAUNCH_WINDOW_ID")
+            .env("TERMCTRL_SESSION", name)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let mut daemon = daemon.spawn().context("start Windows session daemon")?;
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if request(socket.clone(), &Request::Ping).is_ok() {
+                return Ok(());
+            }
+            if let Some(status) = daemon.try_wait().context("poll Windows session daemon")? {
+                bail!("session daemon exited before becoming ready: {status}");
+            }
+            if Instant::now() >= deadline {
+                let _ = daemon.kill();
+                bail!("timed out starting session {name:?}");
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+    }
+
+    pub fn restart(
+        name: &str,
+        command: &[String],
+        cwd: Option<&Path>,
+        record: Option<&Path>,
+        options: &Options,
+    ) -> Result<()> {
+        let socket = marker_path(name)?;
+        if request(socket.clone(), &Request::Stop).is_ok() {
+            let deadline = Instant::now() + Duration::from_secs(2);
+            while request(socket.clone(), &Request::Ping).is_ok() && Instant::now() < deadline {
+                thread::sleep(Duration::from_millis(20));
+            }
+        }
+        start(name, command, cwd, record, options)
+    }
+
+    pub fn request(socket: PathBuf, request: &Request) -> Result<Response> {
+        let mut stream = stream(&socket).with_context(|| {
+            format!("connect to session at {}; is it running?", socket.display())
+        })?;
+        let request_bytes = serde_json::to_vec(request).context("encode session request")?;
+        if request_bytes.len() as u64 > MAX_REQUEST_BYTES {
+            bail!("session request exceeds 1 MiB");
+        }
+        stream
+            .write_all(&request_bytes)
+            .context("write session request")?;
+        stream.write_all(b"\n").context("finish session request")?;
+        stream.flush().context("flush session request")?;
+        let mut bytes = Vec::new();
+        stream
+            .take(MAX_RESPONSE_BYTES + 1)
+            .read_to_end(&mut bytes)
+            .context("read session response")?;
+        serde_json::from_slice(&bytes).context("decode session response")
+    }
+
+    pub fn request_layout_command(_: &str, operation: &Request) -> Result<Response> {
+        if operation.requirements().hold_name_lock {
+            bail!("workspace layout commands are not supported on Windows yet");
+        }
+        unreachable!()
+    }
+
+    pub fn serve(
+        name: String,
+        socket: PathBuf,
+        command: Vec<String>,
+        cwd: Option<PathBuf>,
+        record: Option<PathBuf>,
+        mut options: Options,
+    ) -> Result<()> {
+        if command.is_empty() {
+            bail!("provide a command after --");
+        }
+        options.env.insert("TERMCTRL_SESSION".to_owned(), name);
+        let listener = listener(&socket)?;
+        fs::write(&socket, b"named-pipe")?;
+        let mut session = Session::start(&command, cwd.as_deref(), record.as_deref(), &options)?;
+        let result = run(&listener, &mut session);
+        let _ = session.stop();
+        let _ = fs::remove_file(&socket);
+        result
+    }
+
+    fn run(listener: &LocalSocketListener, session: &mut Session) -> Result<()> {
+        loop {
+            session.consume_batch()?;
+            match listener.accept() {
+                Ok(mut stream) => {
+                    let stopped = handle(&mut stream, session)?;
+                    if stopped {
+                        return Ok(());
+                    }
+                }
+                Err(error) if error.kind() == ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(10))
+                }
+                Err(error) => return Err(error).context("accept Windows session request"),
+            }
+        }
+    }
+
+    fn handle(stream: &mut LocalSocketStream, session: &mut Session) -> Result<bool> {
+        let mut bytes = Vec::new();
+        let mut chunk = [0_u8; 4096];
+        loop {
+            let length = stream.read(&mut chunk)?;
+            if length == 0 {
+                break;
+            }
+            bytes.extend_from_slice(&chunk[..length]);
+            if bytes.contains(&b'\n') {
+                break;
+            }
+            if bytes.len() as u64 > MAX_REQUEST_BYTES {
+                bail!("session request exceeds 1 MiB");
+            }
+        }
+        let request = serde_json::from_slice::<Request>(
+            bytes
+                .split(|byte| *byte == b'\n')
+                .next()
+                .unwrap_or_default(),
+        )?;
+        let stop = matches!(request, Request::Stop);
+        let response =
+            respond(session, request).unwrap_or_else(|error| Response::error(format!("{error:#}")));
+        serde_json::to_writer(&mut *stream, &response)?;
+        stream.flush()?;
+        Ok(stop)
+    }
+
+    fn respond(session: &mut Session, request: Request) -> Result<Response> {
+        let mut response = Response::default();
+        match request {
+            Request::Ping => {}
+            Request::Status => response.status = Some(session.status()?),
+            Request::Send {
+                input,
+                pace_ms,
+                pane,
+            } => {
+                if pane.is_some_and(|pane| pane != 0) {
+                    bail!("single sessions only contain pane 0");
+                }
+                session.send_all(&input, Duration::from_millis(pace_ms))?;
+            }
+            Request::Wait {
+                text,
+                timeout_ms,
+                pane,
+            } => {
+                if pane.is_some_and(|pane| pane != 0) {
+                    bail!("single sessions only contain pane 0");
+                }
+                session.wait_for_text(&text, Duration::from_millis(timeout_ms))?;
+            }
+            Request::Show {
+                settle_ms,
+                deadline_ms,
+                pane,
+            } => {
+                if pane.is_some_and(|pane| pane != 0) {
+                    bail!("single sessions only contain pane 0");
+                }
+                response.captured = Some(
+                    session
+                        .capture(
+                            Duration::from_millis(settle_ms),
+                            Duration::from_millis(deadline_ms),
+                        )?
+                        .shot,
+                );
+                response.status = Some(session.status()?);
+            }
+            Request::Logs { ansi } => response.logs = Some(session.logs(ansi)?),
+            Request::Resize {
+                cols,
+                rows,
+                cell_width,
+                cell_height,
+            } => session.resize(
+                cols,
+                rows,
+                cell_width.unwrap_or(9),
+                cell_height.unwrap_or(18),
+            )?,
+            Request::Stop => {}
+            _ => bail!("this session operation is not supported on Windows single sessions"),
+        }
+        Ok(response)
+    }
+
+    pub fn list() -> Result<Vec<NamedSessionStatus>> {
+        let mut sessions = Vec::new();
+        for entry in fs::read_dir(runtime_dir()?)? {
+            let path = entry?.path();
+            if path.extension().and_then(|x| x.to_str()) != Some("sock") {
+                continue;
+            }
+            let Some(name) = path.file_stem().and_then(|x| x.to_str()).map(str::to_owned) else {
+                continue;
+            };
+            match request(path, &Request::Status) {
+                Ok(response) => sessions.push(NamedSessionStatus {
+                    name,
+                    status: response.status,
+                    error: response.error,
+                    unavailable: None,
+                }),
+                Err(error) => sessions.push(NamedSessionStatus {
+                    name,
+                    status: None,
+                    error: Some(format!("{error:#}")),
+                    unavailable: Some(UnavailableReason::Stale),
+                }),
+            }
+        }
+        sessions.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(sessions)
+    }
+
+    pub fn prune(name: &str, dry_run: bool) -> Result<Option<PruneKind>> {
+        let socket = marker_path(name)?;
+        if !socket.exists() {
+            return Ok(None);
+        }
+        match request(socket.clone(), &Request::Status) {
+            Ok(response)
+                if response
+                    .status
+                    .as_ref()
+                    .is_some_and(|status| status.state == SessionState::Exited) =>
+            {
+                if !dry_run {
+                    let _ = request(socket.clone(), &Request::Stop);
+                    let _ = fs::remove_file(socket);
+                }
+                Ok(Some(PruneKind::Exited))
+            }
+            Err(_) => {
+                if !dry_run {
+                    fs::remove_file(socket)?;
+                }
+                Ok(Some(PruneKind::Stale))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    pub fn attach(_: PathBuf, _: &str, _: &Options) -> Result<()> {
+        bail!("workspace attachment is not supported on Windows yet")
     }
     pub fn serve_workspace(
         _: String,
@@ -3564,51 +3946,7 @@ mod implementation {
         _: Options,
         _: TabPosition,
     ) -> Result<()> {
-        bail!("persistent workspaces require Unix sockets")
-    }
-    pub fn start(
-        _: &str,
-        _: &[String],
-        _: Option<&Path>,
-        _: Option<&Path>,
-        _: &Options,
-    ) -> Result<()> {
-        bail!("persistent sessions require Unix sockets")
-    }
-    pub fn restart(
-        _: &str,
-        _: &[String],
-        _: Option<&Path>,
-        _: Option<&Path>,
-        _: &Options,
-    ) -> Result<()> {
-        bail!("persistent sessions require Unix sockets")
-    }
-    pub fn request(_: PathBuf, _: &Request) -> Result<Response> {
-        bail!("persistent sessions require Unix sockets")
-    }
-    pub fn request_layout_command(_: &str, _: &Request) -> Result<Response> {
-        bail!("persistent sessions require Unix sockets")
-    }
-
-    pub fn attach(_: PathBuf, _: &str, _: &Options) -> Result<()> {
-        bail!("workspace attachment requires Unix sockets")
-    }
-    pub fn list() -> Result<Vec<NamedSessionStatus>> {
-        bail!("persistent sessions require Unix sockets")
-    }
-    pub fn prune(_: &str, _: bool) -> Result<Option<PruneKind>> {
-        bail!("persistent sessions require Unix sockets")
-    }
-    pub fn serve(
-        _: String,
-        _: PathBuf,
-        _: Vec<String>,
-        _: Option<PathBuf>,
-        _: Option<PathBuf>,
-        _: Options,
-    ) -> Result<()> {
-        bail!("persistent sessions require Unix sockets")
+        bail!("persistent workspaces are not supported on Windows yet")
     }
     pub fn run_foreground(
         _: &str,
@@ -3618,7 +3956,81 @@ mod implementation {
         _: &Options,
         _: TabPosition,
     ) -> Result<()> {
-        bail!("persistent sessions require Unix sockets")
+        bail!("workspace attachment is not supported on Windows yet")
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+mod implementation {
+    use super::{NamedSessionStatus, Options, PruneKind, Request, Response, TabPosition};
+    use anyhow::{Result, bail};
+    use std::path::{Path, PathBuf};
+    pub fn runtime_dir() -> Result<PathBuf> {
+        bail!("persistent sessions require a local IPC transport")
+    }
+    pub fn serve_workspace(
+        _: String,
+        _: PathBuf,
+        _: Vec<String>,
+        _: Option<PathBuf>,
+        _: Option<PathBuf>,
+        _: Options,
+        _: TabPosition,
+    ) -> Result<()> {
+        bail!("persistent workspaces require a local IPC transport")
+    }
+    pub fn start(
+        _: &str,
+        _: &[String],
+        _: Option<&Path>,
+        _: Option<&Path>,
+        _: &Options,
+    ) -> Result<()> {
+        bail!("persistent sessions require a local IPC transport")
+    }
+    pub fn restart(
+        _: &str,
+        _: &[String],
+        _: Option<&Path>,
+        _: Option<&Path>,
+        _: &Options,
+    ) -> Result<()> {
+        bail!("persistent sessions require a local IPC transport")
+    }
+    pub fn request(_: PathBuf, _: &Request) -> Result<Response> {
+        bail!("persistent sessions require a local IPC transport")
+    }
+    pub fn request_layout_command(_: &str, _: &Request) -> Result<Response> {
+        bail!("persistent sessions require a local IPC transport")
+    }
+    pub fn attach(_: PathBuf, _: &str, _: &Options) -> Result<()> {
+        bail!("workspace attachment requires a local IPC transport")
+    }
+    pub fn list() -> Result<Vec<NamedSessionStatus>> {
+        bail!("persistent sessions require a local IPC transport")
+    }
+    pub fn prune(_: &str, _: bool) -> Result<Option<PruneKind>> {
+        bail!("persistent sessions require a local IPC transport")
+    }
+    pub fn serve(
+        _: String,
+        _: PathBuf,
+        _: Vec<String>,
+        _: Option<PathBuf>,
+        _: Option<PathBuf>,
+        _: Options,
+    ) -> Result<()> {
+        bail!("persistent sessions require a local IPC transport")
+    }
+    pub fn run_foreground(
+        _: &str,
+        _: &[String],
+        _: Option<&Path>,
+        _: Option<&Path>,
+        _: &Options,
+        _: TabPosition,
+    ) -> Result<()> {
+        bail!("workspace attachment requires a local IPC transport")
     }
 }
 

--- a/src/shot.rs
+++ b/src/shot.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use crate::semantic;
 
 const OPENTUI_QUERY: &[u8] = b"\x1b]10;?\x07\x1b]11;?\x07";
+const CURSOR_POSITION_QUERY: &[u8] = b"\x1b[6n";
 #[cfg(test)]
 const PALETTE_QUERY: &[u8] = b"\x1b]4;0;?\x07";
 const KITTY_QUERY: &[u8] = b"\x1b_Gi=31337";
@@ -197,6 +198,11 @@ pub fn from_command(command: &[String], cwd: Option<&Path>, options: &Options) -
             libc::kill(-process_group, libc::SIGKILL);
         }
     }
+    // On Windows, ConPTY owns a hidden conhost process behind the master handle. Closing the
+    // master before waiting for the child lets that host observe the PTY shutdown instead of
+    // surviving as an orphan after a one-shot capture.
+    #[cfg(windows)]
+    drop(pair.master);
     let _ = child.kill();
     drop(receive);
     let teardown_deadline = Instant::now() + Duration::from_secs(1);
@@ -573,6 +579,7 @@ pub(crate) struct Host {
     opentui_replied: bool,
     kitty_replied: bool,
     probe: Vec<u8>,
+    cursor_position_probe: Vec<u8>,
     color_probe: Vec<u8>,
     pixel_width: u32,
     pixel_height: u32,
@@ -595,6 +602,7 @@ impl Host {
             opentui_replied: false,
             kitty_replied: false,
             probe: Vec::new(),
+            cursor_position_probe: Vec::new(),
             color_probe: Vec::new(),
             pixel_width: u32::from(options.cols) * u32::from(options.cell_width),
             pixel_height: u32::from(options.rows) * u32::from(options.cell_height),
@@ -636,7 +644,11 @@ impl Host {
         }
         let mut response = Vec::new();
         self.probe.extend_from_slice(output);
+        self.cursor_position_probe.extend_from_slice(output);
         self.color_probe.extend_from_slice(output);
+        for _ in 0..take_queries(&mut self.cursor_position_probe, CURSOR_POSITION_QUERY) {
+            response.extend_from_slice(b"\x1b[1;1R");
+        }
         for query in take_color_queries(&mut self.color_probe) {
             match query {
                 ColorQuery::Foreground => {
@@ -690,6 +702,22 @@ impl Host {
         }
         Ok(response)
     }
+}
+
+fn take_queries(probe: &mut Vec<u8>, query: &[u8]) -> usize {
+    let mut count = 0;
+    let mut offset = 0;
+    while let Some(index) = probe[offset..]
+        .windows(query.len())
+        .position(|window| window == query)
+    {
+        count += 1;
+        offset += index + query.len();
+    }
+    let keep = query.len().saturating_sub(1);
+    let drain = probe.len().saturating_sub(keep);
+    probe.drain(..drain);
+    count
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -984,6 +1012,24 @@ mod tests {
         assert!(output.contains("\x1b[4;480;900t"));
         assert!(output.contains("\x1b]4;0;rgb:0000/0000/0000\x1b\\"));
         assert!(output.contains("\x1b_Gi=31337;EINVAL:graphics unavailable\x1b\\"));
+    }
+
+    #[test]
+    fn responds_to_standalone_cursor_position_queries() {
+        let result = Arc::new(Mutex::new(Vec::new()));
+        let mut host = Host::new(
+            Box::new(Writer(result.clone())),
+            &Options {
+                opentui_host: true,
+                ..Options::default()
+            },
+        );
+
+        host.respond(b"\x1b[").unwrap();
+        host.respond(b"6n").unwrap();
+
+        let output = result.lock().unwrap().clone();
+        assert_eq!(output, b"\x1b[1;1R");
     }
 
     #[test]

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -4353,8 +4353,18 @@ fn attachment_closed(error: &anyhow::Error) -> bool {
                 | std::io::ErrorKind::TimedOut
                 | std::io::ErrorKind::WouldBlock
                 | std::io::ErrorKind::UnexpectedEof
-        ) || error.raw_os_error() == Some(libc::EIO)
+        ) || is_eio(error)
     })
+}
+
+#[cfg(unix)]
+fn is_eio(error: &std::io::Error) -> bool {
+    error.raw_os_error() == Some(libc::EIO)
+}
+
+#[cfg(not(unix))]
+fn is_eio(_: &std::io::Error) -> bool {
+    false
 }
 
 fn add_overlay(frame: &mut Frame, text: &str) {


### PR DESCRIPTION
## Summary

- make OpenTUI host handling respond to standalone cursor-position reports used during OpenCode startup
- close the ConPTY master during Windows one-shot teardown and guard Unix-only `EIO` handling
- add Windows named-pipe transport for persistent single sessions while preserving Unix sockets on macOS/Linux
- update CLI help and README platform support notes

## Root cause

OpenCode's TUI waits for a standalone `CSI 6 n` cursor-position response during startup. The host only replied as part of a larger OpenTUI capability probe. Persistent sessions were also compiled out on Windows because their control transport was implemented only with Unix sockets.

## Impact

Windows can now launch and capture OpenCode through the PTY and orchestrate a persistent OpenCode TUI with `start`, `show`, `send`, `wait`, and `stop`. Unix and macOS continue using the existing Unix-socket implementation. Windows workspace attachment remains out of scope.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --locked`
- `cargo test --locked --lib shot::tests` (10 passed)
- live Windows persistent PowerShell input smoke test (`GOT:HELLO`)
- live persistent OpenCode TUI test: render UI, inject prompt using `termctrl send`, wait for `ORCHESTRATED_TUI_OK`, capture response, and stop cleanly
