### PR TITLE
feat: add deterministic tape playback and pointer-aware automation

### DIFF
--- a/.changeset/bright-tapes-wave.md
+++ b/.changeset/bright-tapes-wave.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/terminal-control": minor
+---
+
+Add deterministic tape playback, structured mouse recordings and pointer rendering, plus bounded fixture actions and viewport-safe mouse input.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -19,6 +19,9 @@ An embedded session owns the same live terminal lifecycle in-process; the named 
 Mouse control addresses zero-based cells in the target application's viewport. For workspace panes,
 coordinates are pane-local and exclude composed workspace chrome and borders. A click is one primary
 button press and release; a drag is a primary press, interpolated held-button motion, and release.
+Direct named sessions may explicitly enable structured pointer recording. That produces recording
+version 2 press, move, and release events and exposes the current pointer state to opt-in live SVG or
+PNG rendering. Default direct and composed-workspace recordings remain version 1.
 
 ### Workspace
 
@@ -47,7 +50,13 @@ A versioned JSON Lines stdin/stdout adapter over embedded sessions for external 
 
 ### Recording
 
-A timestamped terminal event timeline containing output, client or automatic host input, viewport resize events, and named editing markers. A recording can be rendered directly to a realtime video that preserves observed timing or rendered through an explicit edit plan that stitches marker ranges with clip-specific speed, holds, and captions. The source recording remains unchanged and should be treated as potentially sensitive.
+A timestamped terminal event timeline containing output, client or automatic host input, viewport
+resize events, and named editing markers. Default recordings use version 1. Explicit pointer capture
+uses version 2 and adds structured press, move, and release events; replay, saved images, and video
+render the high-contrast pointer only when requested. A recording can be rendered directly to a
+realtime video that preserves observed timing or rendered through an explicit edit plan that stitches
+marker ranges with clip-specific speed, holds, and captions. The source recording remains unchanged
+and should be treated as potentially sensitive.
 
 Agents inspect marker names with `termctrl markers` and inspect exact recording moments with `termctrl show --recording ... --at-marker ...` or `--at-ms ...` before committing to a video edit plan.
 
@@ -63,6 +72,7 @@ and failures identify the source line and clean up the session owned by that pla
 A tape is executable authoring input and should be reviewed before use. It is not a recording:
 `.termctrl` remains the timestamped observed timeline, and `video --edit` remains a separate explicit
 rendering phase.
+Tapes may opt into recording version 2 with `Pointer on`; otherwise they preserve version 1 behavior.
 
 ### ANSI/VT Stream
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,7 +23,8 @@ Direct named sessions may explicitly enable structured pointer recording. That p
 version 2 press, move, and release events and exposes the current pointer state to opt-in live SVG or
 PNG rendering. Bare pointer rendering fades after inactivity; persistent rendering retains the last
 position at full opacity while keeping click feedback transient. Neither mode renders before the first
-event. Default direct and composed-workspace recordings remain version 1.
+event. Secondary clicks add an optional button field to their version 2 structured events; primary
+events keep the earlier representation. Default direct and composed-workspace recordings remain version 1.
 
 ### Workspace
 
@@ -73,8 +74,11 @@ stop. Reverse-order cleanup runs only after the owned session is confirmed stopp
 and safe failure paths. Relative paths resolve from the tape directory, failures identify the source
 line, and cleanup failures follow rather than mask the primary failure.
 Tape pointer position is execution state, not recording policy. The first unpressed Move establishes
-it with one no-button SGR event; subsequent Moves interpolate from it, and Click or Drag updates it.
+it with one no-button SGR event; subsequent Moves interpolate from it, and Click, RightClick, or Drag updates it.
 `Pointer on` only decides whether those inputs are also retained as structured v2 events.
+Tape Key uses the live CLI input parser, including `shift+enter`. Wait remains substring-based unless
+`Match line` requests equality with a complete visible row. Successful playback has human, JSON, and
+quiet receipt modes.
 
 A tape is executable authoring input and should be reviewed before use. It is not a recording:
 `.termctrl` remains the timestamped observed timeline, and `video --edit` remains a separate explicit

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,9 +18,11 @@ An embedded session owns the same live terminal lifecycle in-process; the named 
 
 Mouse control addresses zero-based cells in the target application's viewport. For workspace panes,
 coordinates are pane-local and exclude composed workspace chrome and borders. Live mouse input is
-checked against the actual selected target before PTY input or structured recording mutation. A click
-is one primary button press and release; a drag is a primary press, interpolated held-button motion,
-and release.
+an additive structured daemon mutation: direct sessions validate their current dimensions, while
+workspaces resolve the current selected pane, stable pane ID, or named window's active pane and then
+validate it within the same single-threaded operation. PTY input and structured recording mutation
+occur only after that check. Older daemons return an actionable restart requirement. A click is one
+primary button press and release; a drag is a primary press, interpolated held-button motion, and release.
 Direct named sessions may explicitly enable structured pointer recording. That produces recording
 version 2 press, move, and release events and exposes the current pointer state to opt-in live SVG or
 PNG rendering. Bare pointer rendering fades after inactivity; persistent rendering retains the last

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -14,7 +14,11 @@ The versioned structured visible terminal state underlying a shot. A frame conta
 
 A named terminal application that remains available across waiting, input, resizing, log inspection, and visible-screen reads or captures. A session is `running` while accepting input, or `exited` when its application has ended but its final screen remains inspectable until explicitly stopped. A session retains bounded readable logs and the most recent bounded ANSI/VT transcript bytes; alternate-screen TUIs are read with `show` rather than logs. A session may write a recording timeline while it runs, including viewport resize events. Named CLI sessions retain non-secret launch settings so status can identify them and restart can reuse their command and working directory.
 
-An embedded session owns the same live terminal lifecycle in-process; the named CLI session commands are an adapter for interacting with that lifecycle across invocations.
+An embedded session owns the same live terminal lifecycle in-process; the named CLI session commands are an adapter for interacting with that lifecycle across invocations. A named session daemon starts in a separate Unix session from its launcher, so shell and process-group hangups do not end it. It remains available until explicitly stopped, including after its application exits while the final screen is retained.
+
+Mouse control addresses zero-based cells in the target application's viewport. For workspace panes,
+coordinates are pane-local and exclude composed workspace chrome and borders. A click is one primary
+button press and release; a drag is a primary press, interpolated held-button motion, and release.
 
 ### Workspace
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -51,6 +51,19 @@ A timestamped terminal event timeline containing output, client or automatic hos
 
 Agents inspect marker names with `termctrl markers` and inspect exact recording moments with `termctrl show --recording ... --at-marker ...` or `--at-ms ...` before committing to a video edit plan.
 
+### Tape
+
+A UTF-8, line-oriented `.tape` source program for a deterministic demo. The complete tape is parsed
+and validated before its named session is launched. Header directives fix viewport, launch argv,
+working directory, environment, host profile, recording path, and resource limits; ordered steps use
+visible-text waits, paced text or key input, click and drag controls, markers, presentation holds,
+argv-based host actions, and a required clean stop. Relative paths resolve from the tape directory,
+and failures identify the source line and clean up the session owned by that play invocation.
+
+A tape is executable authoring input and should be reviewed before use. It is not a recording:
+`.termctrl` remains the timestamped observed timeline, and `video --edit` remains a separate explicit
+rendering phase.
+
 ### ANSI/VT Stream
 
 Raw terminal output bytes containing text and terminal control sequences. Files commonly use an `.ansi` suffix, but the suffix does not imply a separate container format.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,7 +21,9 @@ coordinates are pane-local and exclude composed workspace chrome and borders. A 
 button press and release; a drag is a primary press, interpolated held-button motion, and release.
 Direct named sessions may explicitly enable structured pointer recording. That produces recording
 version 2 press, move, and release events and exposes the current pointer state to opt-in live SVG or
-PNG rendering. Default direct and composed-workspace recordings remain version 1.
+PNG rendering. Bare pointer rendering fades after inactivity; persistent rendering retains the last
+position at full opacity while keeping click feedback transient. Neither mode renders before the first
+event. Default direct and composed-workspace recordings remain version 1.
 
 ### Workspace
 
@@ -70,6 +72,9 @@ drag controls, markers, presentation holds, bounded argv-based host actions, and
 stop. Reverse-order cleanup runs only after the owned session is confirmed stopped, on both success
 and safe failure paths. Relative paths resolve from the tape directory, failures identify the source
 line, and cleanup failures follow rather than mask the primary failure.
+Tape pointer position is execution state, not recording policy. The first unpressed Move establishes
+it with one no-button SGR event; subsequent Moves interpolate from it, and Click or Drag updates it.
+`Pointer on` only decides whether those inputs are also retained as structured v2 events.
 
 A tape is executable authoring input and should be reviewed before use. It is not a recording:
 `.termctrl` remains the timestamped observed timeline, and `video --edit` remains a separate explicit

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,8 +17,10 @@ A named terminal application that remains available across waiting, input, resiz
 An embedded session owns the same live terminal lifecycle in-process; the named CLI session commands are an adapter for interacting with that lifecycle across invocations. A named session daemon starts in a separate Unix session from its launcher, so shell and process-group hangups do not end it. It remains available until explicitly stopped, including after its application exits while the final screen is retained.
 
 Mouse control addresses zero-based cells in the target application's viewport. For workspace panes,
-coordinates are pane-local and exclude composed workspace chrome and borders. A click is one primary
-button press and release; a drag is a primary press, interpolated held-button motion, and release.
+coordinates are pane-local and exclude composed workspace chrome and borders. Live mouse input is
+checked against the actual selected target before PTY input or structured recording mutation. A click
+is one primary button press and release; a drag is a primary press, interpolated held-button motion,
+and release.
 Direct named sessions may explicitly enable structured pointer recording. That produces recording
 version 2 press, move, and release events and exposes the current pointer state to opt-in live SVG or
 PNG rendering. Bare pointer rendering fades after inactivity; persistent rendering retains the last
@@ -72,7 +74,10 @@ actions run before launch; ordered steps use visible-text waits, paced text or k
 drag controls, markers, presentation holds, bounded argv-based host actions, and a required clean
 stop. Reverse-order cleanup runs only after the owned session is confirmed stopped, on both success
 and safe failure paths. Relative paths resolve from the tape directory, failures identify the source
-line, and cleanup failures follow rather than mask the primary failure.
+line, and cleanup failures follow rather than mask the primary failure. Mouse endpoints are validated
+against the declared viewport before lifecycle effects. Action output capture and drain are finite;
+escaped new-session descendants can outlive the action group but cannot retain pipes indefinitely and
+block owned-session cleanup. JSON receipt paths are validated as UTF-8 before setup or launch.
 Tape pointer position is execution state, not recording policy. The first unpressed Move establishes
 it with one no-button SGR event; subsequent Moves interpolate from it, and Click, RightClick, or Drag updates it.
 `Pointer on` only decides whether those inputs are also retained as structured v2 events.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -64,10 +64,12 @@ Agents inspect marker names with `termctrl markers` and inspect exact recording 
 
 A UTF-8, line-oriented `.tape` source program for a deterministic demo. The complete tape is parsed
 and validated before its named session is launched. Header directives fix viewport, launch argv,
-working directory, environment, host profile, recording path, and resource limits; ordered steps use
-visible-text waits, paced text or key input, click and drag controls, markers, presentation holds,
-argv-based host actions, and a required clean stop. Relative paths resolve from the tape directory,
-and failures identify the source line and clean up the session owned by that play invocation.
+working directory, environment, host profile, recording path, and resource limits. Repeatable setup
+actions run before launch; ordered steps use visible-text waits, paced text or key input, click and
+drag controls, markers, presentation holds, bounded argv-based host actions, and a required clean
+stop. Reverse-order cleanup runs only after the owned session is confirmed stopped, on both success
+and safe failure paths. Relative paths resolve from the tape directory, failures identify the source
+line, and cleanup failures follow rather than mask the primary failure.
 
 A tape is executable authoring input and should be reviewed before use. It is not a recording:
 `.termctrl` remains the timestamped observed timeline, and `video --edit` remains a separate explicit

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ termctrl save demo --format png --out captures/help.png
 termctrl stop demo
 ```
 
-- `send` accepts `text:<value>`, named keys (`enter`, `escape`, arrows, `tab`, `shift-tab`, `backspace`, `delete`, `home`, `end`, `page-up`, `page-down`), and `ctrl-a` through `ctrl-z`. Pipe exact bytes with `--stdin`.
+- `send` accepts `text:<value>`, named keys (`enter`, `escape`, arrows, `tab`, `shift-tab`, `backspace`, `delete`, `home`, `end`, `page-up`, `page-down`), modifier chords including `shift+enter`, and `ctrl-a` through `ctrl-z`. Pipe exact bytes with `--stdin`.
 - `click NAME X Y` sends a primary-button press and release. `drag NAME FROM_X FROM_Y TO_X TO_Y`
   sends a primary press, interpolated held-button motion, and release; `--steps` controls the motion
   event count and `--pace-ms` controls their interval. Coordinates are zero-based application cells:
@@ -168,9 +168,10 @@ Wait "Choose a square" Timeout 10s
 Move 8 8
 Move 12 8 Steps 8 Pace 16ms
 Click 12 8
+RightClick 20 8
 Wait "Your turn"
 Type "middle" Pace 35ms
-Key enter
+Key shift+enter
 Mark result
 Sleep 750ms
 Stop
@@ -204,7 +205,17 @@ first structured pointer event. Capture policy (`Pointer on`) and render persist
 
 Tape `Move X Y [Steps N] [Pace DURATION]` emits unpressed SGR motion. The first Move establishes the
 authoritative position with one event; later Moves interpolate from it, defaulting to 10 points at
-8 ms. Click and Drag update that position so subsequent motion remains continuous.
+8 ms. Click, RightClick, and Drag update that position so subsequent motion remains continuous.
+`RightClick X Y` emits a secondary SGR press and release. With `Pointer on`, its version 2 pointer
+events add `button: "secondary"`; primary events retain their original representation and default
+recordings remain version 1.
+
+`Wait TEXT` keeps substring matching for compatibility. Add `Match line` when the visible text must
+equal a complete trimmed terminal row, so `Wait "history entry 1" Match line` does not match
+`history entry 10`. `Timeout DURATION` and `Match line` may appear in either order.
+
+Successful `play` prints the canonical tape path and any recording path. Use `--json` for a stable
+receipt containing `status`, `tape`, `session`, and `recording`, or `--quiet` to suppress stdout.
 
 ## Semantic UI Snapshots
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Use a named session when several interactions target the same running applicatio
 termctrl start demo --host opentui --cols 112 --rows 34 -- my-terminal-app
 termctrl wait demo "Ready"
 termctrl send demo text:help enter
+termctrl click demo 12 4
+termctrl drag demo 12 4 30 4
 termctrl show demo
 termctrl show demo --format semantic
 termctrl save demo --format png --out captures/help.png
@@ -113,6 +115,11 @@ termctrl stop demo
 ```
 
 - `send` accepts `text:<value>`, named keys (`enter`, `escape`, arrows, `tab`, `shift-tab`, `backspace`, `delete`, `home`, `end`, `page-up`, `page-down`), and `ctrl-a` through `ctrl-z`. Pipe exact bytes with `--stdin`.
+- `click NAME X Y` sends a primary-button press and release. `drag NAME FROM_X FROM_Y TO_X TO_Y`
+  sends a primary press, interpolated held-button motion, and release; `--steps` controls the motion
+  event count and `--pace-ms` controls their interval. Coordinates are zero-based application cells:
+  X increases rightward and Y downward. Workspace coordinates are local to the selected or targeted
+  pane and exclude tab chrome and borders. The application must have mouse tracking enabled.
 - `wait` blocks until text is visible; use it instead of sleeping. It defaults to a five-second
   maximum, so omit `--timeout 5000` and override only when choosing a different limit.
 - `status` reports running/exited state, command, cwd, viewport, and recording path. `list` shows
@@ -230,6 +237,8 @@ termctrl layout workspace --grid 2x2
 termctrl show workspace
 termctrl show workspace --pane 1
 termctrl send workspace --pane 1 text:opencode2 enter
+termctrl click workspace 12 4 --pane 1
+termctrl drag workspace 12 4 30 4 --pane 1
 termctrl focus workspace --pane 1
 termctrl close-pane workspace --pane 1
 ```

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ Cleanup "/usr/bin/rm" "-f" "fixtures/game.json"
 Launch "cargo" "run" "--release" "--bin" "ttt"
 
 Wait "Choose a square" Timeout 10s
+Move 8 8
+Move 12 8 Steps 8 Pace 16ms
 Click 12 8
 Wait "Your turn"
 Type "middle" Pace 35ms
@@ -195,7 +197,14 @@ Pointer overlays are opt-in. Start a direct session with `--record ... --record-
 `Pointer on` in a recording tape, then pass `--pointer` to rendered `show`/`save` output or `video`.
 This writes recording format version 2 with structured press, move, and release events. Ordinary
 recordings remain version 1 and existing rendering stays unchanged. Pointer capture is currently a
-direct named-session capability; composed workspaces continue to use version 1 recordings.
+direct named-session capability; composed workspaces continue to use version 1 recordings. Bare
+`--pointer` retains the fading behavior. Use `--pointer=persistent` to keep the latest pointer at
+full opacity through long idle periods; the click ring still expires, and nothing renders before the
+first structured pointer event. Capture policy (`Pointer on`) and render persistence are independent.
+
+Tape `Move X Y [Steps N] [Pace DURATION]` emits unpressed SGR motion. The first Move establishes the
+authoritative position with one event; later Moves interpolate from it, defaulting to 10 points at
+8 ms. Click and Drag update that position so subsequent motion remains continuous.
 
 ## Semantic UI Snapshots
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,44 @@ termctrl logs demo --ansi > captures/demo-output.ansi
 
 Full-screen alternate-screen TUIs do not produce useful logs; read their visible screen with `show`.
 
+## Script A Deterministic Demo
+
+`play` validates a complete tape before launching anything, then drives the existing named-session,
+wait, keyboard, mouse, marker, and recording controls:
+
+```text
+# demos/ttt.tape
+Session ttt-demo
+Viewport 80 24
+Cwd ".."
+Env TTT_FIXTURE "demo game"
+Record "captures/ttt.termctrl"
+Launch "cargo" "run" "--release" "--bin" "ttt"
+
+Wait "Choose a square" Timeout 10s
+Click 12 8
+Wait "Your turn"
+Type "middle" Pace 35ms
+Key enter
+Mark result
+Sleep 750ms
+Stop
+```
+
+```bash
+termctrl play demos/ttt.tape
+termctrl video demos/captures/ttt.termctrl --edit demos/captures/ttt-edit.json \
+  --out demos/captures/ttt.mp4
+```
+
+A `.tape` file is readable authoring source, not a `.termctrl` recording. Relative `Cwd` and `Record`
+paths use the tape directory; `Action` uses the configured cwd. Prefer state-aware `Wait` steps;
+reserve `Sleep` for a deliberate presentation hold. `Action` runs an explicit argv vector without a
+shell for controlled fixture changes, so play only tapes you trust. A failed step reports its file and
+line, includes the last visible screen for wait timeouts, and stops the session it launched. Video
+selection and editing remain an explicit phase after the recording exists. See
+[docs/tape-scripting.md](docs/tape-scripting.md) for the complete format.
+
 ## Semantic UI Snapshots
 
 Terminal Control gives applications launched with `--host opentui` a private
@@ -334,6 +372,7 @@ See [docs/typescript-client.md](docs/typescript-client.md) for artifacts, record
 
 ## More Documentation
 
+- [docs/tape-scripting.md](docs/tape-scripting.md) — deterministic `.tape` demo scripts and their safety boundary.
 - [docs/rust-library.md](docs/rust-library.md) — embed the shot engine and sessions in Rust, plus versioned JSON schemas.
 - [docs/driver-protocol.md](docs/driver-protocol.md) — the `termctrl driver` JSON Lines protocol for external tooling.
 - [docs/semantic-protocol.md](docs/semantic-protocol.md) — the application semantic socket handshake and snapshot contract.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Viewport 80 24
 Cwd ".."
 Env TTT_FIXTURE "demo game"
 Record "captures/ttt.termctrl"
+Pointer on
 Launch "cargo" "run" "--release" "--bin" "ttt"
 
 Wait "Choose a square" Timeout 10s
@@ -184,6 +185,12 @@ shell for controlled fixture changes, so play only tapes you trust. A failed ste
 line, includes the last visible screen for wait timeouts, and stops the session it launched. Video
 selection and editing remain an explicit phase after the recording exists. See
 [docs/tape-scripting.md](docs/tape-scripting.md) for the complete format.
+
+Pointer overlays are opt-in. Start a direct session with `--record ... --record-pointer`, or use
+`Pointer on` in a recording tape, then pass `--pointer` to rendered `show`/`save` output or `video`.
+This writes recording format version 2 with structured press, move, and release events. Ordinary
+recordings remain version 1 and existing rendering stays unchanged. Pointer capture is currently a
+direct named-session capability; composed workspaces continue to use version 1 recordings.
 
 ## Semantic UI Snapshots
 
@@ -336,7 +343,8 @@ An edit plan selects marker ranges with per-clip speed, captions, and optional e
 
 Without `--edit`, export preserves recorded timing. `--footer` renders captions, timecode, and branding in a bottom bar. `--tail-ms 0` removes the default one-second final hold. Keep speeds low enough for text to stay readable.
 
-Recordings are JSON Lines files containing terminal output and typed input; they can include prompts or secrets. Treat them as sensitive.
+Recordings are JSON Lines files containing terminal output and typed input; opt-in version 2 files
+also contain structured pointer events. They can include prompts or secrets. Treat them as sensitive.
 
 ## Pipes And ANSI Streams
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ Cwd ".."
 Env TTT_FIXTURE "demo game"
 Record "captures/ttt.termctrl"
 Pointer on
+Setup "/usr/bin/cp" "fixtures/empty.json" "fixtures/game.json"
+Cleanup "/usr/bin/rm" "-f" "fixtures/game.json"
 Launch "cargo" "run" "--release" "--bin" "ttt"
 
 Wait "Choose a square" Timeout 10s
@@ -179,10 +181,13 @@ termctrl video demos/captures/ttt.termctrl --edit demos/captures/ttt-edit.json \
 ```
 
 A `.tape` file is readable authoring source, not a `.termctrl` recording. Relative `Cwd` and `Record`
-paths use the tape directory; `Action` uses the configured cwd. Prefer state-aware `Wait` steps;
-reserve `Sleep` for a deliberate presentation hold. `Action` runs an explicit argv vector without a
-shell for controlled fixture changes, so play only tapes you trust. A failed step reports its file and
-line, includes the last visible screen for wait timeouts, and stops the session it launched. Video
+paths use the tape directory; host actions use the configured cwd and environment. Prefer state-aware
+`Wait` steps; reserve `Sleep` for a deliberate presentation hold. `Setup`, `Action`, and `Cleanup`
+run explicit argv vectors without implicit shell evaluation. They default to a finite 30-second
+timeout, accept a trailing `Timeout DURATION`, and retain bounded diagnostics. Setup runs before
+Launch; cleanup runs in reverse order after session stop on success or safe failure paths. Cleanup
+errors do not mask the primary failure. A failed step reports its file and line, and wait timeouts
+include the last visible screen. Video
 selection and editing remain an explicit phase after the recording exists. See
 [docs/tape-scripting.md](docs/tape-scripting.md) for the complete format.
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ termctrl stop demo
   sends a primary press, interpolated held-button motion, and release; `--steps` controls the motion
   event count and `--pace-ms` controls their interval. Coordinates are zero-based application cells:
   X increases rightward and Y downward. Workspace coordinates are local to the selected or targeted
-  pane and exclude tab chrome and borders. The application must have mouse tracking enabled.
+  pane and exclude tab chrome and borders. Every coordinate must fit the actual target viewport;
+  invalid clicks and drag endpoints fail before input or pointer evidence is recorded. The application
+  must have mouse tracking enabled.
 - `wait` blocks until text is visible; use it instead of sleeping. It defaults to a five-second
   maximum, so omit `--timeout 5000` and override only when choosing a different limit.
 - `status` reports running/exited state, command, cwd, viewport, and recording path. `list` shows
@@ -189,9 +191,10 @@ paths use the tape directory; host actions use the configured cwd and environmen
 run explicit argv vectors without implicit shell evaluation. They default to a finite 30-second
 timeout, accept a trailing `Timeout DURATION`, and retain bounded diagnostics. Setup runs before
 Launch; cleanup runs in reverse order after session stop on success or safe failure paths. Cleanup
-errors do not mask the primary failure. A failed step reports its file and line, and wait timeouts
-include the last visible screen. Video
-selection and editing remain an explicit phase after the recording exists. See
+errors do not mask the primary failure. Output drain also has a finite grace: an action whose escaped
+descendant retains stdout or stderr fails instead of delaying session cleanup indefinitely. A failed
+step reports its file and line, and wait timeouts include the last visible screen. Video selection
+and editing remain an explicit phase after the recording exists. See
 [docs/tape-scripting.md](docs/tape-scripting.md) for the complete format.
 
 Pointer overlays are opt-in. Start a direct session with `--record ... --record-pointer`, or use
@@ -216,6 +219,7 @@ equal a complete trimmed terminal row, so `Wait "history entry 1" Match line` do
 
 Successful `play` prints the canonical tape path and any recording path. Use `--json` for a stable
 receipt containing `status`, `tape`, `session`, and `recording`, or `--quiet` to suppress stdout.
+On Unix, `--json` requires UTF-8 tape and recording paths; this is rejected before setup or launch.
 
 ## Semantic UI Snapshots
 

--- a/README.md
+++ b/README.md
@@ -120,8 +120,11 @@ termctrl stop demo
   event count and `--pace-ms` controls their interval. Coordinates are zero-based application cells:
   X increases rightward and Y downward. Workspace coordinates are local to the selected or targeted
   pane and exclude tab chrome and borders. Every coordinate must fit the actual target viewport;
-  invalid clicks and drag endpoints fail before input or pointer evidence is recorded. The application
-  must have mouse tracking enabled.
+  the daemon resolves the selected pane or window and validates its current dimensions in the same
+  mutation that writes the PTY, so concurrent resizes or selection changes cannot stale the check.
+  Invalid clicks and drag endpoints fail before input or pointer evidence is recorded. The application
+  must have mouse tracking enabled. Restart an older named session if the client reports that it
+  predates viewport-safe mouse input.
 - `wait` blocks until text is visible; use it instead of sleeping. It defaults to a five-second
   maximum, so omit `--timeout 5000` and override only when choosing a different limit.
 - `status` reports running/exited state, command, cwd, viewport, and recording path. `list` shows

--- a/docs/rust-library.md
+++ b/docs/rust-library.md
@@ -58,5 +58,8 @@ No connected provider returns `termctrl-semantic-snapshot-v1` with an empty `nod
 ## Versioned Structured Output
 
 - A `save --format json` capture is a `Frame` object with `version: 1`, described by `schemas/frame-v1.schema.json`.
-- A `.termctrl` recording is JSON Lines: its first line is a versioned header and subsequent lines are timed output, input, resize, or marker entries, each described by `schemas/recording-entry-v1.schema.json`.
+- A default `.termctrl` recording is JSON Lines version 1: its first line is a versioned header and
+  subsequent lines are timed output, input, resize, or marker entries described by
+  `schemas/recording-entry-v1.schema.json`. Explicit structured pointer capture writes version 2 and
+  adds press, move, and release entries described by `schemas/recording-entry-v2.schema.json`.
 - Recording byte arrays contain the original terminal or input bytes as integers from `0` to `255`; recordings can contain sensitive text or input.

--- a/docs/tape-scripting.md
+++ b/docs/tape-scripting.md
@@ -54,19 +54,27 @@ Steps follow `Launch` in order:
 | `Type TEXT [Pace DURATION]` | Send text, optionally one Unicode scalar at a time. |
 | `Key KEY [KEY ...] [Pace DURATION]` | Send supported named keys in order. |
 | `Click X Y` | Send a primary click at a zero-based application cell. |
+| `Move X Y [Steps N] [Pace DURATION]` | Move the unpressed pointer; defaults to 10 points at 8 ms. |
 | `Drag X1 Y1 X2 Y2 [Steps N] [Pace DURATION]` | Send primary drag events; defaults to 10 steps at 8 ms. |
 | `Mark NAME` | Add a unique recording marker; requires `Record`. |
 | `Sleep DURATION` | Hold the presentation deliberately without checking state. |
 | `Action PROGRAM [ARG ...] [Timeout DURATION]` | Run an in-session host action using exact argv. |
 | `Stop` | Required final command; stop the owned named session cleanly. |
 
-`Type` and `Key` accept the same named-key vocabulary as `termctrl send`. `Click` and `Drag` reuse
-the normal SGR mouse implementation, so the application must enable mouse tracking. Coordinates are
-application-cell coordinates, not screen pixels.
+`Type` and `Key` accept the same named-key vocabulary as `termctrl send`. `Click`, `Move`, and `Drag`
+reuse the normal SGR mouse implementation, so the application must enable the corresponding mouse
+tracking. Coordinates are application-cell coordinates, not screen pixels. The first `Move`
+establishes the tape pointer position with one honest no-button motion event; it does not invent a
+path from an unknown origin. Later Moves interpolate `Steps` events from the authoritative position,
+including the destination. Click sets the position to its target and Drag sets it to its endpoint.
 
-With `Pointer on`, click and drag also produce structured press, move, and release events in an
+With `Pointer on`, click, move, and drag also produce structured press, move, and release events in an
 opt-in version 2 recording. Render them with `save --recording ... --pointer` or `video --pointer`.
-Without that directive, tape recordings remain version 1 and render exactly as before.
+Without that directive, tape recordings remain version 1 and existing Click/Drag behavior is
+unchanged; Move still sends its explicit no-button input to the application. `Pointer on` controls
+capture only. Bare `--pointer` uses the fading renderer, while `--pointer=persistent` keeps the most
+recent event visible without prolonging press or click feedback. No overlay exists before the first
+event.
 
 `Setup`, `Action`, and `Cleanup` have a finite 30-second default timeout. A trailing
 `Timeout DURATION` overrides it. Each action starts in its own Unix process group; timeout terminates
@@ -93,6 +101,8 @@ Cleanup "/usr/bin/rm" "-f" "fixtures/game.json"
 Launch "cargo" "run" "--release" "--bin" "ttt"
 
 Wait "Choose a square" Timeout 10s
+Move 8 8
+Move 12 8 Steps 8 Pace 16ms
 Click 12 8
 Wait "Your turn"
 Type "middle" Pace 35ms

--- a/docs/tape-scripting.md
+++ b/docs/tape-scripting.md
@@ -1,0 +1,90 @@
+# Tape Scripting
+
+`termctrl play FILE.tape` runs a deterministic terminal demo from readable source. A tape is distinct
+from a `.termctrl` recording: the tape describes intended actions, while a recording stores the timed
+terminal events that actually occurred. Video export remains a separate command after playback.
+
+## Execution Contract
+
+`play` reads at most 1 MiB of UTF-8, parses and validates every non-comment line, checks the working
+directory, and only then launches the named session. It does not partially run a syntactically invalid
+tape. A launch or step failure is reported as `file:line`, and the session created by that invocation
+is stopped. A `Wait` timeout also includes the last visible screen, truncated for diagnostics.
+
+Relative `Cwd` and `Record` paths resolve from the directory containing the tape. The default working
+directory is that directory, and `Action` runs in the configured working directory. `Record` creates
+a private `.termctrl` timeline through the normal session recorder. Run `termctrl video RECORDING
+--edit PLAN` explicitly after playback if a video is wanted.
+
+## Syntax
+
+Each command occupies one line. Blank lines and `#` comments are ignored. A comment starts at `#`
+outside quotes. Single-quoted text is literal. Double-quoted text supports `\\`, `\"`, `\'`, `\n`,
+`\r`, and `\t`; a backslash escapes the next character in unquoted text. Adjacent quoted and
+unquoted segments form one argument. Command and option names are case-sensitive.
+
+Durations use an integer followed by `ms`, `s`, or `m`, such as `35ms`, `2s`, or `1m`, and cannot
+exceed ten minutes. Zero is accepted only for input pacing.
+
+All header directives must precede `Launch`:
+
+| Directive | Meaning |
+| --- | --- |
+| `Session NAME` | Required named-session identity. |
+| `Viewport COLS ROWS` | Required fixed terminal size in cells. |
+| `Cell WIDTH HEIGHT` | Cell size in pixels; defaults to `9 18`. |
+| `MaxBytes BYTES` | Retained terminal byte limit; defaults to 16 MiB. |
+| `Cwd PATH` | Launch and action working directory; defaults to the tape directory. |
+| `Env KEY VALUE` | Add or override one inherited environment value; repeat for multiple keys. |
+| `Record FILE.termctrl` | Opt into a recording, resolved from the tape directory. |
+| `Host none\|opentui` | Terminal host profile; defaults to `none`. |
+| `Color auto\|always\|never` | Color environment policy; defaults to `auto`. |
+| `Launch PROGRAM [ARG ...]` | Required application argv; no implicit shell. |
+
+Steps follow `Launch` in order:
+
+| Step | Meaning |
+| --- | --- |
+| `Wait TEXT [Timeout DURATION]` | Wait for visible text; timeout defaults to five seconds. |
+| `Type TEXT [Pace DURATION]` | Send text, optionally one Unicode scalar at a time. |
+| `Key KEY [KEY ...] [Pace DURATION]` | Send supported named keys in order. |
+| `Click X Y` | Send a primary click at a zero-based application cell. |
+| `Drag X1 Y1 X2 Y2 [Steps N] [Pace DURATION]` | Send primary drag events; defaults to 10 steps at 8 ms. |
+| `Mark NAME` | Add a unique recording marker; requires `Record`. |
+| `Sleep DURATION` | Hold the presentation deliberately without checking state. |
+| `Action PROGRAM [ARG ...]` | Run a host process using exact argv, tape cwd, and tape environment. |
+| `Stop` | Required final command; stop the owned named session cleanly. |
+
+`Type` and `Key` accept the same named-key vocabulary as `termctrl send`. `Click` and `Drag` reuse
+the normal SGR mouse implementation, so the application must enable mouse tracking. Coordinates are
+application-cell coordinates, not screen pixels.
+
+## Example
+
+```text
+# demos/ttt.tape
+Session ttt-demo
+Viewport 80 24
+Cell 9 18
+Cwd ".."
+Env TTT_SEED "fixed-demo"
+Record "captures/ttt.termctrl"
+Color always
+Launch "cargo" "run" "--release" "--bin" "ttt"
+
+Wait "Choose a square" Timeout 10s
+Click 12 8
+Wait "Your turn"
+Type "middle" Pace 35ms
+Key enter
+Action "/usr/bin/touch" "fixtures/opponent-ready"
+Wait "You won"
+Mark result
+Sleep 750ms
+Stop
+```
+
+`Action` intentionally supports external fixture mutation without shell parsing. It can still run an
+arbitrary executable, so treat tapes as executable project code. If shell behavior is genuinely the
+application under demonstration, make that choice explicit in argv, for example `Launch /bin/sh -c
+"..."`; `play` itself never joins arguments or evaluates them through a shell.

--- a/docs/tape-scripting.md
+++ b/docs/tape-scripting.md
@@ -50,10 +50,11 @@ Steps follow `Launch` in order:
 
 | Step | Meaning |
 | --- | --- |
-| `Wait TEXT [Timeout DURATION]` | Wait for visible text; timeout defaults to five seconds. |
+| `Wait TEXT [Match MODE] [Timeout DURATION]` | Wait for visible text; MODE is `substring` or `line`, and defaults to substring. Timeout defaults to five seconds. |
 | `Type TEXT [Pace DURATION]` | Send text, optionally one Unicode scalar at a time. |
 | `Key KEY [KEY ...] [Pace DURATION]` | Send supported named keys in order. |
 | `Click X Y` | Send a primary click at a zero-based application cell. |
+| `RightClick X Y` | Send a secondary click at a zero-based application cell. |
 | `Move X Y [Steps N] [Pace DURATION]` | Move the unpressed pointer; defaults to 10 points at 8 ms. |
 | `Drag X1 Y1 X2 Y2 [Steps N] [Pace DURATION]` | Send primary drag events; defaults to 10 steps at 8 ms. |
 | `Mark NAME` | Add a unique recording marker; requires `Record`. |
@@ -61,15 +62,23 @@ Steps follow `Launch` in order:
 | `Action PROGRAM [ARG ...] [Timeout DURATION]` | Run an in-session host action using exact argv. |
 | `Stop` | Required final command; stop the owned named session cleanly. |
 
-`Type` and `Key` accept the same named-key vocabulary as `termctrl send`. `Click`, `Move`, and `Drag`
+`Type` and `Key` accept the same input parser as `termctrl send`, including modifier chords such as
+`shift+enter`. `Click`, `RightClick`, `Move`, and `Drag`
 reuse the normal SGR mouse implementation, so the application must enable the corresponding mouse
 tracking. Coordinates are application-cell coordinates, not screen pixels. The first `Move`
 establishes the tape pointer position with one honest no-button motion event; it does not invent a
 path from an unknown origin. Later Moves interpolate `Steps` events from the authoritative position,
-including the destination. Click sets the position to its target and Drag sets it to its endpoint.
+including the destination. Click and RightClick set the position to their target and Drag sets it to
+its endpoint.
 
-With `Pointer on`, click, move, and drag also produce structured press, move, and release events in an
-opt-in version 2 recording. Render them with `save --recording ... --pointer` or `video --pointer`.
+`Wait` searches for a substring by default. Add `Match line` for equality with one complete visible
+terminal row after trailing cell padding is removed. This prevents `Wait "history entry 1" Match line`
+from succeeding on `history entry 10`. `Match substring` is an explicit spelling of the default;
+`Match` and `Timeout` modifiers may appear in either order.
+
+With `Pointer on`, clicks, move, and drag also produce structured press, move, and release events in
+an opt-in version 2 recording. RightClick events include `button: "secondary"`; the optional field is
+omitted for primary events. Render them with `save --recording ... --pointer` or `video --pointer`.
 Without that directive, tape recordings remain version 1 and existing Click/Drag behavior is
 unchanged; Move still sends its explicit no-button input to the application. `Pointer on` controls
 capture only. Bare `--pointer` uses the fading renderer, while `--pointer=persistent` keeps the most
@@ -104,15 +113,20 @@ Wait "Choose a square" Timeout 10s
 Move 8 8
 Move 12 8 Steps 8 Pace 16ms
 Click 12 8
+RightClick 20 8
 Wait "Your turn"
 Type "middle" Pace 35ms
-Key enter
+Key shift+enter
 Action "/usr/bin/touch" "fixtures/opponent-ready" Timeout 2s
 Wait "You won"
 Mark result
 Sleep 750ms
 Stop
 ```
+
+On success, `termctrl play FILE.tape` prints the canonical tape path and recording path, if any.
+Use `--json` for the stable fields `status`, `tape`, `session`, and `recording`, or `--quiet` when a
+caller requires empty stdout.
 
 Host actions intentionally support external fixture mutation without shell parsing. They can still
 run arbitrary executables, so treat tapes as executable project code. If shell behavior is genuinely the

--- a/docs/tape-scripting.md
+++ b/docs/tape-scripting.md
@@ -7,13 +7,15 @@ terminal events that actually occurred. Video export remains a separate command 
 ## Execution Contract
 
 `play` reads at most 1 MiB of UTF-8, parses and validates every non-comment line, checks the working
-directory, and only then launches the named session. It does not partially run a syntactically invalid
-tape. A launch or step failure is reported as `file:line`, and the session created by that invocation
-is stopped. A `Wait` timeout also includes the last visible screen, truncated for diagnostics.
+directory, and only then performs setup. It does not partially run a syntactically invalid tape.
+A setup, launch, or step failure is reported as `file:line`. The session created by that invocation is
+stopped before cleanup runs; if shutdown cannot be confirmed, cleanup is skipped rather than mutating
+a fixture underneath a possibly live application. A `Wait` timeout also includes the last visible
+screen, truncated for diagnostics.
 
 Relative `Cwd` and `Record` paths resolve from the directory containing the tape. The default working
-directory is that directory, and `Action` runs in the configured working directory. `Record` creates
-a private `.termctrl` timeline through the normal session recorder. Run `termctrl video RECORDING
+directory is that directory, and host actions run in the configured working directory. `Record`
+creates a private `.termctrl` timeline through the normal session recorder. Run `termctrl video RECORDING
 --edit PLAN` explicitly after playback if a video is wanted.
 
 ## Syntax
@@ -40,6 +42,8 @@ All header directives must precede `Launch`:
 | `Pointer on\|off` | Opt into version 2 structured pointer recording; `on` requires `Record`. |
 | `Host none\|opentui` | Terminal host profile; defaults to `none`. |
 | `Color auto\|always\|never` | Color environment policy; defaults to `auto`. |
+| `Setup PROGRAM [ARG ...] [Timeout DURATION]` | Repeatable fixture setup argv, run in source order before `Launch`. |
+| `Cleanup PROGRAM [ARG ...] [Timeout DURATION]` | Repeatable fixture cleanup argv, run in reverse order after session stop. |
 | `Launch PROGRAM [ARG ...]` | Required application argv; no implicit shell. |
 
 Steps follow `Launch` in order:
@@ -53,7 +57,7 @@ Steps follow `Launch` in order:
 | `Drag X1 Y1 X2 Y2 [Steps N] [Pace DURATION]` | Send primary drag events; defaults to 10 steps at 8 ms. |
 | `Mark NAME` | Add a unique recording marker; requires `Record`. |
 | `Sleep DURATION` | Hold the presentation deliberately without checking state. |
-| `Action PROGRAM [ARG ...]` | Run a host process using exact argv, tape cwd, and tape environment. |
+| `Action PROGRAM [ARG ...] [Timeout DURATION]` | Run an in-session host action using exact argv. |
 | `Stop` | Required final command; stop the owned named session cleanly. |
 
 `Type` and `Key` accept the same named-key vocabulary as `termctrl send`. `Click` and `Drag` reuse
@@ -63,6 +67,14 @@ application-cell coordinates, not screen pixels.
 With `Pointer on`, click and drag also produce structured press, move, and release events in an
 opt-in version 2 recording. Render them with `save --recording ... --pointer` or `video --pointer`.
 Without that directive, tape recordings remain version 1 and render exactly as before.
+
+`Setup`, `Action`, and `Cleanup` have a finite 30-second default timeout. A trailing
+`Timeout DURATION` overrides it. Each action starts in its own Unix process group; timeout terminates
+the group, and both stdout and stderr are drained with bounded diagnostic retention. Successful
+actions must exit zero. Cleanup runs even after setup, launch, or playback failure when no live owned
+session remains, and all cleanup entries are attempted in reverse declaration order. Cleanup errors
+follow rather than replace the primary error. Write cleanup actions to tolerate partially completed
+setup and repeated use.
 
 ## Example
 
@@ -76,6 +88,8 @@ Env TTT_SEED "fixed-demo"
 Record "captures/ttt.termctrl"
 Pointer on
 Color always
+Setup "/usr/bin/cp" "fixtures/clean.json" "fixtures/game.json" Timeout 5s
+Cleanup "/usr/bin/rm" "-f" "fixtures/game.json"
 Launch "cargo" "run" "--release" "--bin" "ttt"
 
 Wait "Choose a square" Timeout 10s
@@ -83,14 +97,14 @@ Click 12 8
 Wait "Your turn"
 Type "middle" Pace 35ms
 Key enter
-Action "/usr/bin/touch" "fixtures/opponent-ready"
+Action "/usr/bin/touch" "fixtures/opponent-ready" Timeout 2s
 Wait "You won"
 Mark result
 Sleep 750ms
 Stop
 ```
 
-`Action` intentionally supports external fixture mutation without shell parsing. It can still run an
-arbitrary executable, so treat tapes as executable project code. If shell behavior is genuinely the
+Host actions intentionally support external fixture mutation without shell parsing. They can still
+run arbitrary executables, so treat tapes as executable project code. If shell behavior is genuinely the
 application under demonstration, make that choice explicit in argv, for example `Launch /bin/sh -c
 "..."`; `play` itself never joins arguments or evaluates them through a shell.

--- a/docs/tape-scripting.md
+++ b/docs/tape-scripting.md
@@ -69,7 +69,8 @@ tracking. Coordinates are application-cell coordinates, not screen pixels. The f
 establishes the tape pointer position with one honest no-button motion event; it does not invent a
 path from an unknown origin. Later Moves interpolate `Steps` events from the authoritative position,
 including the destination. Click and RightClick set the position to their target and Drag sets it to
-its endpoint.
+its endpoint. Every endpoint is checked against the declared `Viewport` while the complete tape is
+validated, before setup or launch.
 
 `Wait` searches for a substring by default. Add `Match line` for equality with one complete visible
 terminal row after trailing cell padding is removed. This prevents `Wait "history entry 1" Match line`
@@ -87,11 +88,18 @@ event.
 
 `Setup`, `Action`, and `Cleanup` have a finite 30-second default timeout. A trailing
 `Timeout DURATION` overrides it. Each action starts in its own Unix process group; timeout terminates
-the group, and both stdout and stderr are drained with bounded diagnostic retention. Successful
-actions must exit zero. Cleanup runs even after setup, launch, or playback failure when no live owned
-session remains, and all cleanup entries are attempted in reverse declaration order. Cleanup errors
+the group, and both stdout and stderr are drained with bounded diagnostic retention and a finite
+grace. If an escaped process retains either pipe after that grace, the action fails and owned-session
+cleanup proceeds; processes that deliberately create a new Unix session are outside the action's
+owned process group and may remain. Successful actions must exit zero. Cleanup runs even after setup,
+launch, or playback failure when no live owned session remains, and all cleanup entries are attempted
+in reverse declaration order. Cleanup errors
 follow rather than replace the primary error. Write cleanup actions to tolerate partially completed
 setup and repeated use.
+
+Successful `play --json` receipts require UTF-8 tape and recording paths. On Unix, an incompatible
+path is rejected after complete source validation but before Setup or Launch, so receipt encoding
+cannot fail after lifecycle side effects.
 
 ## Example
 

--- a/docs/tape-scripting.md
+++ b/docs/tape-scripting.md
@@ -37,6 +37,7 @@ All header directives must precede `Launch`:
 | `Cwd PATH` | Launch and action working directory; defaults to the tape directory. |
 | `Env KEY VALUE` | Add or override one inherited environment value; repeat for multiple keys. |
 | `Record FILE.termctrl` | Opt into a recording, resolved from the tape directory. |
+| `Pointer on\|off` | Opt into version 2 structured pointer recording; `on` requires `Record`. |
 | `Host none\|opentui` | Terminal host profile; defaults to `none`. |
 | `Color auto\|always\|never` | Color environment policy; defaults to `auto`. |
 | `Launch PROGRAM [ARG ...]` | Required application argv; no implicit shell. |
@@ -59,6 +60,10 @@ Steps follow `Launch` in order:
 the normal SGR mouse implementation, so the application must enable mouse tracking. Coordinates are
 application-cell coordinates, not screen pixels.
 
+With `Pointer on`, click and drag also produce structured press, move, and release events in an
+opt-in version 2 recording. Render them with `save --recording ... --pointer` or `video --pointer`.
+Without that directive, tape recordings remain version 1 and render exactly as before.
+
 ## Example
 
 ```text
@@ -69,6 +74,7 @@ Cell 9 18
 Cwd ".."
 Env TTT_SEED "fixed-demo"
 Record "captures/ttt.termctrl"
+Pointer on
 Color always
 Launch "cargo" "run" "--release" "--bin" "ttt"
 

--- a/schemas/recording-entry-v2.schema.json
+++ b/schemas/recording-entry-v2.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/anomalyco/terminal-control/schemas/recording-entry-v2.schema.json",
   "title": "Terminal Control recording JSON Lines entry v2",
-  "description": "Version 2 extends the version 1 timeline with opt-in structured pointer events.",
+  "description": "Version 2 extends the version 1 timeline with opt-in structured pointer events, including optional button evidence for secondary clicks.",
   "oneOf": [
     { "$ref": "#/$defs/header" },
     { "$ref": "#/$defs/output" },
@@ -84,7 +84,11 @@
         "at_ms": { "type": "integer", "minimum": 0 },
         "x": { "$ref": "#/$defs/dimension" },
         "y": { "$ref": "#/$defs/dimension" },
-        "phase": { "enum": ["press", "move", "release"] }
+        "phase": { "enum": ["press", "move", "release"] },
+        "button": {
+          "description": "Pointer button when it is not the default primary button. Missing means primary.",
+          "enum": ["primary", "secondary"]
+        }
       }
     }
   }

--- a/schemas/recording-entry-v2.schema.json
+++ b/schemas/recording-entry-v2.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/anomalyco/terminal-control/schemas/recording-entry-v2.schema.json",
+  "title": "Terminal Control recording JSON Lines entry v2",
+  "description": "Version 2 extends the version 1 timeline with opt-in structured pointer events.",
+  "oneOf": [
+    { "$ref": "#/$defs/header" },
+    { "$ref": "#/$defs/output" },
+    { "$ref": "#/$defs/input" },
+    { "$ref": "#/$defs/resize" },
+    { "$ref": "#/$defs/marker" },
+    { "$ref": "#/$defs/pointer" }
+  ],
+  "$defs": {
+    "dimension": { "type": "integer", "minimum": 0, "maximum": 65535 },
+    "terminalDimension": { "type": "integer", "minimum": 1, "maximum": 65535 },
+    "byteArray": {
+      "type": "array",
+      "items": { "type": "integer", "minimum": 0, "maximum": 255 }
+    },
+    "header": {
+      "type": "object",
+      "required": ["type", "version", "cols", "rows", "cell_width", "cell_height"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "header" },
+        "version": { "const": 2 },
+        "cols": { "$ref": "#/$defs/terminalDimension" },
+        "rows": { "$ref": "#/$defs/terminalDimension" },
+        "cell_width": { "$ref": "#/$defs/dimension" },
+        "cell_height": { "$ref": "#/$defs/dimension" }
+      }
+    },
+    "output": {
+      "type": "object",
+      "required": ["type", "at_ms", "bytes"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "output" },
+        "at_ms": { "type": "integer", "minimum": 0 },
+        "bytes": { "$ref": "#/$defs/byteArray" }
+      }
+    },
+    "input": {
+      "type": "object",
+      "required": ["type", "at_ms", "origin", "bytes"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "input" },
+        "at_ms": { "type": "integer", "minimum": 0 },
+        "origin": { "enum": ["client", "host"] },
+        "bytes": { "$ref": "#/$defs/byteArray" }
+      }
+    },
+    "resize": {
+      "type": "object",
+      "required": ["type", "at_ms", "cols", "rows", "cell_width", "cell_height"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "resize" },
+        "at_ms": { "type": "integer", "minimum": 0 },
+        "cols": { "$ref": "#/$defs/terminalDimension" },
+        "rows": { "$ref": "#/$defs/terminalDimension" },
+        "cell_width": { "$ref": "#/$defs/dimension" },
+        "cell_height": { "$ref": "#/$defs/dimension" }
+      }
+    },
+    "marker": {
+      "type": "object",
+      "required": ["type", "at_ms", "name"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "marker" },
+        "at_ms": { "type": "integer", "minimum": 0 },
+        "name": { "type": "string", "minLength": 1 }
+      }
+    },
+    "pointer": {
+      "type": "object",
+      "required": ["type", "at_ms", "x", "y", "phase"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "pointer" },
+        "at_ms": { "type": "integer", "minimum": 0 },
+        "x": { "$ref": "#/$defs/dimension" },
+        "y": { "$ref": "#/$defs/dimension" },
+        "phase": { "enum": ["press", "move", "release"] }
+      }
+    }
+  }
+}

--- a/skills/terminal-control/SKILL.md
+++ b/skills/terminal-control/SKILL.md
@@ -44,9 +44,14 @@ before Launch and reverse-order cleanup runs only after the owned session is con
 including safe failure paths. Relative paths resolve from the tape directory. The `.tape` authoring
 source is distinct from any private `.termctrl`
 recording it creates; inspect that recording and run `video --edit` as a separate phase.
-Add `Pointer on` only when the demo needs structured click and drag overlays. It requires `Record`,
+Add `Pointer on` only when the demo needs structured click, move, and drag overlays. It requires `Record`,
 writes opt-in recording version 2, and is rendered only with `--pointer`; ordinary recordings remain
 version 1. Pointer capture currently applies to direct named sessions, not composed workspaces.
+Use `Move X Y [Steps N] [Pace DURATION]` for smooth unpressed travel. The first Move establishes the
+position; later Moves interpolate, and Click/Drag update the same position. Bare `--pointer` fades as
+before. Use `--pointer=persistent` when a long presentation hold should retain the latest position;
+click feedback remains brief and no pointer appears before the first event. Do not confuse this
+render choice with the tape's `Pointer on` capture policy.
 
 Enter a visible workspace that humans and agents control together:
 
@@ -107,6 +112,7 @@ output is a rendered snapshot; pane-targeted ANSI is the original pane stream.
 - Use `save --format ... --out ...` only when a persisted artifact is required.
 - Use `video` only after explicitly recording a timeline with `--record`.
 - Use `--record-pointer` plus `--pointer` only when graphical mouse causality is part of the evidence.
+- Use persistent pointer rendering only when the latest target must remain legible through idle holds.
 - Use `play` when a repeatable interaction belongs in a reviewed `.tape` source file.
 
 Do not treat logs as the visible state of an alternate-screen TUI.

--- a/skills/terminal-control/SKILL.md
+++ b/skills/terminal-control/SKILL.md
@@ -164,6 +164,8 @@ to bottom. For a workspace, coordinates are local to the selected pane or the pa
 release. `drag` sends a primary press, linearly interpolated held-button motion events including the
 destination, and release; tune the event count with `--steps` and their interval with `--pace-ms`.
 Coordinates are checked against the actual target viewport before input or pointer evidence is sent.
+The daemon resolves selected-pane and named-window targets and performs that check in the same
+mutation as the PTY write; restart the named session if an older daemon lacks viewport-safe mouse input.
 The application must have enabled mouse tracking.
 
 ## Operate OpenTUI Applications

--- a/skills/terminal-control/SKILL.md
+++ b/skills/terminal-control/SKILL.md
@@ -29,6 +29,20 @@ termctrl stop app
 
 Always stop named sessions after use unless the user explicitly wants the live process retained.
 
+Use a checked-in `.tape` when the interaction itself should be repeatable as a deterministic demo:
+
+```bash
+termctrl play demos/app.tape
+```
+
+`play` validates the complete source before launching its named session. Tape steps reuse the normal
+`wait`, paced text/key input, click, drag, marker, recording, and stop behavior. Prefer `Wait` for
+state transitions and use `Sleep` only for a deliberate presentation hold. An `Action` is an explicit
+argv-based host command for controlled fixture changes; it does not invoke a shell, but the tape is
+still executable input and must be trusted. Relative paths resolve from the tape directory. A failed
+play stops the session it owns. The `.tape` authoring source is distinct from any private `.termctrl`
+recording it creates; inspect that recording and run `video --edit` as a separate phase.
+
 Enter a visible workspace that humans and agents control together:
 
 ```bash
@@ -87,6 +101,7 @@ output is a rendered snapshot; pane-targeted ANSI is the original pane stream.
 - Use `logs` for readable retained output from normal-screen tools and log-like commands.
 - Use `save --format ... --out ...` only when a persisted artifact is required.
 - Use `video` only after explicitly recording a timeline with `--record`.
+- Use `play` when a repeatable interaction belongs in a reviewed `.tape` source file.
 
 Do not treat logs as the visible state of an alternate-screen TUI.
 

--- a/skills/terminal-control/SKILL.md
+++ b/skills/terminal-control/SKILL.md
@@ -41,9 +41,10 @@ state transitions and use `Sleep` only for a deliberate presentation hold. `Setu
 `Cleanup` are explicit argv-based host commands for controlled fixture changes; they do not
 implicitly invoke a shell, default to a 30-second timeout, and retain bounded diagnostics. Setup runs
 before Launch and reverse-order cleanup runs only after the owned session is confirmed stopped,
-including safe failure paths. Relative paths resolve from the tape directory. The `.tape` authoring
-source is distinct from any private `.termctrl`
-recording it creates; inspect that recording and run `video --edit` as a separate phase.
+including safe failure paths. Action output-pipe drain is also finite; an escaped descendant retaining
+a pipe fails the action rather than blocking cleanup indefinitely. Relative paths resolve from the
+tape directory. The `.tape` authoring source is distinct from any private `.termctrl` recording it
+creates; inspect that recording and run `video --edit` as a separate phase.
 Add `Pointer on` only when the demo needs structured click, move, and drag overlays. It requires `Record`,
 writes opt-in recording version 2, and is rendered only with `--pointer`; ordinary recordings remain
 version 1. Pointer capture currently applies to direct named sessions, not composed workspaces.
@@ -118,6 +119,7 @@ output is a rendered snapshot; pane-targeted ANSI is the original pane stream.
 - Use persistent pointer rendering only when the latest target must remain legible through idle holds.
 - Use `play` when a repeatable interaction belongs in a reviewed `.tape` source file.
 - Use `play --json` when a caller needs stable success fields, or `--quiet` when it needs no stdout.
+  JSON mode requires UTF-8 tape and recording paths and checks them before lifecycle side effects.
 
 Do not treat logs as the visible state of an alternate-screen TUI.
 
@@ -161,6 +163,7 @@ to bottom. For a workspace, coordinates are local to the selected pane or the pa
 `--pane`/`--window`; do not include tab chrome or pane borders. `click` sends a primary press and
 release. `drag` sends a primary press, linearly interpolated held-button motion events including the
 destination, and release; tune the event count with `--steps` and their interval with `--pace-ms`.
+Coordinates are checked against the actual target viewport before input or pointer evidence is sent.
 The application must have enabled mouse tracking.
 
 ## Operate OpenTUI Applications

--- a/skills/terminal-control/SKILL.md
+++ b/skills/terminal-control/SKILL.md
@@ -48,7 +48,10 @@ Add `Pointer on` only when the demo needs structured click, move, and drag overl
 writes opt-in recording version 2, and is rendered only with `--pointer`; ordinary recordings remain
 version 1. Pointer capture currently applies to direct named sessions, not composed workspaces.
 Use `Move X Y [Steps N] [Pace DURATION]` for smooth unpressed travel. The first Move establishes the
-position; later Moves interpolate, and Click/Drag update the same position. Bare `--pointer` fades as
+position; later Moves interpolate, and Click/RightClick/Drag update the same position. `RightClick X Y`
+emits a secondary click and retains button evidence when `Pointer on` is enabled. `Key` accepts the
+same input spellings as live `send`, including `shift+enter`. Use `Wait TEXT Match line` when a complete
+visible row must match rather than a substring. Bare `--pointer` fades as
 before. Use `--pointer=persistent` when a long presentation hold should retain the latest position;
 click feedback remains brief and no pointer appears before the first event. Do not confuse this
 render choice with the tape's `Pointer on` capture policy.
@@ -114,6 +117,7 @@ output is a rendered snapshot; pane-targeted ANSI is the original pane stream.
 - Use `--record-pointer` plus `--pointer` only when graphical mouse causality is part of the evidence.
 - Use persistent pointer rendering only when the latest target must remain legible through idle holds.
 - Use `play` when a repeatable interaction belongs in a reviewed `.tape` source file.
+- Use `play --json` when a caller needs stable success fields, or `--quiet` when it needs no stdout.
 
 Do not treat logs as the visible state of an alternate-screen TUI.
 

--- a/skills/terminal-control/SKILL.md
+++ b/skills/terminal-control/SKILL.md
@@ -37,10 +37,12 @@ termctrl play demos/app.tape
 
 `play` validates the complete source before launching its named session. Tape steps reuse the normal
 `wait`, paced text/key input, click, drag, marker, recording, and stop behavior. Prefer `Wait` for
-state transitions and use `Sleep` only for a deliberate presentation hold. An `Action` is an explicit
-argv-based host command for controlled fixture changes; it does not invoke a shell, but the tape is
-still executable input and must be trusted. Relative paths resolve from the tape directory. A failed
-play stops the session it owns. The `.tape` authoring source is distinct from any private `.termctrl`
+state transitions and use `Sleep` only for a deliberate presentation hold. `Setup`, `Action`, and
+`Cleanup` are explicit argv-based host commands for controlled fixture changes; they do not
+implicitly invoke a shell, default to a 30-second timeout, and retain bounded diagnostics. Setup runs
+before Launch and reverse-order cleanup runs only after the owned session is confirmed stopped,
+including safe failure paths. Relative paths resolve from the tape directory. The `.tape` authoring
+source is distinct from any private `.termctrl`
 recording it creates; inspect that recording and run `video --edit` as a separate phase.
 Add `Pointer on` only when the demo needs structured click and drag overlays. It requires `Record`,
 writes opt-in recording version 2, and is rendered only with `--pointer`; ordinary recordings remain

--- a/skills/terminal-control/SKILL.md
+++ b/skills/terminal-control/SKILL.md
@@ -118,10 +118,19 @@ Send plain text with `text:<value>` and named keys as separate input atoms:
 termctrl send app text:/connect enter
 termctrl send app down enter
 termctrl send app ctrl-c
+termctrl click app 12 4
+termctrl drag app 12 4 30 4
 printf '%s' 'multiline prompt' | termctrl send app --stdin
 ```
 
 Use `wait` after sending input instead of sleeping or assuming that the interface has updated.
+
+Mouse coordinates are zero-based application cells: X increases from left to right and Y from top
+to bottom. For a workspace, coordinates are local to the selected pane or the pane targeted with
+`--pane`/`--window`; do not include tab chrome or pane borders. `click` sends a primary press and
+release. `drag` sends a primary press, linearly interpolated held-button motion events including the
+destination, and release; tune the event count with `--steps` and their interval with `--pace-ms`.
+The application must have enabled mouse tracking.
 
 ## Operate OpenTUI Applications
 

--- a/skills/terminal-control/SKILL.md
+++ b/skills/terminal-control/SKILL.md
@@ -42,6 +42,9 @@ argv-based host command for controlled fixture changes; it does not invoke a she
 still executable input and must be trusted. Relative paths resolve from the tape directory. A failed
 play stops the session it owns. The `.tape` authoring source is distinct from any private `.termctrl`
 recording it creates; inspect that recording and run `video --edit` as a separate phase.
+Add `Pointer on` only when the demo needs structured click and drag overlays. It requires `Record`,
+writes opt-in recording version 2, and is rendered only with `--pointer`; ordinary recordings remain
+version 1. Pointer capture currently applies to direct named sessions, not composed workspaces.
 
 Enter a visible workspace that humans and agents control together:
 
@@ -101,6 +104,7 @@ output is a rendered snapshot; pane-targeted ANSI is the original pane stream.
 - Use `logs` for readable retained output from normal-screen tools and log-like commands.
 - Use `save --format ... --out ...` only when a persisted artifact is required.
 - Use `video` only after explicitly recording a timeline with `--record`.
+- Use `--record-pointer` plus `--pointer` only when graphical mouse causality is part of the evidence.
 - Use `play` when a repeatable interaction belongs in a reviewed `.tape` source file.
 
 Do not treat logs as the visible state of an alternate-screen TUI.

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,6 +164,7 @@ the column from left to right and Y is the row from top to bottom. Workspace coo
 to the targeted pane and exclude workspace chrome and borders. Target the selected pane by default,
 one stable pane with `--pane`, or one named window's active pane with `--window`. The application
 must have mouse tracking enabled. X and Y must be inside the actual target viewport.
+The target is resolved and coordinates are checked by the current session daemon immediately before input.
 Direct sessions started with `--record-pointer` also retain this click as a structured event.
 
 Examples:
@@ -177,6 +178,7 @@ number of motion events, including the destination; short drags may emit the sam
 once. Target the selected pane by default, one stable pane with `--pane`, or one named window's
 active pane with `--window`. The application must have mouse tracking enabled.
 Both endpoints must be inside the actual target viewport.
+The target is resolved and coordinates are checked by the current session daemon immediately before input.
 Direct sessions started with `--record-pointer` also retain structured press, movement, and release.
 
 Examples:

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,11 +80,14 @@ Play validates an entire UTF-8 .tape file, then runs its deterministic named-ses
 files are line-oriented source programs; they are distinct from the private .termctrl recording
 timelines they may produce. Relative Cwd and Record paths resolve from the tape's directory.
 
-Use Wait for application readiness and Sleep only for deliberate presentation holds. Action runs
-an explicit argv vector on the host with the tape cwd and environment; it never invokes a shell.
+Use Wait for application readiness and Sleep only for deliberate presentation holds. Setup, Action,
+and Cleanup run explicit argv vectors with a finite 30-second default timeout and bounded output;
+they never implicitly invoke a shell. Setup runs before Launch. Cleanup runs in reverse declaration
+order after the owned session stops, including failure paths where session shutdown is confirmed.
 `Pointer on` requires Record and captures structured click and drag events for optional rendering.
-Any failed step reports its tape line and stops the session owned by this play invocation. Video
-rendering remains a separate `termctrl video RECORDING --edit PLAN` phase.
+Add `Timeout DURATION` to any host action when the default is unsuitable. Cleanup errors are reported
+after the primary playback error. Video rendering remains a separate
+`termctrl video RECORDING --edit PLAN` phase.
 
 Example:
   termctrl play demos/opencode.tape";

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,8 +85,9 @@ timelines they may produce. Relative Cwd and Record paths resolve from the tape'
 
 Use Wait for application readiness and Sleep only for deliberate presentation holds. Setup, Action,
 and Cleanup run explicit argv vectors with a finite 30-second default timeout and bounded output;
-they never implicitly invoke a shell. Setup runs before Launch. Cleanup runs in reverse declaration
-order after the owned session stops, including failure paths where session shutdown is confirmed.
+they never implicitly invoke a shell. Output pipes also have a finite drain grace, so an escaped
+descendant cannot block cleanup by retaining them. Setup runs before Launch. Cleanup runs in reverse
+declaration order after the owned session stops, including failure paths where shutdown is confirmed.
 `Pointer on` requires Record and captures structured click, move, and drag events for rendering.
 Move sends smooth unpressed motion from the last tape pointer position; the first Move establishes it.
 RightClick sends a secondary click and retains its button in pointer-enabled recordings. Key accepts
@@ -96,7 +97,8 @@ Add `Timeout DURATION` to any host action when the default is unsuitable. Cleanu
 after the primary playback error. Video rendering remains a separate
 `termctrl video RECORDING --edit PLAN` phase.
 Successful playback prints the canonical tape path and recording path, when present. Use `--json`
-for a stable structured receipt or `--quiet` when stdout must remain empty.
+for a stable structured receipt or `--quiet` when stdout must remain empty. JSON receipt paths must
+be UTF-8 and are checked before setup or launch.
 
 Example:
   termctrl play demos/opencode.tape";
@@ -161,7 +163,7 @@ Click sends a primary mouse press and release using zero-based application-cell 
 the column from left to right and Y is the row from top to bottom. Workspace coordinates are local
 to the targeted pane and exclude workspace chrome and borders. Target the selected pane by default,
 one stable pane with `--pane`, or one named window's active pane with `--window`. The application
-must have mouse tracking enabled.
+must have mouse tracking enabled. X and Y must be inside the actual target viewport.
 Direct sessions started with `--record-pointer` also retain this click as a structured event.
 
 Examples:
@@ -174,6 +176,7 @@ TO. Coordinates use the same zero-based, pane-local convention as `click`. `--st
 number of motion events, including the destination; short drags may emit the same cell more than
 once. Target the selected pane by default, one stable pane with `--pane`, or one named window's
 active pane with `--window`. The application must have mouse tracking enabled.
+Both endpoints must be inside the actual target viewport.
 Direct sessions started with `--record-pointer` also retain structured press, movement, and release.
 
 Examples:
@@ -1113,18 +1116,10 @@ fn main() -> Result<()> {
             println!("{}", args.name);
         }
         Command::Play(args) => {
-            let receipt = tape::play(&args.input)?;
+            let receipt = tape::play(&args.input, args.json)?;
             if !args.quiet {
                 if args.json {
-                    println!(
-                        "{}",
-                        serde_json::to_string(&serde_json::json!({
-                            "status": "ok",
-                            "tape": receipt.source,
-                            "session": receipt.session,
-                            "recording": receipt.recording,
-                        }))?
-                    );
+                    println!("{}", serde_json::to_string(&receipt)?);
                 } else {
                     println!("played {}", receipt.source.display());
                     if let Some(recording) = receipt.recording {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,8 @@ Examples:
   termctrl run
   termctrl attach workspace
   termctrl wait demo '/connect' && termctrl send demo text:/connect enter
+  termctrl click demo 12 4
+  termctrl drag demo 12 4 30 4
   termctrl show demo
   termctrl show demo --format semantic
   termctrl save demo --format png --out captures/provider.png
@@ -122,6 +124,28 @@ Examples:
   printf '%s' 'a multiline prompt' | termctrl send demo --stdin
   termctrl send demo --pace-ms 35 'text:Write a terminal haiku.' enter";
 
+const CLICK_HELP: &str = "\
+Click sends a primary mouse press and release using zero-based application-cell coordinates: X is
+the column from left to right and Y is the row from top to bottom. Workspace coordinates are local
+to the targeted pane and exclude workspace chrome and borders. Target the selected pane by default,
+one stable pane with `--pane`, or one named window's active pane with `--window`. The application
+must have mouse tracking enabled.
+
+Examples:
+  termctrl click demo 12 4
+  termctrl click workspace 3 8 --pane 2";
+
+const DRAG_HELP: &str = "\
+Drag sends a primary mouse press at FROM, linearly interpolated held-button motion, and a release at
+TO. Coordinates use the same zero-based, pane-local convention as `click`. `--steps` controls the
+number of motion events, including the destination; short drags may emit the same cell more than
+once. Target the selected pane by default, one stable pane with `--pane`, or one named window's
+active pane with `--window`. The application must have mouse tracking enabled.
+
+Examples:
+  termctrl drag demo 12 4 30 4
+  termctrl drag workspace 3 8 18 8 --pane 2 --steps 6";
+
 const VIDEO_HELP: &str = "\
 Replay a recording produced by `termctrl start --record` into a video artifact. Without `--edit`,
 the video preserves observed timing. For a concise annotated demo, add named moments while recording
@@ -205,6 +229,12 @@ enum Command {
     /// Send ordered input to a named session.
     #[command(after_help = SEND_HELP)]
     Send(SendArgs),
+    /// Send a primary mouse click to a live session.
+    #[command(after_help = CLICK_HELP)]
+    Click(ClickArgs),
+    /// Send a primary mouse drag to a live session.
+    #[command(after_help = DRAG_HELP)]
+    Drag(DragArgs),
     /// Inspect lifecycle state and launch settings of a named session.
     Status(StatusArgs),
     /// List named local sessions and their states.
@@ -507,6 +537,48 @@ struct SendArgs {
     /// Ordered input: key name or `text:<value>`.
     #[arg(value_name = "INPUT")]
     input: Vec<String>,
+}
+
+#[derive(Args)]
+struct ClickArgs {
+    /// Name of a running session.
+    name: String,
+    /// Zero-based application column.
+    x: u16,
+    /// Zero-based application row.
+    y: u16,
+    /// Target one workspace pane instead of the selected pane.
+    #[arg(long)]
+    pane: Option<u32>,
+    /// Target one named workspace window's active pane.
+    #[arg(long, conflicts_with = "pane")]
+    window: Option<String>,
+}
+
+#[derive(Args)]
+struct DragArgs {
+    /// Name of a running session.
+    name: String,
+    /// Zero-based starting application column.
+    from_x: u16,
+    /// Zero-based starting application row.
+    from_y: u16,
+    /// Zero-based destination application column.
+    to_x: u16,
+    /// Zero-based destination application row.
+    to_y: u16,
+    /// Number of interpolated motion events, including the destination.
+    #[arg(long, default_value_t = 10, value_parser = clap::value_parser!(u16).range(1..=1000))]
+    steps: u16,
+    /// Delay between mouse events.
+    #[arg(long, default_value_t = 8, value_name = "MS")]
+    pace_ms: u64,
+    /// Target one workspace pane instead of the selected pane.
+    #[arg(long)]
+    pane: Option<u32>,
+    /// Target one named workspace window's active pane.
+    #[arg(long, conflicts_with = "pane")]
+    window: Option<String>,
 }
 
 #[derive(Args)]
@@ -955,6 +1027,8 @@ fn main() -> Result<()> {
             )?;
         }
         Command::Send(args) => send(args)?,
+        Command::Click(args) => click(args)?,
+        Command::Drag(args) => drag(args)?,
         Command::Status(args) => status(args)?,
         Command::List(args) => list(args)?,
         Command::Prune(args) => prune(args)?,
@@ -1349,6 +1423,65 @@ fn send(args: SendArgs) -> Result<()> {
         Duration::from_millis(args.pace_ms),
     )?;
     Ok(())
+}
+
+fn click(args: ClickArgs) -> Result<()> {
+    session::send_to_in(
+        &args.name,
+        args.window,
+        args.pane,
+        mouse_click(args.x, args.y)?,
+        Duration::ZERO,
+    )
+}
+
+fn drag(args: DragArgs) -> Result<()> {
+    session::send_to_in(
+        &args.name,
+        args.window,
+        args.pane,
+        mouse_drag(
+            (args.from_x, args.from_y),
+            (args.to_x, args.to_y),
+            args.steps,
+        )?,
+        Duration::from_millis(args.pace_ms),
+    )
+}
+
+fn mouse_click(x: u16, y: u16) -> Result<Vec<Vec<u8>>> {
+    Ok(vec![sgr_mouse(0, x, y, b'M')?, sgr_mouse(0, x, y, b'm')?])
+}
+
+fn mouse_drag(from: (u16, u16), to: (u16, u16), steps: u16) -> Result<Vec<Vec<u8>>> {
+    if steps == 0 {
+        bail!("drag steps must be greater than zero");
+    }
+    let mut input = Vec::with_capacity(usize::from(steps) + 2);
+    input.push(sgr_mouse(0, from.0, from.1, b'M')?);
+    for step in 1..=steps {
+        let x = interpolate(from.0, to.0, step, steps);
+        let y = interpolate(from.1, to.1, step, steps);
+        input.push(sgr_mouse(32, x, y, b'M')?);
+    }
+    input.push(sgr_mouse(0, to.0, to.1, b'm')?);
+    Ok(input)
+}
+
+fn interpolate(from: u16, to: u16, step: u16, steps: u16) -> u16 {
+    let from = i64::from(from);
+    let distance = i64::from(to) - from;
+    (from + distance * i64::from(step) / i64::from(steps)) as u16
+}
+
+fn sgr_mouse(button: u8, x: u16, y: u16, final_byte: u8) -> Result<Vec<u8>> {
+    let x = x
+        .checked_add(1)
+        .context("mouse x coordinate exceeds the SGR protocol limit")?;
+    let y = y
+        .checked_add(1)
+        .context("mouse y coordinate exceeds the SGR protocol limit")?;
+    Ok(format!("\x1b[<{button};{x};{y}{}", char::from(final_byte)).into_bytes())
 }
 
 fn status(args: StatusArgs) -> Result<()> {
@@ -2302,5 +2435,77 @@ mod tests {
             session_input(&["text:hi".to_owned(), "enter".to_owned()], true).unwrap(),
             vec![b"h".to_vec(), b"i".to_vec(), b"\r".to_vec()]
         );
+    }
+
+    #[test]
+    fn parses_mouse_control_commands() {
+        let cli = Cli::try_parse_from(["termctrl", "click", "workspace", "12", "4", "--pane", "2"])
+            .unwrap();
+        let Command::Click(args) = cli.command else {
+            panic!("expected click command");
+        };
+        assert_eq!((args.x, args.y, args.pane), (12, 4, Some(2)));
+
+        let cli = Cli::try_parse_from([
+            "termctrl",
+            "drag",
+            "workspace",
+            "12",
+            "4",
+            "30",
+            "8",
+            "--window",
+            "editor",
+            "--steps",
+            "6",
+            "--pace-ms",
+            "0",
+        ])
+        .unwrap();
+        let Command::Drag(args) = cli.command else {
+            panic!("expected drag command");
+        };
+        assert_eq!(
+            (
+                args.from_x,
+                args.from_y,
+                args.to_x,
+                args.to_y,
+                args.steps,
+                args.pace_ms,
+                args.window.as_deref(),
+            ),
+            (12, 4, 30, 8, 6, 0, Some("editor"))
+        );
+
+        assert!(
+            Cli::try_parse_from([
+                "termctrl", "drag", "demo", "0", "0", "1", "1", "--steps", "0",
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn encodes_primary_mouse_click_with_zero_based_cells() {
+        assert_eq!(
+            mouse_click(12, 4).unwrap(),
+            [b"\x1b[<0;13;5M".to_vec(), b"\x1b[<0;13;5m".to_vec()]
+        );
+        assert!(mouse_click(u16::MAX, 0).is_err());
+    }
+
+    #[test]
+    fn encodes_primary_mouse_drag_with_interpolated_motion() {
+        assert_eq!(
+            mouse_drag((0, 2), (4, 0), 2).unwrap(),
+            [
+                b"\x1b[<0;1;3M".to_vec(),
+                b"\x1b[<32;3;2M".to_vec(),
+                b"\x1b[<32;5;1M".to_vec(),
+                b"\x1b[<0;5;1m".to_vec(),
+            ]
+        );
+        assert!(mouse_drag((0, 0), (1, 1), 0).is_err());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+mod tape;
+
 use std::fs;
 use std::io::{self, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
@@ -16,6 +18,7 @@ Examples:
   termctrl show -- my-terminal-app
   termctrl save --format png --out captures/app.png -- my-terminal-app
   termctrl start demo --host opentui -- opencode
+  termctrl play demos/opencode.tape
   termctrl run
   termctrl attach workspace
   termctrl wait demo '/connect' && termctrl send demo text:/connect enter
@@ -69,6 +72,19 @@ Example:
   termctrl show demo
   termctrl save demo --format png --out captures/provider.png
   termctrl stop demo";
+
+const PLAY_HELP: &str = "\
+Play validates an entire UTF-8 .tape file, then runs its deterministic named-session demo. Tape
+files are line-oriented source programs; they are distinct from the private .termctrl recording
+timelines they may produce. Relative Cwd and Record paths resolve from the tape's directory.
+
+Use Wait for application readiness and Sleep only for deliberate presentation holds. Action runs
+an explicit argv vector on the host with the tape cwd and environment; it never invokes a shell.
+Any failed step reports its tape line and stops the session owned by this play invocation. Video
+rendering remains a separate `termctrl video RECORDING --edit PLAN` phase.
+
+Example:
+  termctrl play demos/opencode.tape";
 
 const RUN_HELP: &str = "\
 Run creates or reattaches a visible Terminal Control workspace. With no arguments it uses the
@@ -218,6 +234,9 @@ enum Command {
     /// Start a named persistent terminal application.
     #[command(after_help = START_HELP)]
     Start(StartArgs),
+    /// Play a validated deterministic terminal demo script.
+    #[command(after_help = PLAY_HELP)]
+    Play(PlayArgs),
     /// Enter a visible, agent-controllable terminal workspace.
     #[command(after_help = RUN_HELP)]
     Run(RunArgs),
@@ -447,6 +466,13 @@ struct StartArgs {
     /// Command and arguments to launch, following `--`.
     #[arg(required = true, trailing_var_arg = true, allow_hyphen_values = true)]
     command: Vec<String>,
+}
+
+#[derive(Args)]
+struct PlayArgs {
+    /// UTF-8 Terminal Control tape source; must use the .tape extension.
+    #[arg(value_name = "FILE.tape")]
+    input: PathBuf,
 }
 
 #[derive(Args)]
@@ -1015,6 +1041,7 @@ fn main() -> Result<()> {
             start_session(&args)?;
             println!("{}", args.name);
         }
+        Command::Play(args) => tape::play(&args.input)?,
         Command::Run(args) => run_session(&args)?,
         Command::Attach(args) => attach_session(&args)?,
         Command::Wait(args) => {
@@ -2332,6 +2359,16 @@ mod tests {
 
         assert_eq!(args.name, None);
         assert!(args.command.is_empty());
+    }
+
+    #[test]
+    fn parses_tape_play_command() {
+        let cli = Cli::try_parse_from(["termctrl", "play", "demos/ttt.tape"]).unwrap();
+        let Command::Play(args) = cli.command else {
+            panic!("expected play command");
+        };
+
+        assert_eq!(args.input, PathBuf::from("demos/ttt.tape"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,9 +89,14 @@ they never implicitly invoke a shell. Setup runs before Launch. Cleanup runs in 
 order after the owned session stops, including failure paths where session shutdown is confirmed.
 `Pointer on` requires Record and captures structured click, move, and drag events for rendering.
 Move sends smooth unpressed motion from the last tape pointer position; the first Move establishes it.
+RightClick sends a secondary click and retains its button in pointer-enabled recordings. Key accepts
+the live send vocabulary, including shift+enter. Wait defaults to substring matching; add `Match line`
+when one complete visible row must match exactly.
 Add `Timeout DURATION` to any host action when the default is unsuitable. Cleanup errors are reported
 after the primary playback error. Video rendering remains a separate
 `termctrl video RECORDING --edit PLAN` phase.
+Successful playback prints the canonical tape path and recording path, when present. Use `--json`
+for a stable structured receipt or `--quiet` when stdout must remain empty.
 
 Example:
   termctrl play demos/opencode.tape";
@@ -139,7 +144,8 @@ Example:
 const SEND_HELP: &str = "\
 Send ordered input to a live session. Text uses `text:<value>`; named keys include `enter`,
 `escape`, arrows, `tab`, `shift-tab`, `backspace`, `delete`, `home`, `end`, `page-up`, and
-`page-down`. Use `ctrl-a` through `ctrl-z` for control input such as `ctrl-c` cancellation.
+`page-down`. Modifier chords include `shift+enter`; use `ctrl-a` through `ctrl-z` for control input
+such as `ctrl-c` cancellation.
 Add `--pace-ms 35` when producing a human-readable recording so typed text appears character by
 character in the terminal instead of as one immediate paste. Use `--stdin` to send exact bytes
 from standard input as one burst.
@@ -501,6 +507,12 @@ struct PlayArgs {
     /// UTF-8 Terminal Control tape source; must use the .tape extension.
     #[arg(value_name = "FILE.tape")]
     input: PathBuf,
+    /// Print a stable JSON success receipt.
+    #[arg(long, conflicts_with = "quiet")]
+    json: bool,
+    /// Suppress the success receipt.
+    #[arg(long)]
+    quiet: bool,
 }
 
 #[derive(Args)]
@@ -1100,7 +1112,27 @@ fn main() -> Result<()> {
             start_session(&args)?;
             println!("{}", args.name);
         }
-        Command::Play(args) => tape::play(&args.input)?,
+        Command::Play(args) => {
+            let receipt = tape::play(&args.input)?;
+            if !args.quiet {
+                if args.json {
+                    println!(
+                        "{}",
+                        serde_json::to_string(&serde_json::json!({
+                            "status": "ok",
+                            "tape": receipt.source,
+                            "session": receipt.session,
+                            "recording": receipt.recording,
+                        }))?
+                    );
+                } else {
+                    println!("played {}", receipt.source.display());
+                    if let Some(recording) = receipt.recording {
+                        println!("recording {}", recording.display());
+                    }
+                }
+            }
+        }
         Command::Run(args) => run_session(&args)?,
         Command::Attach(args) => attach_session(&args)?,
         Command::Wait(args) => {
@@ -1548,6 +1580,15 @@ fn mouse_click(x: u16, y: u16) -> Result<Vec<Vec<u8>>> {
         .collect())
 }
 
+fn mouse_secondary_click(x: u16, y: u16) -> Result<Vec<Vec<u8>>> {
+    Ok(
+        mouse_click_events_with_button(x, y, recording::PointerButton::Secondary)?
+            .into_iter()
+            .map(|event| event.bytes)
+            .collect(),
+    )
+}
+
 fn mouse_drag(from: (u16, u16), to: (u16, u16), steps: u16) -> Result<Vec<Vec<u8>>> {
     Ok(mouse_drag_events(from, to, steps)?
         .into_iter()
@@ -1563,18 +1604,32 @@ fn mouse_move(from: Option<(u16, u16)>, to: (u16, u16), steps: u16) -> Result<Ve
 }
 
 fn mouse_click_events(x: u16, y: u16) -> Result<Vec<session::MouseInput>> {
+    mouse_click_events_with_button(x, y, recording::PointerButton::Primary)
+}
+
+fn mouse_click_events_with_button(
+    x: u16,
+    y: u16,
+    button: recording::PointerButton,
+) -> Result<Vec<session::MouseInput>> {
+    let sgr_button = match button {
+        recording::PointerButton::Primary => 0,
+        recording::PointerButton::Secondary => 2,
+    };
     Ok(vec![
         session::MouseInput {
-            bytes: sgr_mouse(0, x, y, b'M')?,
+            bytes: sgr_mouse(sgr_button, x, y, b'M')?,
             x,
             y,
             phase: recording::PointerPhase::Press,
+            button,
         },
         session::MouseInput {
-            bytes: sgr_mouse(0, x, y, b'm')?,
+            bytes: sgr_mouse(sgr_button, x, y, b'm')?,
             x,
             y,
             phase: recording::PointerPhase::Release,
+            button,
         },
     ])
 }
@@ -1593,6 +1648,7 @@ fn mouse_drag_events(
         x: from.0,
         y: from.1,
         phase: recording::PointerPhase::Press,
+        button: recording::PointerButton::Primary,
     });
     for step in 1..=steps {
         let x = interpolate(from.0, to.0, step, steps);
@@ -1602,6 +1658,7 @@ fn mouse_drag_events(
             x,
             y,
             phase: recording::PointerPhase::Move,
+            button: recording::PointerButton::Primary,
         });
     }
     input.push(session::MouseInput {
@@ -1609,6 +1666,7 @@ fn mouse_drag_events(
         x: to.0,
         y: to.1,
         phase: recording::PointerPhase::Release,
+        button: recording::PointerButton::Primary,
     });
     Ok(input)
 }
@@ -1640,6 +1698,7 @@ fn mouse_move_events(
                 x,
                 y,
                 phase: recording::PointerPhase::Move,
+                button: recording::PointerButton::Primary,
             })
         })
         .collect()
@@ -2081,8 +2140,9 @@ fn input_event(event: &str) -> Result<Vec<u8>> {
         "end" => b"\x1b[F".to_vec(),
         "page-up" => b"\x1b[5~".to_vec(),
         "page-down" => b"\x1b[6~".to_vec(),
+        "shift+enter" => b"\x1b[13;2u".to_vec(),
         _ => anyhow::bail!(
-            "unsupported input event {event:?}; use text:<value>, ctrl-a through ctrl-z, enter, escape, arrows, tab, shift-tab, backspace, delete, home, end, page-up, or page-down"
+            "unsupported input event {event:?}; use text:<value>, ctrl-a through ctrl-z, shift+enter, enter, escape, arrows, tab, shift-tab, backspace, delete, home, end, page-up, or page-down"
         ),
     })
 }
@@ -2239,6 +2299,28 @@ mod tests {
             ])
             .unwrap(),
             b"\x03\x1b[Z\x1b[3~"
+        );
+    }
+
+    #[test]
+    fn live_and_tape_input_parser_encodes_shift_enter_chord() {
+        assert_eq!(input_event("shift+enter").unwrap(), b"\x1b[13;2u");
+        assert_eq!(
+            session_input(&["shift+enter".to_owned()], false).unwrap(),
+            [b"\x1b[13;2u".to_vec()]
+        );
+    }
+
+    #[test]
+    fn parses_play_receipt_modes() {
+        let cli = Cli::try_parse_from(["termctrl", "play", "demo.tape", "--json"]).unwrap();
+        let Command::Play(args) = cli.command else {
+            panic!("expected play command");
+        };
+        assert!(args.json);
+        assert!(!args.quiet);
+        assert!(
+            Cli::try_parse_from(["termctrl", "play", "demo.tape", "--json", "--quiet"]).is_err()
         );
     }
 
@@ -2730,6 +2812,15 @@ mod tests {
             [b"\x1b[<0;13;5M".to_vec(), b"\x1b[<0;13;5m".to_vec()]
         );
         assert!(mouse_click(u16::MAX, 0).is_err());
+    }
+
+    #[test]
+    fn encodes_secondary_mouse_click_with_zero_based_cells() {
+        assert_eq!(
+            mouse_secondary_click(12, 4).unwrap(),
+            [b"\x1b[<2;13;5M".to_vec(), b"\x1b[<2;13;5m".to_vec()]
+        );
+        assert!(mouse_secondary_click(u16::MAX, 0).is_err());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,8 @@ The application stays alive until `termctrl stop NAME`, so later commands intera
 same screen and application state. Persistent sessions currently require macOS or Linux. Session
 sockets are local control endpoints protected for the current user; recordings contain terminal
 output plus client and automatic host input, so treat them as sensitive artifacts.
+Add `--record-pointer` with `--record` to write opt-in recording version 2 pointer events. The
+default recording remains version 1.
 
 Example:
   termctrl start demo --host opentui --cols 112 --rows 34 -- opencode
@@ -80,6 +82,7 @@ timelines they may produce. Relative Cwd and Record paths resolve from the tape'
 
 Use Wait for application readiness and Sleep only for deliberate presentation holds. Action runs
 an explicit argv vector on the host with the tape cwd and environment; it never invokes a shell.
+`Pointer on` requires Record and captures structured click and drag events for optional rendering.
 Any failed step reports its tape line and stops the session owned by this play invocation. Video
 rendering remains a separate `termctrl video RECORDING --edit PLAN` phase.
 
@@ -146,6 +149,7 @@ the column from left to right and Y is the row from top to bottom. Workspace coo
 to the targeted pane and exclude workspace chrome and borders. Target the selected pane by default,
 one stable pane with `--pane`, or one named window's active pane with `--window`. The application
 must have mouse tracking enabled.
+Direct sessions started with `--record-pointer` also retain this click as a structured event.
 
 Examples:
   termctrl click demo 12 4
@@ -157,6 +161,7 @@ TO. Coordinates use the same zero-based, pane-local convention as `click`. `--st
 number of motion events, including the destination; short drags may emit the same cell more than
 once. Target the selected pane by default, one stable pane with `--pane`, or one named window's
 active pane with `--window`. The application must have mouse tracking enabled.
+Direct sessions started with `--record-pointer` also retain structured press, movement, and release.
 
 Examples:
   termctrl drag demo 12 4 30 4
@@ -175,6 +180,8 @@ reused. Pass `--include-startup` to retain blank startup or capability negotiati
 input, and markers until the session is closed. Video export requires `ffmpeg` to be installed.
 Pass `--footer` to add a bottom row with the clip caption, elapsed timecode, and TERMINAL CONTROL
 branding; without it, edit-plan captions render as inline annotation rows.
+Use `--pointer` to overlay structured pointer events from a version 2 recording. Pointer capture is
+opt-in at direct-session start and leaves default version 1 recordings and exports unchanged.
 
 Example:
   termctrl start demo --record captures/demo.termctrl -- opencode
@@ -341,6 +348,9 @@ struct RenderArgs {
     /// Hide the terminal cursor in rendered output.
     #[arg(long)]
     hide_cursor: bool,
+    /// Overlay structured pointer state from an opted-in session or version 2 recording.
+    #[arg(long)]
+    pointer: bool,
 }
 
 #[derive(Args)]
@@ -457,6 +467,9 @@ struct StartArgs {
     /// Write timestamped terminal output and client/host input to this private recording file.
     #[arg(long)]
     record: Option<PathBuf>,
+    /// Record structured pointer events and write recording format version 2.
+    #[arg(long, requires = "record")]
+    record_pointer: bool,
     /// Color environment policy for the terminal command.
     #[arg(long, value_enum, default_value = "auto")]
     color: ColorMode,
@@ -858,6 +871,9 @@ struct RestartArgs {
     cwd: Option<PathBuf>,
     #[arg(long)]
     record: Option<PathBuf>,
+    /// Enable structured pointer recording for the restarted session.
+    #[arg(long)]
+    record_pointer: bool,
     #[arg(long, value_enum)]
     color: Option<ColorMode>,
     #[arg(long, value_enum)]
@@ -883,6 +899,8 @@ struct ServeArgs {
     cwd: Option<PathBuf>,
     #[arg(long)]
     record: Option<PathBuf>,
+    #[arg(long)]
+    pointer_recording: bool,
     #[arg(long)]
     opentui_host: bool,
     #[arg(long, value_enum, default_value = "auto")]
@@ -974,6 +992,9 @@ struct VideoArgs {
     /// Include leading contentless startup/terminal negotiation frames.
     #[arg(long)]
     include_startup: bool,
+    /// Overlay recorded pointer movement, click feedback, and inactivity fade.
+    #[arg(long)]
+    pointer: bool,
 }
 
 #[derive(Clone, Copy, ValueEnum)]
@@ -1158,6 +1179,7 @@ fn main() -> Result<()> {
                     tail: Duration::from_millis(args.tail_ms),
                     include_startup: args.include_startup,
                     edit: args.edit,
+                    pointer: args.pointer,
                 },
             )?;
             println!("{}", out.display());
@@ -1190,6 +1212,7 @@ fn main() -> Result<()> {
                     color: args.color.into(),
                     env: Default::default(),
                     inherit_env: true,
+                    pointer_recording: args.pointer_recording,
                 },
             )?;
         }
@@ -1215,6 +1238,7 @@ fn main() -> Result<()> {
                     color: args.color.into(),
                     env: Default::default(),
                     inherit_env: true,
+                    pointer_recording: false,
                 },
                 args.tab_position.into(),
             )?;
@@ -1397,6 +1421,7 @@ fn read_source(args: &SourceArgs, render: &RenderArgs) -> Result<shot_engine::Sh
         color: color.into(),
         env: Default::default(),
         inherit_env: true,
+        pointer_recording: false,
     };
     if args.pipe {
         shot_engine::from_pipe_command(&args.command, args.cwd.as_deref(), &options)
@@ -1453,21 +1478,21 @@ fn send(args: SendArgs) -> Result<()> {
 }
 
 fn click(args: ClickArgs) -> Result<()> {
-    session::send_to_in(
+    session::mouse_to_in(
         &args.name,
         args.window,
         args.pane,
-        mouse_click(args.x, args.y)?,
+        mouse_click_events(args.x, args.y)?,
         Duration::ZERO,
     )
 }
 
 fn drag(args: DragArgs) -> Result<()> {
-    session::send_to_in(
+    session::mouse_to_in(
         &args.name,
         args.window,
         args.pane,
-        mouse_drag(
+        mouse_drag_events(
             (args.from_x, args.from_y),
             (args.to_x, args.to_y),
             args.steps,
@@ -1477,21 +1502,67 @@ fn drag(args: DragArgs) -> Result<()> {
 }
 
 fn mouse_click(x: u16, y: u16) -> Result<Vec<Vec<u8>>> {
-    Ok(vec![sgr_mouse(0, x, y, b'M')?, sgr_mouse(0, x, y, b'm')?])
+    Ok(mouse_click_events(x, y)?
+        .into_iter()
+        .map(|event| event.bytes)
+        .collect())
 }
 
 fn mouse_drag(from: (u16, u16), to: (u16, u16), steps: u16) -> Result<Vec<Vec<u8>>> {
+    Ok(mouse_drag_events(from, to, steps)?
+        .into_iter()
+        .map(|event| event.bytes)
+        .collect())
+}
+
+fn mouse_click_events(x: u16, y: u16) -> Result<Vec<session::MouseInput>> {
+    Ok(vec![
+        session::MouseInput {
+            bytes: sgr_mouse(0, x, y, b'M')?,
+            x,
+            y,
+            phase: recording::PointerPhase::Press,
+        },
+        session::MouseInput {
+            bytes: sgr_mouse(0, x, y, b'm')?,
+            x,
+            y,
+            phase: recording::PointerPhase::Release,
+        },
+    ])
+}
+
+fn mouse_drag_events(
+    from: (u16, u16),
+    to: (u16, u16),
+    steps: u16,
+) -> Result<Vec<session::MouseInput>> {
     if steps == 0 {
         bail!("drag steps must be greater than zero");
     }
     let mut input = Vec::with_capacity(usize::from(steps) + 2);
-    input.push(sgr_mouse(0, from.0, from.1, b'M')?);
+    input.push(session::MouseInput {
+        bytes: sgr_mouse(0, from.0, from.1, b'M')?,
+        x: from.0,
+        y: from.1,
+        phase: recording::PointerPhase::Press,
+    });
     for step in 1..=steps {
         let x = interpolate(from.0, to.0, step, steps);
         let y = interpolate(from.1, to.1, step, steps);
-        input.push(sgr_mouse(32, x, y, b'M')?);
+        input.push(session::MouseInput {
+            bytes: sgr_mouse(32, x, y, b'M')?,
+            x,
+            y,
+            phase: recording::PointerPhase::Move,
+        });
     }
-    input.push(sgr_mouse(0, to.0, to.1, b'm')?);
+    input.push(session::MouseInput {
+        bytes: sgr_mouse(0, to.0, to.1, b'm')?,
+        x: to.0,
+        y: to.1,
+        phase: recording::PointerPhase::Release,
+    });
     Ok(input)
 }
 
@@ -1721,6 +1792,7 @@ fn start_session(args: &StartArgs) -> Result<()> {
         color: args.color.into(),
         env: Default::default(),
         inherit_env: true,
+        pointer_recording: args.record_pointer,
     };
     session::start(
         &args.name,
@@ -1880,6 +1952,7 @@ fn restart_session(args: &RestartArgs) -> Result<()> {
                 matches!(host, HostProfile::Opentui)
             }),
             color: args.color.map_or(previous.color, Into::into),
+            pointer_recording: previous.pointer_recording || args.record_pointer,
             ..shot_engine::Options::default()
         },
     )
@@ -1975,8 +2048,14 @@ fn write_outputs(
         fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
     }
     let enabled = |format| formats.contains(&format);
-    let svg = (enabled(ShotFormat::Svg) || enabled(ShotFormat::Png))
-        .then(|| rendered_svg(captured, args));
+    if args.pointer && !enabled(ShotFormat::Svg) && !enabled(ShotFormat::Png) {
+        bail!("--pointer requires a rendered PNG or SVG format");
+    }
+    let svg = if enabled(ShotFormat::Svg) || enabled(ShotFormat::Png) {
+        Some(rendered_svg(captured, args)?)
+    } else {
+        None
+    };
     if let Some(svg) = svg.as_ref().filter(|_| enabled(ShotFormat::Svg)) {
         let path = out.with_extension("svg");
         fs::write(&path, svg).with_context(|| format!("write {}", path.display()))?;
@@ -2012,7 +2091,7 @@ fn write_stdout(captured: &shot_engine::Shot, args: &RenderArgs, format: ShotFor
         ShotFormat::Txt => captured.frame.text().into_bytes(),
         ShotFormat::Json => serde_json::to_vec_pretty(&captured.frame)?,
         ShotFormat::Ansi => captured.ansi.clone(),
-        ShotFormat::Svg => rendered_svg(captured, args).into_bytes(),
+        ShotFormat::Svg => rendered_svg(captured, args)?.into_bytes(),
         ShotFormat::Png => unreachable!("show validates PNG before reading source"),
         ShotFormat::Semantic => unreachable!("show handles semantic output before reading source"),
     };
@@ -2027,8 +2106,11 @@ fn write_stdout(captured: &shot_engine::Shot, args: &RenderArgs, format: ShotFor
     Ok(())
 }
 
-fn rendered_svg(captured: &shot_engine::Shot, args: &RenderArgs) -> String {
-    render::svg(
+fn rendered_svg(captured: &shot_engine::Shot, args: &RenderArgs) -> Result<String> {
+    if args.pointer && !captured.pointer_recording {
+        bail!("--pointer requires a pointer-enabled named session or version 2 recording");
+    }
+    Ok(render::svg(
         &captured.frame,
         &render::Options {
             cell_width: f32::from(args.cell_width),
@@ -2037,8 +2119,13 @@ fn rendered_svg(captured: &shot_engine::Shot, args: &RenderArgs) -> String {
             padding: args.padding,
             font_family: args.font_family.clone(),
             show_cursor: !args.hide_cursor,
+            pointer: args
+                .pointer
+                .then_some(captured.pointer)
+                .flatten()
+                .and_then(render::PointerOverlay::from_snapshot),
         },
-    )
+    ))
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,10 +44,13 @@ Sources:
 Use --format json, --format ansi, or --format svg for another terminal representation. Use
 `--format semantic` with a named target for optional application-provided UI semantics.
 Use `--at-marker NAME` or `--at-ms MS` with --recording to inspect an exact moment. Use `save`
-to write files.";
+to write files. On pointer-enabled sources, bare `--pointer` fades after inactivity; use
+`--pointer=persistent` to retain the latest position.";
 
 const SAVE_HELP: &str = "\
 Save freezes a visible terminal screen and writes exactly the requested artifact formats.
+On pointer-enabled sources, bare `--pointer` preserves the existing fading overlay behavior;
+`--pointer=persistent` keeps the latest position visible without extending click feedback.
 
 Examples:
   termctrl save demo --format png --out captures/current.png
@@ -84,7 +87,8 @@ Use Wait for application readiness and Sleep only for deliberate presentation ho
 and Cleanup run explicit argv vectors with a finite 30-second default timeout and bounded output;
 they never implicitly invoke a shell. Setup runs before Launch. Cleanup runs in reverse declaration
 order after the owned session stops, including failure paths where session shutdown is confirmed.
-`Pointer on` requires Record and captures structured click and drag events for optional rendering.
+`Pointer on` requires Record and captures structured click, move, and drag events for rendering.
+Move sends smooth unpressed motion from the last tape pointer position; the first Move establishes it.
 Add `Timeout DURATION` to any host action when the default is unsuitable. Cleanup errors are reported
 after the primary playback error. Video rendering remains a separate
 `termctrl video RECORDING --edit PLAN` phase.
@@ -185,6 +189,8 @@ Pass `--footer` to add a bottom row with the clip caption, elapsed timecode, and
 branding; without it, edit-plan captions render as inline annotation rows.
 Use `--pointer` to overlay structured pointer events from a version 2 recording. Pointer capture is
 opt-in at direct-session start and leaves default version 1 recordings and exports unchanged.
+Bare `--pointer` fades after inactivity. `--pointer=persistent` keeps the latest position fully
+opaque while click feedback still expires normally; no overlay precedes the first pointer event.
 
 Example:
   termctrl start demo --record captures/demo.termctrl -- opencode
@@ -351,9 +357,15 @@ struct RenderArgs {
     /// Hide the terminal cursor in rendered output.
     #[arg(long)]
     hide_cursor: bool,
-    /// Overlay structured pointer state from an opted-in session or version 2 recording.
-    #[arg(long)]
-    pointer: bool,
+    /// Overlay structured pointer state; use `--pointer=persistent` to prevent fading.
+    #[arg(
+        long,
+        value_enum,
+        num_args = 0..=1,
+        default_missing_value = "fading",
+        require_equals = true
+    )]
+    pointer: Option<PointerMode>,
 }
 
 #[derive(Args)]
@@ -995,15 +1007,38 @@ struct VideoArgs {
     /// Include leading contentless startup/terminal negotiation frames.
     #[arg(long)]
     include_startup: bool,
-    /// Overlay recorded pointer movement, click feedback, and inactivity fade.
-    #[arg(long)]
-    pointer: bool,
+    /// Overlay recorded pointer movement; use `--pointer=persistent` to prevent fading.
+    #[arg(
+        long,
+        value_enum,
+        num_args = 0..=1,
+        default_missing_value = "fading",
+        require_equals = true
+    )]
+    pointer: Option<PointerMode>,
 }
 
 #[derive(Clone, Copy, ValueEnum)]
 enum HostProfile {
     /// Respond to OpenTUI startup terminal capability queries.
     Opentui,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+enum PointerMode {
+    /// Fade after a short period without pointer input.
+    Fading,
+    /// Keep the most recent pointer position fully visible.
+    Persistent,
+}
+
+impl From<PointerMode> for render::PointerMode {
+    fn from(mode: PointerMode) -> Self {
+        match mode {
+            PointerMode::Fading => Self::Fading,
+            PointerMode::Persistent => Self::Persistent,
+        }
+    }
 }
 
 #[derive(Clone, Copy, ValueEnum)]
@@ -1167,7 +1202,8 @@ fn main() -> Result<()> {
         Command::Stop(args) => session::stop(&args.name)?,
         Command::Video(args) => {
             let out = args.out.clone();
-            recording::video(
+            let pointer_mode = args.pointer.map(Into::into);
+            recording::video_with_pointer_mode(
                 &args.input,
                 &recording::VideoOptions {
                     out: args.out,
@@ -1182,8 +1218,9 @@ fn main() -> Result<()> {
                     tail: Duration::from_millis(args.tail_ms),
                     include_startup: args.include_startup,
                     edit: args.edit,
-                    pointer: args.pointer,
+                    pointer: pointer_mode.is_some(),
                 },
+                pointer_mode,
             )?;
             println!("{}", out.display());
         }
@@ -1518,6 +1555,13 @@ fn mouse_drag(from: (u16, u16), to: (u16, u16), steps: u16) -> Result<Vec<Vec<u8
         .collect())
 }
 
+fn mouse_move(from: Option<(u16, u16)>, to: (u16, u16), steps: u16) -> Result<Vec<Vec<u8>>> {
+    Ok(mouse_move_events(from, to, steps)?
+        .into_iter()
+        .map(|event| event.bytes)
+        .collect())
+}
+
 fn mouse_click_events(x: u16, y: u16) -> Result<Vec<session::MouseInput>> {
     Ok(vec![
         session::MouseInput {
@@ -1567,6 +1611,38 @@ fn mouse_drag_events(
         phase: recording::PointerPhase::Release,
     });
     Ok(input)
+}
+
+fn mouse_move_events(
+    from: Option<(u16, u16)>,
+    to: (u16, u16),
+    steps: u16,
+) -> Result<Vec<session::MouseInput>> {
+    if steps == 0 {
+        bail!("move steps must be greater than zero");
+    }
+    let points = match from {
+        Some(from) => (1..=steps)
+            .map(|step| {
+                (
+                    interpolate(from.0, to.0, step, steps),
+                    interpolate(from.1, to.1, step, steps),
+                )
+            })
+            .collect::<Vec<_>>(),
+        None => vec![to],
+    };
+    points
+        .into_iter()
+        .map(|(x, y)| {
+            Ok(session::MouseInput {
+                bytes: sgr_mouse(35, x, y, b'M')?,
+                x,
+                y,
+                phase: recording::PointerPhase::Move,
+            })
+        })
+        .collect()
 }
 
 fn interpolate(from: u16, to: u16, step: u16, steps: u16) -> u16 {
@@ -2051,7 +2127,7 @@ fn write_outputs(
         fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
     }
     let enabled = |format| formats.contains(&format);
-    if args.pointer && !enabled(ShotFormat::Svg) && !enabled(ShotFormat::Png) {
+    if args.pointer.is_some() && !enabled(ShotFormat::Svg) && !enabled(ShotFormat::Png) {
         bail!("--pointer requires a rendered PNG or SVG format");
     }
     let svg = if enabled(ShotFormat::Svg) || enabled(ShotFormat::Png) {
@@ -2110,7 +2186,7 @@ fn write_stdout(captured: &shot_engine::Shot, args: &RenderArgs, format: ShotFor
 }
 
 fn rendered_svg(captured: &shot_engine::Shot, args: &RenderArgs) -> Result<String> {
-    if args.pointer && !captured.pointer_recording {
+    if args.pointer.is_some() && !captured.pointer_recording {
         bail!("--pointer requires a pointer-enabled named session or version 2 recording");
     }
     Ok(render::svg(
@@ -2122,11 +2198,11 @@ fn rendered_svg(captured: &shot_engine::Shot, args: &RenderArgs) -> Result<Strin
             padding: args.padding,
             font_family: args.font_family.clone(),
             show_cursor: !args.hide_cursor,
-            pointer: args
-                .pointer
-                .then_some(captured.pointer)
-                .flatten()
-                .and_then(render::PointerOverlay::from_snapshot),
+            pointer: args.pointer.and_then(|mode| {
+                captured.pointer.and_then(|pointer| {
+                    render::PointerOverlay::from_snapshot_with_mode(pointer, mode.into())
+                })
+            }),
         },
     ))
 }
@@ -2530,6 +2606,40 @@ mod tests {
     }
 
     #[test]
+    fn pointer_flag_defaults_to_fading_and_accepts_explicit_modes() {
+        let cli = Cli::try_parse_from(["termctrl", "show", "--pointer", "demo", "--format", "svg"])
+            .unwrap();
+        let Command::Show(args) = cli.command else {
+            panic!("expected show command");
+        };
+        assert_eq!(args.render.pointer, Some(PointerMode::Fading));
+        assert_eq!(args.source.name.as_deref(), Some("demo"));
+
+        let cli = Cli::try_parse_from([
+            "termctrl",
+            "save",
+            "demo",
+            "--format",
+            "svg",
+            "--out",
+            "demo.svg",
+            "--pointer=persistent",
+        ])
+        .unwrap();
+        let Command::Save(args) = cli.command else {
+            panic!("expected save command");
+        };
+        assert_eq!(args.render.pointer, Some(PointerMode::Persistent));
+
+        let cli = Cli::try_parse_from(["termctrl", "video", "demo.termctrl", "--pointer=fading"])
+            .unwrap();
+        let Command::Video(args) = cli.command else {
+            panic!("expected video command");
+        };
+        assert_eq!(args.pointer, Some(PointerMode::Fading));
+    }
+
+    #[test]
     fn rejects_settling_options_for_pipe_reads() {
         let cli = Cli::try_parse_from([
             "termctrl",
@@ -2634,5 +2744,19 @@ mod tests {
             ]
         );
         assert!(mouse_drag((0, 0), (1, 1), 0).is_err());
+    }
+
+    #[test]
+    fn encodes_first_and_interpolated_unpressed_mouse_motion() {
+        assert_eq!(
+            mouse_move(None, (4, 2), 10).unwrap(),
+            [b"\x1b[<35;5;3M".to_vec()]
+        );
+        assert_eq!(
+            mouse_move(Some((4, 2)), (8, 0), 2).unwrap(),
+            [b"\x1b[<35;7;2M".to_vec(), b"\x1b[<35;9;1M".to_vec()]
+        );
+        assert!(mouse_move(None, (u16::MAX, 0), 1).is_err());
+        assert!(mouse_move(Some((0, 0)), (1, 1), 0).is_err());
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1274,6 +1274,7 @@ mod tests {
                     max_bytes: 1024,
                     opentui_host: false,
                     color: crate::shot::ColorMode::Auto,
+                    pointer_recording: false,
                 },
             },
         );

--- a/src/recording.rs
+++ b/src/recording.rs
@@ -340,6 +340,18 @@ pub struct VideoOptions {
 }
 
 pub fn video(path: &Path, options: &VideoOptions) -> Result<()> {
+    video_with_pointer_mode(
+        path,
+        options,
+        options.pointer.then_some(render::PointerMode::Fading),
+    )
+}
+
+pub fn video_with_pointer_mode(
+    path: &Path,
+    options: &VideoOptions,
+    pointer_mode: Option<render::PointerMode>,
+) -> Result<()> {
     if options.fps == 0 {
         bail!("--fps must be greater than zero");
     }
@@ -347,7 +359,7 @@ pub fn video(path: &Path, options: &VideoOptions) -> Result<()> {
         bail!("--fps must not exceed {MAX_VIDEO_FPS}");
     }
     let recording = read(path)?;
-    if options.pointer && recording.version != POINTER_FORMAT_VERSION {
+    if pointer_mode.is_some() && recording.version != POINTER_FORMAT_VERSION {
         bail!("--pointer requires a version 2 recording created with pointer capture enabled");
     }
     let states = states(&recording)?;
@@ -392,7 +404,7 @@ pub fn video(path: &Path, options: &VideoOptions) -> Result<()> {
         fs::set_permissions(&temp, fs::Permissions::from_mode(0o700))
             .with_context(|| format!("secure {}", temp.display()))?;
     }
-    let result = render_video_frames(&temp, &recording, &states, &samples, options);
+    let result = render_video_frames(&temp, &recording, &states, &samples, options, pointer_mode);
     let _ = fs::remove_dir_all(&temp);
     result
 }
@@ -878,6 +890,7 @@ fn render_video_frames(
     states: &[VideoFrame],
     samples: &[VideoSample],
     options: &VideoOptions,
+    pointer_mode: Option<render::PointerMode>,
 ) -> Result<()> {
     eprintln!("Rendering {} sampled frames...", samples.len());
     let cols = states
@@ -917,13 +930,8 @@ fn render_video_frames(
             base_keys[sample.state].clone()
         };
         let mut sample_options = render_options.clone();
-        sample_options.pointer = options
-            .pointer
-            .then_some(states[sample.state].pointer)
-            .flatten()
-            .and_then(|pointer| {
-                render::PointerOverlay::from_snapshot(pointer.snapshot(sample.at_ms))
-            });
+        sample_options.pointer =
+            sampled_pointer(states[sample.state].pointer, sample.at_ms, pointer_mode);
         render_or_link(
             &renderer,
             &mut rendered,
@@ -948,6 +956,18 @@ fn render_video_frames(
         bail!("ffmpeg failed while exporting {}", options.out.display());
     }
     Ok(())
+}
+
+fn sampled_pointer(
+    pointer: Option<PointerState>,
+    at_ms: u64,
+    mode: Option<render::PointerMode>,
+) -> Option<render::PointerOverlay> {
+    mode.and_then(|mode| {
+        pointer.and_then(|pointer| {
+            render::PointerOverlay::from_snapshot_with_mode(pointer.snapshot(at_ms), mode)
+        })
+    })
 }
 
 fn render_or_link(
@@ -1527,6 +1547,20 @@ mod tests {
         assert_eq!(pointer.age_ms, 980);
         assert_eq!(pointer.click_age_ms, Some(990));
         assert!(!pointer.pressed);
+    }
+
+    #[test]
+    fn video_pointer_mode_controls_idle_visibility_without_extending_clicks() {
+        let pointer = PointerState::apply(None, 0, 2, 3, PointerPhase::Press);
+        let pointer = PointerState::apply(Some(pointer), 10, 2, 3, PointerPhase::Release);
+
+        assert!(sampled_pointer(Some(pointer), 5_000, Some(render::PointerMode::Fading)).is_none());
+        let persistent =
+            sampled_pointer(Some(pointer), 5_000, Some(render::PointerMode::Persistent)).unwrap();
+        assert_eq!(persistent.opacity, u8::MAX);
+        assert_eq!(persistent.click, 0);
+        assert!(!persistent.pressed);
+        assert!(sampled_pointer(None, 5_000, Some(render::PointerMode::Persistent)).is_none());
     }
 
     #[test]

--- a/src/recording.rs
+++ b/src/recording.rs
@@ -60,6 +60,8 @@ pub enum Entry {
         x: u16,
         y: u16,
         phase: PointerPhase,
+        #[serde(default, skip_serializing_if = "PointerButton::is_primary")]
+        button: PointerButton,
     },
 }
 
@@ -69,6 +71,20 @@ pub enum PointerPhase {
     Press,
     Move,
     Release,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PointerButton {
+    #[default]
+    Primary,
+    Secondary,
+}
+
+impl PointerButton {
+    fn is_primary(&self) -> bool {
+        *self == Self::Primary
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -284,6 +300,16 @@ impl Writer {
     }
 
     pub fn pointer(&mut self, x: u16, y: u16, phase: PointerPhase) -> Result<()> {
+        self.pointer_with_button(x, y, phase, PointerButton::Primary)
+    }
+
+    pub fn pointer_with_button(
+        &mut self,
+        x: u16,
+        y: u16,
+        phase: PointerPhase,
+        button: PointerButton,
+    ) -> Result<()> {
         if self.version != POINTER_FORMAT_VERSION {
             bail!("structured pointer events require a version 2 recording");
         }
@@ -292,6 +318,7 @@ impl Writer {
             x,
             y,
             phase,
+            button,
         })
     }
 
@@ -558,7 +585,9 @@ fn replay(recording: &Recording, cutoff: Option<u64>) -> Result<Replay> {
                 terminal.resize(*cols, *rows, *cell_width, *cell_height)?;
                 *at_ms
             }
-            Entry::Pointer { at_ms, x, y, phase } => {
+            Entry::Pointer {
+                at_ms, x, y, phase, ..
+            } => {
                 if cutoff.is_some_and(|cutoff| *at_ms > cutoff) {
                     continue;
                 }
@@ -1458,6 +1487,8 @@ mod tests {
         writer.pointer(4, 5, PointerPhase::Release).unwrap();
         drop(writer);
 
+        assert!(!fs::read_to_string(&temp).unwrap().contains("\"button\""));
+
         let recording = read(&temp).unwrap();
         let _ = fs::remove_file(temp);
         assert_eq!(recording.version, POINTER_FORMAT_VERSION);
@@ -1479,6 +1510,42 @@ mod tests {
                 Entry::Pointer {
                     x: 4,
                     y: 5,
+                    phase: PointerPhase::Release,
+                    ..
+                }
+            ]
+        ));
+    }
+
+    #[test]
+    fn secondary_pointer_events_retain_button_evidence() {
+        let temp = std::env::temp_dir().join(format!(
+            "termctrl-recording-secondary-v2-{}",
+            std::process::id()
+        ));
+        let mut writer = Writer::new_with_pointer(&temp, Instant::now(), 20, 10, 9, 18).unwrap();
+        writer
+            .pointer_with_button(6, 7, PointerPhase::Press, PointerButton::Secondary)
+            .unwrap();
+        writer
+            .pointer_with_button(6, 7, PointerPhase::Release, PointerButton::Secondary)
+            .unwrap();
+        drop(writer);
+
+        let text = fs::read_to_string(&temp).unwrap();
+        assert_eq!(text.matches("\"button\":\"secondary\"").count(), 2);
+        let recording = read(&temp).unwrap();
+        let _ = fs::remove_file(temp);
+        assert!(matches!(
+            recording.events.as_slice(),
+            [
+                Entry::Pointer {
+                    button: PointerButton::Secondary,
+                    phase: PointerPhase::Press,
+                    ..
+                },
+                Entry::Pointer {
+                    button: PointerButton::Secondary,
                     phase: PointerPhase::Release,
                     ..
                 }
@@ -1527,12 +1594,14 @@ mod tests {
                     x: 2,
                     y: 3,
                     phase: PointerPhase::Press,
+                    button: PointerButton::Primary,
                 },
                 Entry::Pointer {
                     at_ms: 20,
                     x: 4,
                     y: 5,
                     phase: PointerPhase::Release,
+                    button: PointerButton::Primary,
                 },
                 Entry::Marker {
                     at_ms: 1000,

--- a/src/recording.rs
+++ b/src/recording.rs
@@ -14,8 +14,14 @@ use crate::shot::Shot;
 use crate::terminal_core::{SCROLLBACK_ROWS, TerminalCore};
 
 const MAX_VIDEO_FPS: u32 = 1000;
-/// Schema version written in the header of every `.termctrl` recording.
+/// Default schema version written by recordings without pointer capture.
 pub const FORMAT_VERSION: u8 = 1;
+/// Schema version used only when structured pointer capture is explicitly enabled.
+pub const POINTER_FORMAT_VERSION: u8 = 2;
+
+pub const POINTER_HOLD_MS: u64 = 500;
+pub const POINTER_FADE_MS: u64 = 700;
+pub const POINTER_CLICK_MS: u64 = 220;
 
 /// One JSON Lines entry in a `.termctrl` recording timeline.
 #[derive(Serialize, Deserialize)]
@@ -49,6 +55,79 @@ pub enum Entry {
         at_ms: u64,
         name: String,
     },
+    Pointer {
+        at_ms: u64,
+        x: u16,
+        y: u16,
+        phase: PointerPhase,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PointerPhase {
+    Press,
+    Move,
+    Release,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PointerSnapshot {
+    pub x: u16,
+    pub y: u16,
+    pub age_ms: u64,
+    pub pressed: bool,
+    pub click_age_ms: Option<u64>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct PointerState {
+    x: u16,
+    y: u16,
+    at_ms: u64,
+    pressed: bool,
+    click_at_ms: Option<u64>,
+}
+
+impl PointerState {
+    pub(crate) fn apply(
+        previous: Option<Self>,
+        at_ms: u64,
+        x: u16,
+        y: u16,
+        phase: PointerPhase,
+    ) -> Self {
+        let pressed = match phase {
+            PointerPhase::Press => true,
+            PointerPhase::Move => previous.is_some_and(|pointer| pointer.pressed),
+            PointerPhase::Release => false,
+        };
+        let click_at_ms = match phase {
+            PointerPhase::Press => Some(at_ms),
+            PointerPhase::Move | PointerPhase::Release => {
+                previous.and_then(|pointer| pointer.click_at_ms)
+            }
+        };
+        Self {
+            x,
+            y,
+            at_ms,
+            pressed,
+            click_at_ms,
+        }
+    }
+
+    pub(crate) fn snapshot(self, at_ms: u64) -> PointerSnapshot {
+        PointerSnapshot {
+            x: self.x,
+            y: self.y,
+            age_ms: at_ms.saturating_sub(self.at_ms),
+            pressed: self.pressed,
+            click_age_ms: self
+                .click_at_ms
+                .map(|clicked| at_ms.saturating_sub(clicked)),
+        }
+    }
 }
 
 /// Source of bytes written to the application while recording a session.
@@ -62,6 +141,7 @@ pub enum InputOrigin {
 pub struct Writer {
     file: fs::File,
     started: Instant,
+    version: u8,
     poisoned: bool,
 }
 
@@ -73,6 +153,45 @@ impl Writer {
         rows: u16,
         cell_width: u16,
         cell_height: u16,
+    ) -> Result<Self> {
+        Self::new_versioned(
+            path,
+            started,
+            cols,
+            rows,
+            cell_width,
+            cell_height,
+            FORMAT_VERSION,
+        )
+    }
+
+    pub fn new_with_pointer(
+        path: &Path,
+        started: Instant,
+        cols: u16,
+        rows: u16,
+        cell_width: u16,
+        cell_height: u16,
+    ) -> Result<Self> {
+        Self::new_versioned(
+            path,
+            started,
+            cols,
+            rows,
+            cell_width,
+            cell_height,
+            POINTER_FORMAT_VERSION,
+        )
+    }
+
+    fn new_versioned(
+        path: &Path,
+        started: Instant,
+        cols: u16,
+        rows: u16,
+        cell_width: u16,
+        cell_height: u16,
+        version: u8,
     ) -> Result<Self> {
         crate::shot::validate_geometry(rows, cols)?;
         if let Some(parent) = path
@@ -100,7 +219,7 @@ impl Writer {
         serde_json::to_writer(
             &mut file,
             &Entry::Header {
-                version: FORMAT_VERSION,
+                version,
                 cols,
                 rows,
                 cell_width,
@@ -113,6 +232,7 @@ impl Writer {
         Ok(Self {
             file,
             started,
+            version,
             poisoned: false,
         })
     }
@@ -163,6 +283,18 @@ impl Writer {
         })
     }
 
+    pub fn pointer(&mut self, x: u16, y: u16, phase: PointerPhase) -> Result<()> {
+        if self.version != POINTER_FORMAT_VERSION {
+            bail!("structured pointer events require a version 2 recording");
+        }
+        self.write(Entry::Pointer {
+            at_ms: self.started.elapsed().as_millis() as u64,
+            x,
+            y,
+            phase,
+        })
+    }
+
     fn write(&mut self, entry: Entry) -> Result<()> {
         if self.poisoned {
             bail!("recording writer is unavailable after a failed rollback");
@@ -204,6 +336,7 @@ pub struct VideoOptions {
     pub tail: Duration,
     pub include_startup: bool,
     pub edit: Option<PathBuf>,
+    pub pointer: bool,
 }
 
 pub fn video(path: &Path, options: &VideoOptions) -> Result<()> {
@@ -214,6 +347,9 @@ pub fn video(path: &Path, options: &VideoOptions) -> Result<()> {
         bail!("--fps must not exceed {MAX_VIDEO_FPS}");
     }
     let recording = read(path)?;
+    if options.pointer && recording.version != POINTER_FORMAT_VERSION {
+        bail!("--pointer requires a version 2 recording created with pointer capture enabled");
+    }
     let states = states(&recording)?;
     let states = visible_states(&states, options.include_startup);
     if states.is_empty() {
@@ -263,6 +399,7 @@ pub fn video(path: &Path, options: &VideoOptions) -> Result<()> {
 
 /// Parsed recording metadata and timeline entries.
 pub struct Recording {
+    pub version: u8,
     pub cols: u16,
     pub rows: u16,
     pub cell_width: u16,
@@ -295,7 +432,7 @@ pub fn read(path: &Path) -> Result<Recording> {
     else {
         bail!("recording does not start with a header");
     };
-    if version != FORMAT_VERSION {
+    if !matches!(version, FORMAT_VERSION | POINTER_FORMAT_VERSION) {
         bail!("unsupported recording version {version}");
     }
     crate::shot::validate_geometry(rows, cols)?;
@@ -311,7 +448,15 @@ pub fn read(path: &Path) -> Result<Recording> {
     {
         bail!("recording contains a header after the first line");
     }
+    if version == FORMAT_VERSION
+        && events
+            .iter()
+            .any(|entry| matches!(entry, Entry::Pointer { .. }))
+    {
+        bail!("recording version 1 cannot contain structured pointer events");
+    }
     Ok(Recording {
+        version,
         cols,
         rows,
         cell_width,
@@ -343,6 +488,8 @@ pub fn shot_at(path: &Path, at_ms: Option<u64>, marker: Option<&str>) -> Result<
             .frame
             .clone(),
         ansi: replay.ansi,
+        pointer_recording: recording.version == POINTER_FORMAT_VERSION,
+        pointer: replay.pointer,
     })
 }
 
@@ -351,11 +498,13 @@ struct VideoFrame {
     at_ms: u64,
     frame: Frame,
     footer_caption: Option<String>,
+    pointer: Option<PointerState>,
 }
 
 struct Replay {
     ansi: Vec<u8>,
     frames: Vec<VideoFrame>,
+    pointer: Option<PointerSnapshot>,
 }
 
 fn states(recording: &Recording) -> Result<Vec<VideoFrame>> {
@@ -370,7 +519,10 @@ fn replay(recording: &Recording, cutoff: Option<u64>) -> Result<Replay> {
         at_ms: 0,
         frame: terminal.frame()?,
         footer_caption: None,
+        pointer: None,
     });
+    let mut pointer = None;
+    let mut replayed_at_ms = 0;
     for event in &recording.events {
         let at_ms = match event {
             Entry::Output { at_ms, bytes } => {
@@ -394,12 +546,26 @@ fn replay(recording: &Recording, cutoff: Option<u64>) -> Result<Replay> {
                 terminal.resize(*cols, *rows, *cell_width, *cell_height)?;
                 *at_ms
             }
-            Entry::Input { .. } | Entry::Marker { .. } | Entry::Header { .. } => continue,
+            Entry::Pointer { at_ms, x, y, phase } => {
+                if cutoff.is_some_and(|cutoff| *at_ms > cutoff) {
+                    continue;
+                }
+                pointer = Some(PointerState::apply(pointer, *at_ms, *x, *y, *phase));
+                *at_ms
+            }
+            Entry::Input { at_ms, .. } | Entry::Marker { at_ms, .. } => {
+                if cutoff.is_none_or(|cutoff| *at_ms <= cutoff) {
+                    replayed_at_ms = replayed_at_ms.max(*at_ms);
+                }
+                continue;
+            }
+            Entry::Header { .. } => continue,
         };
+        replayed_at_ms = replayed_at_ms.max(at_ms);
         let frame = terminal.frame()?;
         if frames
             .last()
-            .is_some_and(|previous| previous.frame == frame)
+            .is_some_and(|previous| previous.frame == frame && previous.pointer == pointer)
         {
             continue;
         }
@@ -407,9 +573,15 @@ fn replay(recording: &Recording, cutoff: Option<u64>) -> Result<Replay> {
             at_ms,
             frame,
             footer_caption: None,
+            pointer,
         });
     }
-    Ok(Replay { ansi, frames })
+    let snapshot_at = cutoff.unwrap_or(replayed_at_ms).max(replayed_at_ms);
+    Ok(Replay {
+        ansi,
+        frames,
+        pointer: pointer.map(|pointer| pointer.snapshot(snapshot_at)),
+    })
 }
 
 fn visible_states(states: &[VideoFrame], include_startup: bool) -> &[VideoFrame] {
@@ -519,6 +691,7 @@ fn edited_states(
             at_ms: offset,
             frame: frame_with_caption(&first.frame, clip.caption.as_deref(), caption_placement),
             footer_caption: footer_caption(clip.caption.as_deref(), caption_placement),
+            pointer: scale_pointer(first.pointer, clip_start, from, speed),
         });
         output.extend(
             states
@@ -532,6 +705,7 @@ fn edited_states(
                         caption_placement,
                     ),
                     footer_caption: footer_caption(clip.caption.as_deref(), caption_placement),
+                    pointer: scale_pointer(state.pointer, clip_start, from, speed),
                 }),
         );
         let clip_end = scale_clip_time(clip_start, from, to, speed);
@@ -542,6 +716,7 @@ fn edited_states(
                 at_ms: clip_end,
                 frame: last.frame.clone(),
                 footer_caption: last.footer_caption.clone(),
+                pointer: last.pointer,
             });
         }
         let hold_ms = clip.hold_ms.unwrap_or(0);
@@ -553,6 +728,7 @@ fn edited_states(
                 at_ms: offset,
                 frame: last.frame.clone(),
                 footer_caption: last.footer_caption.clone(),
+                pointer: last.pointer,
             });
         }
     }
@@ -574,6 +750,29 @@ fn footer_caption(caption: Option<&str>, placement: CaptionPlacement) -> Option<
 
 fn scale_clip_time(clip_start: u64, from: u64, at_ms: u64, speed: f64) -> u64 {
     clip_start + ((at_ms.saturating_sub(from) as f64) / speed) as u64
+}
+
+fn scale_pointer(
+    pointer: Option<PointerState>,
+    clip_start: u64,
+    from: u64,
+    speed: f64,
+) -> Option<PointerState> {
+    pointer.map(|pointer| PointerState {
+        at_ms: scale_event_time(clip_start, from, pointer.at_ms, speed),
+        click_at_ms: pointer
+            .click_at_ms
+            .map(|at_ms| scale_event_time(clip_start, from, at_ms, speed)),
+        ..pointer
+    })
+}
+
+fn scale_event_time(clip_start: u64, from: u64, at_ms: u64, speed: f64) -> u64 {
+    if at_ms >= from {
+        scale_clip_time(clip_start, from, at_ms, speed)
+    } else {
+        clip_start.saturating_sub(((from - at_ms) as f64 / speed) as u64)
+    }
 }
 
 fn marker_times(entries: &[Entry]) -> Result<HashMap<String, u64>> {
@@ -624,7 +823,14 @@ fn annotate(mut frame: Frame, caption: Option<&str>) -> Frame {
     frame
 }
 
-fn samples(states: &[VideoFrame], options: &VideoOptions) -> Vec<usize> {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct VideoSample {
+    state: usize,
+    at_ms: u64,
+    elapsed_ms: u64,
+}
+
+fn samples(states: &[VideoFrame], options: &VideoOptions) -> Vec<VideoSample> {
     if states.is_empty() {
         return Vec::new();
     }
@@ -649,11 +855,19 @@ fn samples(states: &[VideoFrame], options: &VideoOptions) -> Vec<usize> {
         while state + 1 < timeline.len() && timeline[state + 1] <= sample_ms {
             state += 1;
         }
-        output.push(state);
+        output.push(VideoSample {
+            state,
+            at_ms: states[0].at_ms.saturating_add(sample_ms),
+            elapsed_ms: sample_ms,
+        });
         sample += 1;
     }
-    if output.last() != Some(&(states.len() - 1)) {
-        output.push(states.len() - 1);
+    if output.last().map(|sample| sample.state) != Some(states.len() - 1) {
+        output.push(VideoSample {
+            state: states.len() - 1,
+            at_ms: states[0].at_ms.saturating_add(end_ms),
+            elapsed_ms: end_ms,
+        });
     }
     output
 }
@@ -662,7 +876,7 @@ fn render_video_frames(
     temp: &Path,
     recording: &Recording,
     states: &[VideoFrame],
-    samples: &[usize],
+    samples: &[VideoSample],
     options: &VideoOptions,
 ) -> Result<()> {
     eprintln!("Rendering {} sampled frames...", samples.len());
@@ -680,7 +894,7 @@ fn render_video_frames(
         .iter()
         .map(|state| render_key(&state.frame, cols, rows, options.hide_cursor))
         .collect::<Vec<_>>();
-    let mut rendered = HashMap::<Frame, PathBuf>::new();
+    let mut rendered = HashMap::<String, PathBuf>::new();
     let renderer = render::PngRenderer::new();
     let render_options = render::Options {
         cell_width: f32::from(options.cell_width.unwrap_or(recording.cell_width)),
@@ -689,33 +903,35 @@ fn render_video_frames(
         padding: options.padding,
         font_family: options.font_family.clone(),
         show_cursor: !options.hide_cursor,
+        pointer: None,
     };
-    for (index, state) in samples.iter().enumerate() {
+    for (index, sample) in samples.iter().enumerate() {
         let path = temp.join(format!("frame-{index:06}.png"));
-        if options.footer {
-            let key = with_footer(
-                base_keys[*state].clone(),
-                states[*state].footer_caption.as_deref(),
-                (u128::from(index as u64) * 1000 / u128::from(options.fps)) as u64,
-            );
-            render_or_link(
-                &renderer,
-                &mut rendered,
-                &key,
-                &path,
-                &render_options,
-                options.pixel_ratio,
-            )?;
+        let key = if options.footer {
+            with_footer(
+                base_keys[sample.state].clone(),
+                states[sample.state].footer_caption.as_deref(),
+                sample.elapsed_ms,
+            )
         } else {
-            render_or_link(
-                &renderer,
-                &mut rendered,
-                &base_keys[*state],
-                &path,
-                &render_options,
-                options.pixel_ratio,
-            )?;
-        }
+            base_keys[sample.state].clone()
+        };
+        let mut sample_options = render_options.clone();
+        sample_options.pointer = options
+            .pointer
+            .then_some(states[sample.state].pointer)
+            .flatten()
+            .and_then(|pointer| {
+                render::PointerOverlay::from_snapshot(pointer.snapshot(sample.at_ms))
+            });
+        render_or_link(
+            &renderer,
+            &mut rendered,
+            &key,
+            &path,
+            &sample_options,
+            options.pixel_ratio,
+        )?;
     }
     eprintln!("Rendered {} unique screens.", rendered.len());
     eprintln!("Encoding {}...", options.out.display());
@@ -736,18 +952,19 @@ fn render_video_frames(
 
 fn render_or_link(
     renderer: &render::PngRenderer,
-    rendered: &mut HashMap<Frame, PathBuf>,
+    rendered: &mut HashMap<String, PathBuf>,
     key: &Frame,
     path: &Path,
     options: &render::Options,
     pixel_ratio: f32,
 ) -> Result<()> {
-    if let Some(existing) = rendered.get(key) {
+    let svg = render::svg(key, options);
+    if let Some(existing) = rendered.get(&svg) {
         fs::hard_link(existing, path).or_else(|_| fs::copy(existing, path).map(|_| ()))?;
         return Ok(());
     }
-    renderer.render(&render::svg(key, options), path, pixel_ratio)?;
-    rendered.insert(key.clone(), path.to_path_buf());
+    renderer.render(&svg, path, pixel_ratio)?;
+    rendered.insert(svg, path.to_path_buf());
     Ok(())
 }
 
@@ -910,6 +1127,7 @@ mod tests {
             tail: Duration::ZERO,
             include_startup: false,
             edit: None,
+            pointer: false,
         }
     }
 
@@ -942,18 +1160,20 @@ mod tests {
                     at_ms: 0,
                     frame: initial,
                     footer_caption: None,
+                    pointer: None,
                 },
                 VideoFrame {
                     at_ms: 4000,
                     frame: final_frame.clone(),
                     footer_caption: None,
+                    pointer: None,
                 },
             ],
             &options(),
         );
 
         assert_eq!(frames.len(), 81);
-        assert_eq!(frames.last(), Some(&1));
+        assert_eq!(frames.last().map(|sample| sample.state), Some(1));
     }
 
     #[test]
@@ -966,16 +1186,19 @@ mod tests {
                     at_ms: 0,
                     frame: first.clone(),
                     footer_caption: None,
+                    pointer: None,
                 },
                 VideoFrame {
                     at_ms: 1000,
                     frame: second.clone(),
                     footer_caption: None,
+                    pointer: None,
                 },
                 VideoFrame {
                     at_ms: 2000,
                     frame: first.clone(),
                     footer_caption: None,
+                    pointer: None,
                 },
             ],
             &[
@@ -1018,11 +1241,13 @@ mod tests {
                     at_ms: 0,
                     frame: frame("a"),
                     footer_caption: None,
+                    pointer: None,
                 },
                 VideoFrame {
                     at_ms: 1000,
                     frame: frame("b"),
                     footer_caption: None,
+                    pointer: None,
                 },
             ],
             &[
@@ -1054,6 +1279,7 @@ mod tests {
                 at_ms: 0,
                 frame: frame("a"),
                 footer_caption: None,
+                pointer: None,
             }],
             &[
                 Entry::Marker {
@@ -1129,6 +1355,7 @@ mod tests {
             at_ms: 0,
             frame: frame("a"),
             footer_caption: None,
+            pointer: None,
         }];
 
         assert!(
@@ -1187,8 +1414,125 @@ mod tests {
     }
 
     #[test]
+    fn default_writer_remains_version_one_byte_for_byte() {
+        let temp =
+            std::env::temp_dir().join(format!("termctrl-recording-v1-{}", std::process::id()));
+        let mut writer = Writer::new(&temp, Instant::now(), 2, 1, 9, 18).unwrap();
+        writer.output(1, b"A").unwrap();
+        drop(writer);
+
+        assert_eq!(
+            fs::read_to_string(&temp).unwrap(),
+            "{\"type\":\"header\",\"version\":1,\"cols\":2,\"rows\":1,\"cell_width\":9,\"cell_height\":18}\n{\"type\":\"output\",\"at_ms\":1,\"bytes\":[65]}\n"
+        );
+        let _ = fs::remove_file(temp);
+    }
+
+    #[test]
+    fn pointer_writer_uses_version_two_and_round_trips_structured_phases() {
+        let temp =
+            std::env::temp_dir().join(format!("termctrl-recording-v2-{}", std::process::id()));
+        let mut writer = Writer::new_with_pointer(&temp, Instant::now(), 20, 10, 9, 18).unwrap();
+        writer.pointer(2, 3, PointerPhase::Press).unwrap();
+        writer.pointer(4, 5, PointerPhase::Move).unwrap();
+        writer.pointer(4, 5, PointerPhase::Release).unwrap();
+        drop(writer);
+
+        let recording = read(&temp).unwrap();
+        let _ = fs::remove_file(temp);
+        assert_eq!(recording.version, POINTER_FORMAT_VERSION);
+        assert!(matches!(
+            recording.events.as_slice(),
+            [
+                Entry::Pointer {
+                    x: 2,
+                    y: 3,
+                    phase: PointerPhase::Press,
+                    ..
+                },
+                Entry::Pointer {
+                    x: 4,
+                    y: 5,
+                    phase: PointerPhase::Move,
+                    ..
+                },
+                Entry::Pointer {
+                    x: 4,
+                    y: 5,
+                    phase: PointerPhase::Release,
+                    ..
+                }
+            ]
+        ));
+    }
+
+    #[test]
+    fn version_one_rejects_pointer_events_and_unknown_versions_are_clear() {
+        let temp = std::env::temp_dir().join(format!(
+            "termctrl-recording-invalid-version-{}",
+            std::process::id()
+        ));
+        fs::write(
+            &temp,
+            "{\"type\":\"header\",\"version\":1,\"cols\":2,\"rows\":1,\"cell_width\":9,\"cell_height\":18}\n{\"type\":\"pointer\",\"at_ms\":0,\"x\":0,\"y\":0,\"phase\":\"press\"}\n",
+        )
+        .unwrap();
+        assert_eq!(
+            read(&temp).err().unwrap().to_string(),
+            "recording version 1 cannot contain structured pointer events"
+        );
+        fs::write(
+            &temp,
+            "{\"type\":\"header\",\"version\":3,\"cols\":2,\"rows\":1,\"cell_width\":9,\"cell_height\":18}\n",
+        )
+        .unwrap();
+        assert_eq!(
+            read(&temp).err().unwrap().to_string(),
+            "unsupported recording version 3"
+        );
+        let _ = fs::remove_file(temp);
+    }
+
+    #[test]
+    fn replay_tracks_pointer_age_through_quiet_markers() {
+        let recording = Recording {
+            version: POINTER_FORMAT_VERSION,
+            cols: 20,
+            rows: 10,
+            cell_width: 9,
+            cell_height: 18,
+            events: vec![
+                Entry::Pointer {
+                    at_ms: 10,
+                    x: 2,
+                    y: 3,
+                    phase: PointerPhase::Press,
+                },
+                Entry::Pointer {
+                    at_ms: 20,
+                    x: 4,
+                    y: 5,
+                    phase: PointerPhase::Release,
+                },
+                Entry::Marker {
+                    at_ms: 1000,
+                    name: "later".to_owned(),
+                },
+            ],
+        };
+
+        let replay = replay(&recording, Some(1000)).unwrap();
+        let pointer = replay.pointer.unwrap();
+        assert_eq!((pointer.x, pointer.y), (4, 5));
+        assert_eq!(pointer.age_ms, 980);
+        assert_eq!(pointer.click_age_ms, Some(990));
+        assert!(!pointer.pressed);
+    }
+
+    #[test]
     fn replays_resized_recordings_on_a_stable_video_canvas() {
         let recording = Recording {
+            version: FORMAT_VERSION,
             cols: 2,
             rows: 1,
             cell_width: 9,
@@ -1227,6 +1571,7 @@ mod tests {
     #[test]
     fn replay_preserves_reflowed_scrollback_across_multiple_resizes() {
         let recording = Recording {
+            version: FORMAT_VERSION,
             cols: 10,
             rows: 3,
             cell_width: 9,
@@ -1269,11 +1614,13 @@ mod tests {
                 at_ms: 0,
                 frame: frame(""),
                 footer_caption: None,
+                pointer: None,
             },
             VideoFrame {
                 at_ms: 1,
                 frame: painted.clone(),
                 footer_caption: None,
+                pointer: None,
             },
         ];
 
@@ -1290,17 +1637,22 @@ mod tests {
                     at_ms: 0,
                     frame: initial.clone(),
                     footer_caption: None,
+                    pointer: None,
                 },
                 VideoFrame {
                     at_ms: 1,
                     frame: final_frame.clone(),
                     footer_caption: None,
+                    pointer: None,
                 },
             ],
             &options(),
         );
 
-        assert_eq!(frames, vec![0, 1]);
+        assert_eq!(
+            frames.iter().map(|sample| sample.state).collect::<Vec<_>>(),
+            vec![0, 1]
+        );
     }
 
     #[test]
@@ -1316,17 +1668,22 @@ mod tests {
                     at_ms: 0,
                     frame: initial.clone(),
                     footer_caption: None,
+                    pointer: None,
                 },
                 VideoFrame {
                     at_ms: 100,
                     frame: final_frame.clone(),
                     footer_caption: None,
+                    pointer: None,
                 },
             ],
             &options,
         );
 
-        assert_eq!(frames, vec![0, 0, 0, 1]);
+        assert_eq!(
+            frames.iter().map(|sample| sample.state).collect::<Vec<_>>(),
+            vec![0, 0, 0, 1]
+        );
     }
 
     #[test]

--- a/src/render.rs
+++ b/src/render.rs
@@ -43,9 +43,22 @@ pub struct PointerOverlay {
     pub pressed: bool,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PointerMode {
+    Fading,
+    Persistent,
+}
+
 impl PointerOverlay {
     pub fn from_snapshot(pointer: PointerSnapshot) -> Option<Self> {
-        let opacity = if pointer.pressed || pointer.age_ms <= POINTER_HOLD_MS {
+        Self::from_snapshot_with_mode(pointer, PointerMode::Fading)
+    }
+
+    pub fn from_snapshot_with_mode(pointer: PointerSnapshot, mode: PointerMode) -> Option<Self> {
+        let opacity = if mode == PointerMode::Persistent
+            || pointer.pressed
+            || pointer.age_ms <= POINTER_HOLD_MS
+        {
             u8::MAX
         } else {
             let fade_age = pointer.age_ms.saturating_sub(POINTER_HOLD_MS);
@@ -136,11 +149,11 @@ fn pointer_svg(pointer: PointerOverlay, options: &Options) -> String {
         x + 13.0 * scale,
         y + 8.0 * scale,
     );
-    let mut output = String::new();
+    let mut output = r#"<g data-termctrl-pointer="true">"#.to_owned();
     if click > 0.0 {
         let radius = (1.0 - click) * 8.0 * scale + 4.0 * scale;
         output.push_str(&format!(
-            r##"<circle cx="{x}" cy="{y}" r="{radius}" fill="none" stroke="#67e8f9" stroke-width="{}" opacity="{}"/>"##,
+            r##"<circle data-termctrl-pointer-click="true" cx="{x}" cy="{y}" r="{radius}" fill="none" stroke="#67e8f9" stroke-width="{}" opacity="{}"/>"##,
             if pointer.pressed { 2.5 } else { 2.0 },
             click * opacity * 0.8,
         ));
@@ -148,6 +161,7 @@ fn pointer_svg(pointer: PointerOverlay, options: &Options) -> String {
     output.push_str(&format!(
         r##"<path d="{path}" fill="#111827" stroke="#111827" stroke-width="4" stroke-linejoin="round" opacity="{opacity}"/><path d="{path}" fill="#f9fafb" stroke="#f9fafb" stroke-width="1.4" stroke-linejoin="round" opacity="{opacity}"/>"##,
     ));
+    output.push_str("</g>");
     output
 }
 
@@ -427,35 +441,24 @@ mod tests {
 
     #[test]
     fn pointer_overlay_fades_and_click_feedback_expires() {
-        let fresh = PointerOverlay::from_snapshot(PointerSnapshot {
-            x: 2,
-            y: 3,
-            age_ms: 0,
-            pressed: false,
-            click_age_ms: Some(0),
-        })
-        .unwrap();
-        assert_eq!(fresh.opacity, u8::MAX);
-        assert_eq!(fresh.click, u8::MAX);
-
-        let fading = PointerOverlay::from_snapshot(PointerSnapshot {
-            age_ms: POINTER_HOLD_MS + POINTER_FADE_MS / 2,
-            click_age_ms: Some(POINTER_CLICK_MS),
-            ..PointerSnapshot {
+        let fresh = PointerOverlay::from_snapshot_with_mode(
+            PointerSnapshot {
                 x: 2,
                 y: 3,
                 age_ms: 0,
                 pressed: false,
-                click_age_ms: None,
-            }
-        })
+                click_age_ms: Some(0),
+            },
+            PointerMode::Fading,
+        )
         .unwrap();
-        assert!(fading.opacity > 0 && fading.opacity < u8::MAX);
-        assert_eq!(fading.click, 0);
-        assert!(
-            PointerOverlay::from_snapshot(PointerSnapshot {
-                age_ms: POINTER_HOLD_MS + POINTER_FADE_MS,
-                click_age_ms: None,
+        assert_eq!(fresh.opacity, u8::MAX);
+        assert_eq!(fresh.click, u8::MAX);
+
+        let fading = PointerOverlay::from_snapshot_with_mode(
+            PointerSnapshot {
+                age_ms: POINTER_HOLD_MS + POINTER_FADE_MS / 2,
+                click_age_ms: Some(POINTER_CLICK_MS),
                 ..PointerSnapshot {
                     x: 2,
                     y: 3,
@@ -463,9 +466,48 @@ mod tests {
                     pressed: false,
                     click_age_ms: None,
                 }
-            })
+            },
+            PointerMode::Fading,
+        )
+        .unwrap();
+        assert!(fading.opacity > 0 && fading.opacity < u8::MAX);
+        assert_eq!(fading.click, 0);
+        assert!(
+            PointerOverlay::from_snapshot_with_mode(
+                PointerSnapshot {
+                    age_ms: POINTER_HOLD_MS + POINTER_FADE_MS,
+                    click_age_ms: None,
+                    ..PointerSnapshot {
+                        x: 2,
+                        y: 3,
+                        age_ms: 0,
+                        pressed: false,
+                        click_age_ms: None,
+                    }
+                },
+                PointerMode::Fading
+            )
             .is_none()
         );
+    }
+
+    #[test]
+    fn persistent_pointer_survives_idle_but_click_feedback_expires() {
+        let pointer = PointerOverlay::from_snapshot_with_mode(
+            PointerSnapshot {
+                x: 7,
+                y: 4,
+                age_ms: 60_000,
+                pressed: false,
+                click_age_ms: Some(60_000),
+            },
+            PointerMode::Persistent,
+        )
+        .unwrap();
+
+        assert_eq!(pointer.opacity, u8::MAX);
+        assert_eq!(pointer.click, 0);
+        assert!(!pointer.pressed);
     }
 
     #[test]

--- a/src/render.rs
+++ b/src/render.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use anyhow::{Context, Result};
 
 use crate::frame::{Cell, Frame, Underline};
+use crate::recording::{POINTER_CLICK_MS, POINTER_FADE_MS, POINTER_HOLD_MS, PointerSnapshot};
 
 mod box_drawing;
 
@@ -16,6 +17,7 @@ pub struct Options {
     pub padding: f32,
     pub font_family: String,
     pub show_cursor: bool,
+    pub pointer: Option<PointerOverlay>,
 }
 
 impl Default for Options {
@@ -27,7 +29,45 @@ impl Default for Options {
             padding: 18.0,
             font_family: "JetBrains Mono, SFMono-Regular, Menlo, monospace".to_owned(),
             show_cursor: true,
+            pointer: None,
         }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct PointerOverlay {
+    pub x: u16,
+    pub y: u16,
+    pub opacity: u8,
+    pub click: u8,
+    pub pressed: bool,
+}
+
+impl PointerOverlay {
+    pub fn from_snapshot(pointer: PointerSnapshot) -> Option<Self> {
+        let opacity = if pointer.pressed || pointer.age_ms <= POINTER_HOLD_MS {
+            u8::MAX
+        } else {
+            let fade_age = pointer.age_ms.saturating_sub(POINTER_HOLD_MS);
+            if fade_age >= POINTER_FADE_MS {
+                return None;
+            }
+            ((POINTER_FADE_MS - fade_age) * u64::from(u8::MAX) / POINTER_FADE_MS) as u8
+        };
+        let click = pointer.click_age_ms.map_or(0, |age| {
+            if age >= POINTER_CLICK_MS {
+                0
+            } else {
+                ((POINTER_CLICK_MS - age) * u64::from(u8::MAX) / POINTER_CLICK_MS) as u8
+            }
+        });
+        Some(Self {
+            x: pointer.x,
+            y: pointer.y,
+            opacity,
+            click,
+            pressed: pointer.pressed,
+        })
     }
 }
 
@@ -69,7 +109,45 @@ pub fn svg(frame: &Frame, options: &Options) -> String {
             cursor.color.css(),
         ));
     }
+    if let Some(pointer) = options.pointer {
+        output.push_str(&pointer_svg(pointer, options));
+    }
     output.push_str("</g></svg>");
+    output
+}
+
+fn pointer_svg(pointer: PointerOverlay, options: &Options) -> String {
+    let x = options.padding + (f32::from(pointer.x) + 0.5) * options.cell_width;
+    let y = options.padding + (f32::from(pointer.y) + 0.5) * options.cell_height;
+    let opacity = f32::from(pointer.opacity) / 255.0;
+    let click = f32::from(pointer.click) / 255.0;
+    let scale = options.cell_width.min(options.cell_height).max(6.0) / 14.0;
+    let path = format!(
+        "M {x} {y} L {x} {} L {} {} L {} {} L {} {} L {} {} L {} {} Z",
+        y + 14.0 * scale,
+        x + 4.0 * scale,
+        y + 10.0 * scale,
+        x + 7.0 * scale,
+        y + 16.0 * scale,
+        x + 10.0 * scale,
+        y + 14.0 * scale,
+        x + 7.0 * scale,
+        y + 8.0 * scale,
+        x + 13.0 * scale,
+        y + 8.0 * scale,
+    );
+    let mut output = String::new();
+    if click > 0.0 {
+        let radius = (1.0 - click) * 8.0 * scale + 4.0 * scale;
+        output.push_str(&format!(
+            r##"<circle cx="{x}" cy="{y}" r="{radius}" fill="none" stroke="#67e8f9" stroke-width="{}" opacity="{}"/>"##,
+            if pointer.pressed { 2.5 } else { 2.0 },
+            click * opacity * 0.8,
+        ));
+    }
+    output.push_str(&format!(
+        r##"<path d="{path}" fill="#111827" stroke="#111827" stroke-width="4" stroke-linejoin="round" opacity="{opacity}"/><path d="{path}" fill="#f9fafb" stroke="#f9fafb" stroke-width="1.4" stroke-linejoin="round" opacity="{opacity}"/>"##,
+    ));
     output
 }
 
@@ -346,6 +424,82 @@ fn xml(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pointer_overlay_fades_and_click_feedback_expires() {
+        let fresh = PointerOverlay::from_snapshot(PointerSnapshot {
+            x: 2,
+            y: 3,
+            age_ms: 0,
+            pressed: false,
+            click_age_ms: Some(0),
+        })
+        .unwrap();
+        assert_eq!(fresh.opacity, u8::MAX);
+        assert_eq!(fresh.click, u8::MAX);
+
+        let fading = PointerOverlay::from_snapshot(PointerSnapshot {
+            age_ms: POINTER_HOLD_MS + POINTER_FADE_MS / 2,
+            click_age_ms: Some(POINTER_CLICK_MS),
+            ..PointerSnapshot {
+                x: 2,
+                y: 3,
+                age_ms: 0,
+                pressed: false,
+                click_age_ms: None,
+            }
+        })
+        .unwrap();
+        assert!(fading.opacity > 0 && fading.opacity < u8::MAX);
+        assert_eq!(fading.click, 0);
+        assert!(
+            PointerOverlay::from_snapshot(PointerSnapshot {
+                age_ms: POINTER_HOLD_MS + POINTER_FADE_MS,
+                click_age_ms: None,
+                ..PointerSnapshot {
+                    x: 2,
+                    y: 3,
+                    age_ms: 0,
+                    pressed: false,
+                    click_age_ms: None,
+                }
+            })
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn renders_high_contrast_pointer_and_click_ring_at_target_cell() {
+        let frame = Frame {
+            version: 1,
+            cols: 10,
+            rows: 5,
+            foreground: crate::frame::DEFAULT_FOREGROUND,
+            background: crate::frame::DEFAULT_BACKGROUND,
+            cursor: None,
+            cells: Vec::new(),
+        };
+        let output = svg(
+            &frame,
+            &Options {
+                pointer: Some(PointerOverlay {
+                    x: 2,
+                    y: 3,
+                    opacity: u8::MAX,
+                    click: u8::MAX,
+                    pressed: true,
+                }),
+                ..Options::default()
+            },
+        );
+
+        assert!(output.contains("<circle"));
+        assert!(output.contains("#67e8f9"));
+        assert!(output.contains("#111827"));
+        assert!(output.contains("#f9fafb"));
+        assert!(output.contains("cx=\"40.5\""));
+        assert!(output.contains("cy=\"81\""));
+    }
     use crate::frame::{Attributes, Color, Frame, Underline};
 
     #[test]

--- a/src/render.rs
+++ b/src/render.rs
@@ -122,7 +122,10 @@ pub fn svg(frame: &Frame, options: &Options) -> String {
             cursor.color.css(),
         ));
     }
-    if let Some(pointer) = options.pointer {
+    if let Some(pointer) = options.pointer
+        && pointer.x < frame.cols
+        && pointer.y < frame.rows
+    {
         output.push_str(&pointer_svg(pointer, options));
     }
     output.push_str("</g></svg>");
@@ -541,6 +544,34 @@ mod tests {
         assert!(output.contains("#f9fafb"));
         assert!(output.contains("cx=\"40.5\""));
         assert!(output.contains("cy=\"81\""));
+    }
+
+    #[test]
+    fn does_not_render_pointer_evidence_outside_the_frame() {
+        let frame = Frame {
+            version: 1,
+            cols: 2,
+            rows: 1,
+            foreground: crate::frame::DEFAULT_FOREGROUND,
+            background: crate::frame::DEFAULT_BACKGROUND,
+            cursor: None,
+            cells: Vec::new(),
+        };
+        let output = svg(
+            &frame,
+            &Options {
+                pointer: Some(PointerOverlay {
+                    x: 2,
+                    y: 0,
+                    opacity: u8::MAX,
+                    click: u8::MAX,
+                    pressed: true,
+                }),
+                ..Options::default()
+            },
+        );
+
+        assert!(!output.contains("data-termctrl-pointer"), "{output}");
     }
     use crate::frame::{Attributes, Color, Frame, Underline};
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -2068,6 +2068,10 @@ mod implementation {
             .arg(options.cell_height.to_string())
             .arg("--max-bytes")
             .arg(options.max_bytes.to_string());
+        if !options.inherit_env {
+            daemon.env_clear();
+        }
+        daemon.envs(&options.env);
         daemon
             .env_remove("TERMCTRL_WORKSPACE")
             .env_remove("TERMCTRL_PANE_ID")

--- a/src/session.rs
+++ b/src/session.rs
@@ -2104,6 +2104,7 @@ mod implementation {
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null());
+        detach_daemon(&mut daemon);
         let mut daemon = daemon.spawn().context("start session daemon")?;
         let deadline = Instant::now() + Duration::from_secs(5);
         loop {
@@ -2818,14 +2819,7 @@ mod implementation {
         if !command.is_empty() {
             daemon.arg("--").args(command);
         }
-        unsafe {
-            daemon.pre_exec(|| {
-                if libc::setsid() < 0 {
-                    return Err(std::io::Error::last_os_error());
-                }
-                Ok(())
-            });
-        }
+        detach_daemon(&mut daemon);
         daemon
             .stdin(Stdio::null())
             .stdout(Stdio::null())
@@ -2844,6 +2838,17 @@ mod implementation {
                 bail!("timed out starting workspace {name:?}");
             }
             thread::sleep(Duration::from_millis(20));
+        }
+    }
+
+    fn detach_daemon(command: &mut Command) {
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
         }
     }
 
@@ -3432,6 +3437,20 @@ mod implementation {
             drop(held);
             assert!(StartLock::acquire(&path).is_ok());
             let _ = fs::remove_file(path);
+        }
+
+        #[test]
+        fn detached_daemon_starts_in_its_own_unix_session() {
+            let mut command = Command::new("sleep");
+            command.arg("30");
+            detach_daemon(&mut command);
+            let mut child = command.spawn().unwrap();
+            let pid = child.id() as libc::pid_t;
+
+            assert_eq!(unsafe { libc::getsid(pid) }, pid);
+
+            child.kill().unwrap();
+            child.wait().unwrap();
         }
 
         #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -6,7 +6,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::frame::Frame;
-use crate::recording::{self, InputOrigin, PointerPhase};
+use crate::recording::{self, InputOrigin, PointerButton, PointerPhase};
 use crate::semantic;
 use crate::shot::{self, Host, Options, Shot, respond_to_output};
 use crate::terminal_core::{InputModes, SCROLLBACK_ROWS, TerminalCore};
@@ -30,7 +30,8 @@ const LAYOUT_COMMAND_PROTOCOL_VERSION: u8 = 4;
 const WORKSPACE_CONTROL_PROTOCOL_VERSION: u8 = 5;
 const SEMANTIC_PROTOCOL_VERSION: u8 = 6;
 const POINTER_PROTOCOL_VERSION: u8 = 7;
-const CURRENT_PROTOCOL_VERSION: u8 = POINTER_PROTOCOL_VERSION;
+const POINTER_BUTTON_PROTOCOL_VERSION: u8 = 8;
+const CURRENT_PROTOCOL_VERSION: u8 = POINTER_BUTTON_PROTOCOL_VERSION;
 const ATTACHED_TERMINAL_ERROR: &str = "workspace already has an attached terminal";
 
 fn attachment_rejection(name: &str, error: &str) -> anyhow::Error {
@@ -176,6 +177,12 @@ pub struct MouseInput {
     pub x: u16,
     pub y: u16,
     pub phase: PointerPhase,
+    #[serde(default, skip_serializing_if = "is_primary_pointer_button")]
+    pub button: PointerButton,
+}
+
+fn is_primary_pointer_button(button: &PointerButton) -> bool {
+    *button == PointerButton::Primary
 }
 
 /// One named daemon session discovered in the local runtime directory.
@@ -458,7 +465,7 @@ impl Session {
                 .recording
                 .as_mut()
                 .context("session has no active pointer recording")?;
-            recording.pointer(event.x, event.y, event.phase)?;
+            recording.pointer_with_button(event.x, event.y, event.phase, event.button)?;
             let at_ms = self.started.elapsed().as_millis() as u64;
             self.pointer = Some(recording::PointerState::apply(
                 self.pointer,
@@ -1125,6 +1132,7 @@ enum ProtocolCapability {
     WorkspaceControl,
     Semantic,
     Pointer,
+    PointerButton,
 }
 
 impl ProtocolCapability {
@@ -1137,6 +1145,7 @@ impl ProtocolCapability {
             Self::WorkspaceControl => WORKSPACE_CONTROL_PROTOCOL_VERSION,
             Self::Semantic => SEMANTIC_PROTOCOL_VERSION,
             Self::Pointer => POINTER_PROTOCOL_VERSION,
+            Self::PointerButton => POINTER_BUTTON_PROTOCOL_VERSION,
         }
     }
 
@@ -1162,6 +1171,9 @@ impl ProtocolCapability {
             }
             Self::Pointer => {
                 "running session predates structured pointer recording; restart it with the current termctrl"
+            }
+            Self::PointerButton => {
+                "running session predates structured pointer button recording; restart it with the current termctrl"
             }
         }
     }
@@ -1214,6 +1226,13 @@ impl Request {
             | Self::ClosePane { .. } => ProtocolCapability::Pane,
             Self::Attach { .. } | Self::ResizeAttachment { .. } => ProtocolCapability::Attachment,
             Self::SemanticSnapshot { .. } => ProtocolCapability::Semantic,
+            Self::Mouse { input, .. }
+                if input
+                    .iter()
+                    .any(|event| event.button != PointerButton::Primary) =>
+            {
+                ProtocolCapability::PointerButton
+            }
             Self::Mouse { .. } => ProtocolCapability::Pointer,
             Self::Ping
             | Self::Status
@@ -1918,6 +1937,13 @@ pub fn infer_name(command: &[String]) -> Result<String> {
 fn request(name: &str, operation: Request) -> Result<Response> {
     validate_name(name)?;
     let requirements = operation.requirements();
+    if requirements.capability == Some(ProtocolCapability::PointerButton) {
+        let response = implementation::request(socket_path(name)?, &Request::Ping)?;
+        ProtocolCapability::PointerButton.require(&response)?;
+        if let Some(error) = response.error {
+            bail!(error);
+        }
+    }
     let response = if requirements.hold_name_lock {
         implementation::request_layout_command(name, &operation)?
     } else {
@@ -3883,9 +3909,16 @@ mod tests {
                 .to_string()
                 .contains("predates structured pointer recording")
         );
+        assert!(
+            ProtocolCapability::PointerButton
+                .require(&response)
+                .unwrap_err()
+                .to_string()
+                .contains("predates structured pointer button recording")
+        );
         assert_eq!(
             Response::default().protocol_version,
-            POINTER_PROTOCOL_VERSION
+            POINTER_BUTTON_PROTOCOL_VERSION
         );
     }
 
@@ -3948,6 +3981,21 @@ mod tests {
                     pane: None,
                 },
                 Some(ProtocolCapability::Pointer),
+                false,
+            ),
+            (
+                Request::Mouse {
+                    input: vec![MouseInput {
+                        bytes: b"secondary".to_vec(),
+                        x: 1,
+                        y: 2,
+                        phase: PointerPhase::Press,
+                        button: PointerButton::Secondary,
+                    }],
+                    pace_ms: 0,
+                    pane: None,
+                },
+                Some(ProtocolCapability::PointerButton),
                 false,
             ),
             (Request::Status, None, false),

--- a/src/session.rs
+++ b/src/session.rs
@@ -185,6 +185,19 @@ fn is_primary_pointer_button(button: &PointerButton) -> bool {
     *button == PointerButton::Primary
 }
 
+fn validate_mouse_input(input: &[MouseInput], cols: u16, rows: u16) -> Result<()> {
+    for event in input {
+        if event.x >= cols || event.y >= rows {
+            bail!(
+                "mouse coordinate ({}, {}) is outside target viewport {cols}x{rows}; coordinates must satisfy X < {cols} and Y < {rows}",
+                event.x,
+                event.y,
+            );
+        }
+    }
+    Ok(())
+}
+
 /// One named daemon session discovered in the local runtime directory.
 #[derive(Debug, Serialize)]
 pub struct NamedSessionStatus {
@@ -458,6 +471,7 @@ impl Session {
         if self.has_exited()? || self.stopped {
             bail!("session command has exited");
         }
+        validate_mouse_input(input, self.cols, self.rows)?;
         let last = input.len().saturating_sub(1);
         for (index, event) in input.iter().enumerate() {
             self.write_input(&event.bytes)?;
@@ -1472,18 +1486,25 @@ pub fn mouse_to_in(
     input: Vec<MouseInput>,
     pace: Duration,
 ) -> Result<()> {
+    let target = terminal_target(window, pane)?;
+    let shot = show_target(name, target.clone(), Duration::ZERO, Duration::ZERO)?;
+    validate_mouse_input(&input, shot.frame.cols, shot.frame.rows)?;
     if !status(name)?.launch.pointer_recording {
-        return send_to_in(
+        return send_to_target(
             name,
-            window,
-            pane,
+            target,
             input.into_iter().map(|event| event.bytes).collect(),
             pace,
         );
     }
-    if window.is_some() {
+    if matches!(target, TerminalTarget::Window(_)) {
         bail!("structured pointer recording is currently supported only by direct named sessions");
     }
+    let pane = match target {
+        TerminalTarget::Selected => None,
+        TerminalTarget::Pane(pane) => Some(pane),
+        TerminalTarget::Window(_) => unreachable!(),
+    };
     request(
         name,
         Request::Mouse {

--- a/src/session.rs
+++ b/src/session.rs
@@ -31,7 +31,8 @@ const WORKSPACE_CONTROL_PROTOCOL_VERSION: u8 = 5;
 const SEMANTIC_PROTOCOL_VERSION: u8 = 6;
 const POINTER_PROTOCOL_VERSION: u8 = 7;
 const POINTER_BUTTON_PROTOCOL_VERSION: u8 = 8;
-const CURRENT_PROTOCOL_VERSION: u8 = POINTER_BUTTON_PROTOCOL_VERSION;
+const MOUSE_INPUT_PROTOCOL_VERSION: u8 = 9;
+const CURRENT_PROTOCOL_VERSION: u8 = MOUSE_INPUT_PROTOCOL_VERSION;
 const ATTACHED_TERMINAL_ERROR: &str = "workspace already has an attached terminal";
 
 fn attachment_rejection(name: &str, error: &str) -> anyhow::Error {
@@ -464,8 +465,25 @@ impl Session {
     }
 
     pub(crate) fn send_mouse_all(&mut self, input: &[MouseInput], pace: Duration) -> Result<()> {
+        self.send_mouse_input_all_inner(input, pace, true)
+    }
+
+    pub(crate) fn send_mouse_input_all(
+        &mut self,
+        input: &[MouseInput],
+        pace: Duration,
+    ) -> Result<()> {
+        self.send_mouse_input_all_inner(input, pace, false)
+    }
+
+    fn send_mouse_input_all_inner(
+        &mut self,
+        input: &[MouseInput],
+        pace: Duration,
+        require_pointer_recording: bool,
+    ) -> Result<()> {
         self.consume_batch()?;
-        if !self.launch.pointer_recording {
+        if require_pointer_recording && !self.launch.pointer_recording {
             bail!("session was not started with structured pointer recording enabled");
         }
         if self.has_exited()? || self.stopped {
@@ -475,19 +493,21 @@ impl Session {
         let last = input.len().saturating_sub(1);
         for (index, event) in input.iter().enumerate() {
             self.write_input(&event.bytes)?;
-            let recording = self
-                .recording
-                .as_mut()
-                .context("session has no active pointer recording")?;
-            recording.pointer_with_button(event.x, event.y, event.phase, event.button)?;
-            let at_ms = self.started.elapsed().as_millis() as u64;
-            self.pointer = Some(recording::PointerState::apply(
-                self.pointer,
-                at_ms,
-                event.x,
-                event.y,
-                event.phase,
-            ));
+            if self.launch.pointer_recording {
+                let recording = self
+                    .recording
+                    .as_mut()
+                    .context("session has no active pointer recording")?;
+                recording.pointer_with_button(event.x, event.y, event.phase, event.button)?;
+                let at_ms = self.started.elapsed().as_millis() as u64;
+                self.pointer = Some(recording::PointerState::apply(
+                    self.pointer,
+                    at_ms,
+                    event.x,
+                    event.y,
+                    event.phase,
+                ));
+            }
             if !pace.is_zero() && index < last {
                 thread::sleep(pace);
             }
@@ -1011,6 +1031,12 @@ enum Request {
         #[serde(default)]
         pane: Option<crate::workspace::PaneId>,
     },
+    MouseInput {
+        input: Vec<MouseInput>,
+        pace_ms: u64,
+        #[serde(default)]
+        pane: Option<crate::workspace::PaneId>,
+    },
     Show {
         settle_ms: u64,
         deadline_ms: u64,
@@ -1074,6 +1100,11 @@ enum Request {
     SendWindow {
         name: String,
         input: Vec<Vec<u8>>,
+        pace_ms: u64,
+    },
+    MouseInputWindow {
+        name: String,
+        input: Vec<MouseInput>,
         pace_ms: u64,
     },
     WaitWindow {
@@ -1147,6 +1178,7 @@ enum ProtocolCapability {
     Semantic,
     Pointer,
     PointerButton,
+    MouseInput,
 }
 
 impl ProtocolCapability {
@@ -1160,6 +1192,7 @@ impl ProtocolCapability {
             Self::Semantic => SEMANTIC_PROTOCOL_VERSION,
             Self::Pointer => POINTER_PROTOCOL_VERSION,
             Self::PointerButton => POINTER_BUTTON_PROTOCOL_VERSION,
+            Self::MouseInput => MOUSE_INPUT_PROTOCOL_VERSION,
         }
     }
 
@@ -1188,6 +1221,9 @@ impl ProtocolCapability {
             }
             Self::PointerButton => {
                 "running session predates structured pointer button recording; restart it with the current termctrl"
+            }
+            Self::MouseInput => {
+                "running session predates viewport-safe mouse input; restart it with the current termctrl"
             }
         }
     }
@@ -1248,6 +1284,9 @@ impl Request {
                 ProtocolCapability::PointerButton
             }
             Self::Mouse { .. } => ProtocolCapability::Pointer,
+            Self::MouseInput { .. } | Self::MouseInputWindow { .. } => {
+                ProtocolCapability::MouseInput
+            }
             Self::Ping
             | Self::Status
             | Self::Wait { pane: None, .. }
@@ -1487,32 +1526,24 @@ pub fn mouse_to_in(
     pace: Duration,
 ) -> Result<()> {
     let target = terminal_target(window, pane)?;
-    let shot = show_target(name, target.clone(), Duration::ZERO, Duration::ZERO)?;
-    validate_mouse_input(&input, shot.frame.cols, shot.frame.rows)?;
-    if !status(name)?.launch.pointer_recording {
-        return send_to_target(
-            name,
-            target,
-            input.into_iter().map(|event| event.bytes).collect(),
-            pace,
-        );
-    }
-    if matches!(target, TerminalTarget::Window(_)) {
-        bail!("structured pointer recording is currently supported only by direct named sessions");
-    }
-    let pane = match target {
-        TerminalTarget::Selected => None,
-        TerminalTarget::Pane(pane) => Some(pane),
-        TerminalTarget::Window(_) => unreachable!(),
-    };
-    request(
-        name,
-        Request::Mouse {
+    let operation = match target {
+        TerminalTarget::Selected => Request::MouseInput {
             input,
             pace_ms: pace.as_millis() as u64,
-            pane,
+            pane: None,
         },
-    )?;
+        TerminalTarget::Pane(pane) => Request::MouseInput {
+            input,
+            pace_ms: pace.as_millis() as u64,
+            pane: Some(pane),
+        },
+        TerminalTarget::Window(name) => Request::MouseInputWindow {
+            name,
+            input,
+            pace_ms: pace.as_millis() as u64,
+        },
+    };
+    request(name, operation)?;
     Ok(())
 }
 
@@ -3182,6 +3213,16 @@ mod implementation {
                 }
                 session.send_mouse_all(&input, Duration::from_millis(pace_ms))?;
             }
+            Request::MouseInput {
+                input,
+                pace_ms,
+                pane,
+            } => {
+                if pane.is_some_and(|pane| pane != 0) {
+                    bail!("single sessions only contain pane 0");
+                }
+                session.send_mouse_input_all(&input, Duration::from_millis(pace_ms))?;
+            }
             Request::Wait {
                 text,
                 timeout_ms,
@@ -3254,6 +3295,7 @@ mod implementation {
             | Request::WindowLayout { .. }
             | Request::ShowWindow { .. }
             | Request::SendWindow { .. }
+            | Request::MouseInputWindow { .. }
             | Request::WaitWindow { .. }
             | Request::LogsWindow { .. }
             | Request::MovePane { .. } => {
@@ -3313,6 +3355,15 @@ mod implementation {
                 bail!(
                     "structured pointer recording is currently supported only by direct named sessions"
                 )
+            }
+            Request::MouseInput {
+                input,
+                pace_ms,
+                pane,
+            } => {
+                let duration = pace_ms.saturating_mul(input.len().saturating_sub(1) as u64);
+                require_control_duration("paced mouse input", duration)?;
+                workspace.send_mouse_input_all(pane, &input, Duration::from_millis(pace_ms))?;
             }
             Request::Wait {
                 text,
@@ -3434,6 +3485,15 @@ mod implementation {
                     Duration::from_millis(pace_ms),
                     |workspace| terminal.tick(workspace),
                 )?;
+            }
+            Request::MouseInputWindow {
+                name,
+                input,
+                pace_ms,
+            } => {
+                let duration = pace_ms.saturating_mul(input.len().saturating_sub(1) as u64);
+                require_control_duration("paced mouse input", duration)?;
+                workspace.send_mouse_input_all_in(&name, &input, Duration::from_millis(pace_ms))?;
             }
             Request::WaitWindow {
                 name,
@@ -3604,6 +3664,8 @@ mod implementation {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use crate::session::{MouseInput, PointerButton, PointerPhase};
+        use crate::terminal_theme::TerminalTheme;
 
         #[test]
         fn name_start_lock_rejects_a_concurrent_owner() {
@@ -3666,6 +3728,155 @@ mod implementation {
             assert!(response.captured.is_some());
             assert!(response.status.is_some());
             workspace.stop();
+        }
+
+        fn primary_mouse_input(x: u16, y: u16) -> Vec<MouseInput> {
+            vec![MouseInput {
+                bytes: format!("\x1b[<0;{};{}M", x + 1, y + 1).into_bytes(),
+                x,
+                y,
+                phase: PointerPhase::Press,
+                button: PointerButton::Primary,
+            }]
+        }
+
+        #[test]
+        fn direct_mouse_mutation_revalidates_after_a_deterministic_resize_race() {
+            let record = std::env::temp_dir().join(format!(
+                "termctrl-direct-mouse-race-{}-{:?}.termctrl",
+                std::process::id(),
+                std::thread::current().id()
+            ));
+            let options = Options {
+                cols: 200,
+                rows: 2,
+                ..Options::default()
+            };
+            let command = ["sh".to_owned(), "-c".to_owned(), "cat".to_owned()];
+            let mut session = Session::start(&command, None, Some(&record), &options).unwrap();
+
+            let before = respond(
+                &mut session,
+                Request::Show {
+                    settle_ms: 0,
+                    deadline_ms: 0,
+                    pane: None,
+                },
+            )
+            .unwrap();
+            assert_eq!(before.captured.unwrap().frame.cols, 200);
+            respond(
+                &mut session,
+                Request::Resize {
+                    cols: 1,
+                    rows: 2,
+                    cell_width: None,
+                    cell_height: None,
+                },
+            )
+            .unwrap();
+
+            let error = respond(
+                &mut session,
+                Request::MouseInput {
+                    input: primary_mouse_input(199, 0),
+                    pace_ms: 0,
+                    pane: None,
+                },
+            )
+            .err()
+            .expect("post-resize mouse input must fail");
+            assert!(
+                error.to_string().contains("outside target viewport 1x2"),
+                "{error:#}"
+            );
+            session.stop().unwrap();
+            let recording = fs::read_to_string(&record).unwrap();
+            assert!(!recording.contains("\"origin\":\"client\""), "{recording}");
+            let _ = fs::remove_file(record);
+        }
+
+        #[test]
+        fn workspace_mouse_routes_resolve_and_validate_after_resize_in_one_dispatch() {
+            let record = std::env::temp_dir().join(format!(
+                "termctrl-workspace-mouse-race-{}-{:?}.termctrl",
+                std::process::id(),
+                std::thread::current().id()
+            ));
+            let options = Options {
+                cols: 200,
+                rows: 3,
+                ..Options::default()
+            };
+            let command = ["sh".to_owned(), "-c".to_owned(), "cat".to_owned()];
+            let mut workspace = Workspace::start_named_with_theme(
+                "mouse-routes",
+                &command,
+                None,
+                Some(&record),
+                &options,
+                TerminalTheme::default(),
+                TabPosition::Bottom,
+            )
+            .unwrap();
+            workspace
+                .create_window(Some("other"), &command, None)
+                .unwrap();
+            workspace.select_window("main").unwrap();
+            let mut terminal = WorkspaceTerminal::detached();
+
+            for request in [
+                Request::Show {
+                    settle_ms: 0,
+                    deadline_ms: 0,
+                    pane: None,
+                },
+                Request::Show {
+                    settle_ms: 0,
+                    deadline_ms: 0,
+                    pane: Some(0),
+                },
+                Request::ShowWindow {
+                    name: "other".to_owned(),
+                    settle_ms: 0,
+                    deadline_ms: 0,
+                },
+            ] {
+                let response = respond_workspace(&mut workspace, request, &mut terminal).unwrap();
+                assert_eq!(response.captured.unwrap().frame.cols, 200);
+            }
+            workspace.resize(1, 3, 9, 18).unwrap();
+
+            for request in [
+                Request::MouseInput {
+                    input: primary_mouse_input(199, 0),
+                    pace_ms: 0,
+                    pane: None,
+                },
+                Request::MouseInput {
+                    input: primary_mouse_input(199, 0),
+                    pace_ms: 0,
+                    pane: Some(0),
+                },
+                Request::MouseInputWindow {
+                    name: "other".to_owned(),
+                    input: primary_mouse_input(199, 0),
+                    pace_ms: 0,
+                },
+            ] {
+                let error = respond_workspace(&mut workspace, request, &mut terminal)
+                    .err()
+                    .expect("post-resize workspace mouse input must fail");
+                assert!(
+                    error.to_string().contains("outside target viewport 1x2"),
+                    "{error:#}"
+                );
+            }
+            workspace.pump().unwrap();
+            workspace.stop();
+            let recording = fs::read_to_string(&record).unwrap();
+            assert!(!recording.contains("\"origin\":\"client\""), "{recording}");
+            let _ = fs::remove_file(record);
         }
 
         #[test]
@@ -3937,9 +4148,27 @@ mod tests {
                 .to_string()
                 .contains("predates structured pointer button recording")
         );
+        assert!(
+            ProtocolCapability::MouseInput
+                .require(&response)
+                .unwrap_err()
+                .to_string()
+                .contains("predates viewport-safe mouse input")
+        );
+        let version_eight = Response {
+            protocol_version: POINTER_BUTTON_PROTOCOL_VERSION,
+            ..Response::default()
+        };
+        assert!(
+            ProtocolCapability::MouseInput
+                .require(&version_eight)
+                .unwrap_err()
+                .to_string()
+                .contains("restart it with the current termctrl")
+        );
         assert_eq!(
             Response::default().protocol_version,
-            POINTER_BUTTON_PROTOCOL_VERSION
+            MOUSE_INPUT_PROTOCOL_VERSION
         );
     }
 
@@ -4005,6 +4234,24 @@ mod tests {
                 false,
             ),
             (
+                Request::MouseInput {
+                    input: Vec::new(),
+                    pace_ms: 0,
+                    pane: None,
+                },
+                Some(ProtocolCapability::MouseInput),
+                false,
+            ),
+            (
+                Request::MouseInputWindow {
+                    name: "editor".to_owned(),
+                    input: Vec::new(),
+                    pace_ms: 0,
+                },
+                Some(ProtocolCapability::MouseInput),
+                false,
+            ),
+            (
                 Request::Mouse {
                     input: vec![MouseInput {
                         bytes: b"secondary".to_vec(),
@@ -4034,7 +4281,7 @@ mod tests {
     }
 
     #[test]
-    fn semantic_workspace_requests_round_trip() {
+    fn additive_control_requests_round_trip() {
         for request in [
             Request::Layout {
                 columns: 2,
@@ -4107,6 +4354,22 @@ mod tests {
                 deadline_unix_ms: 1,
                 pane: Some(3),
                 window: None,
+            },
+            Request::MouseInput {
+                input: vec![MouseInput {
+                    bytes: b"mouse".to_vec(),
+                    x: 2,
+                    y: 1,
+                    phase: PointerPhase::Move,
+                    button: PointerButton::Primary,
+                }],
+                pace_ms: 8,
+                pane: Some(3),
+            },
+            Request::MouseInputWindow {
+                name: "code".to_owned(),
+                input: Vec::new(),
+                pace_ms: 0,
             },
         ] {
             let encoded = serde_json::to_vec(&request).unwrap();

--- a/src/session.rs
+++ b/src/session.rs
@@ -6,7 +6,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::frame::Frame;
-use crate::recording::{self, InputOrigin};
+use crate::recording::{self, InputOrigin, PointerPhase};
 use crate::semantic;
 use crate::shot::{self, Host, Options, Shot, respond_to_output};
 use crate::terminal_core::{InputModes, SCROLLBACK_ROWS, TerminalCore};
@@ -29,7 +29,8 @@ const WINDOW_PROTOCOL_VERSION: u8 = 3;
 const LAYOUT_COMMAND_PROTOCOL_VERSION: u8 = 4;
 const WORKSPACE_CONTROL_PROTOCOL_VERSION: u8 = 5;
 const SEMANTIC_PROTOCOL_VERSION: u8 = 6;
-const CURRENT_PROTOCOL_VERSION: u8 = SEMANTIC_PROTOCOL_VERSION;
+const POINTER_PROTOCOL_VERSION: u8 = 7;
+const CURRENT_PROTOCOL_VERSION: u8 = POINTER_PROTOCOL_VERSION;
 const ATTACHED_TERMINAL_ERROR: &str = "workspace already has an attached terminal";
 
 fn attachment_rejection(name: &str, error: &str) -> anyhow::Error {
@@ -75,6 +76,8 @@ pub struct Session {
     exit_ready: bool,
     last_output: Option<Instant>,
     recording: Option<recording::Writer>,
+    started: Instant,
+    pointer: Option<recording::PointerState>,
     capture_input: bool,
     captured_input: Vec<(InputOrigin, Vec<u8>)>,
     cols: u16,
@@ -158,6 +161,21 @@ pub struct SessionLaunch {
     pub max_bytes: usize,
     pub opentui_host: bool,
     pub color: shot::ColorMode,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub pointer_recording: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+#[doc(hidden)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct MouseInput {
+    pub bytes: Vec<u8>,
+    pub x: u16,
+    pub y: u16,
+    pub phase: PointerPhase,
 }
 
 /// One named daemon session discovered in the local runtime directory.
@@ -218,9 +236,17 @@ impl Session {
         let terminal =
             TerminalCore::new_with_theme(options.rows, options.cols, SCROLLBACK_ROWS, theme)?;
         let started = Instant::now();
+        if options.pointer_recording && record.is_none() {
+            bail!("pointer recording requires a .termctrl recording path");
+        }
         let recording = record
             .map(|path| {
-                recording::Writer::new(
+                let create = if options.pointer_recording {
+                    recording::Writer::new_with_pointer
+                } else {
+                    recording::Writer::new
+                };
+                create(
                     path,
                     started,
                     options.cols,
@@ -309,6 +335,8 @@ impl Session {
             exit_ready: false,
             last_output: None,
             recording,
+            started,
+            pointer: None,
             capture_input: false,
             captured_input: Vec::new(),
             cols: options.cols,
@@ -326,6 +354,7 @@ impl Session {
                 max_bytes: options.max_bytes,
                 opentui_host: options.opentui_host,
                 color: options.color,
+                pointer_recording: options.pointer_recording,
             },
             mirror: None,
             semantic,
@@ -414,6 +443,37 @@ impl Session {
         Ok(())
     }
 
+    pub(crate) fn send_mouse_all(&mut self, input: &[MouseInput], pace: Duration) -> Result<()> {
+        self.consume_batch()?;
+        if !self.launch.pointer_recording {
+            bail!("session was not started with structured pointer recording enabled");
+        }
+        if self.has_exited()? || self.stopped {
+            bail!("session command has exited");
+        }
+        let last = input.len().saturating_sub(1);
+        for (index, event) in input.iter().enumerate() {
+            self.write_input(&event.bytes)?;
+            let recording = self
+                .recording
+                .as_mut()
+                .context("session has no active pointer recording")?;
+            recording.pointer(event.x, event.y, event.phase)?;
+            let at_ms = self.started.elapsed().as_millis() as u64;
+            self.pointer = Some(recording::PointerState::apply(
+                self.pointer,
+                at_ms,
+                event.x,
+                event.y,
+                event.phase,
+            ));
+            if !pace.is_zero() && index < last {
+                thread::sleep(pace);
+            }
+        }
+        Ok(())
+    }
+
     /// Wait until visible terminal text contains `text`.
     pub fn wait_for_text(&mut self, text: &str, timeout: Duration) -> Result<()> {
         let deadline = Instant::now() + timeout;
@@ -488,6 +548,10 @@ impl Session {
                     shot: Shot {
                         frame: self.terminal.frame()?,
                         ansi: self.ansi.clone(),
+                        pointer_recording: self.launch.pointer_recording,
+                        pointer: self.pointer.map(|pointer| {
+                            pointer.snapshot(self.started.elapsed().as_millis() as u64)
+                        }),
                     },
                     reason,
                 });
@@ -630,6 +694,10 @@ impl Session {
         Ok(Shot {
             frame: self.terminal.frame()?,
             ansi: self.ansi.clone(),
+            pointer_recording: self.launch.pointer_recording,
+            pointer: self
+                .pointer
+                .map(|pointer| pointer.snapshot(self.started.elapsed().as_millis() as u64)),
         })
     }
 
@@ -916,6 +984,12 @@ enum Request {
         #[serde(default)]
         pane: Option<crate::workspace::PaneId>,
     },
+    Mouse {
+        input: Vec<MouseInput>,
+        pace_ms: u64,
+        #[serde(default)]
+        pane: Option<crate::workspace::PaneId>,
+    },
     Show {
         settle_ms: u64,
         deadline_ms: u64,
@@ -1050,6 +1124,7 @@ enum ProtocolCapability {
     LayoutCommand,
     WorkspaceControl,
     Semantic,
+    Pointer,
 }
 
 impl ProtocolCapability {
@@ -1061,6 +1136,7 @@ impl ProtocolCapability {
             Self::LayoutCommand => LAYOUT_COMMAND_PROTOCOL_VERSION,
             Self::WorkspaceControl => WORKSPACE_CONTROL_PROTOCOL_VERSION,
             Self::Semantic => SEMANTIC_PROTOCOL_VERSION,
+            Self::Pointer => POINTER_PROTOCOL_VERSION,
         }
     }
 
@@ -1083,6 +1159,9 @@ impl ProtocolCapability {
             }
             Self::Semantic => {
                 "running session predates semantic snapshots; restart it with the current termctrl"
+            }
+            Self::Pointer => {
+                "running session predates structured pointer recording; restart it with the current termctrl"
             }
         }
     }
@@ -1135,6 +1214,7 @@ impl Request {
             | Self::ClosePane { .. } => ProtocolCapability::Pane,
             Self::Attach { .. } | Self::ResizeAttachment { .. } => ProtocolCapability::Attachment,
             Self::SemanticSnapshot { .. } => ProtocolCapability::Semantic,
+            Self::Mouse { .. } => ProtocolCapability::Pointer,
             Self::Ping
             | Self::Status
             | Self::Wait { pane: None, .. }
@@ -1363,6 +1443,37 @@ pub fn send_to_in(
     pace: Duration,
 ) -> Result<()> {
     send_to_target(name, terminal_target(window, pane)?, input, pace)
+}
+
+#[doc(hidden)]
+pub fn mouse_to_in(
+    name: &str,
+    window: Option<String>,
+    pane: Option<crate::workspace::PaneId>,
+    input: Vec<MouseInput>,
+    pace: Duration,
+) -> Result<()> {
+    if !status(name)?.launch.pointer_recording {
+        return send_to_in(
+            name,
+            window,
+            pane,
+            input.into_iter().map(|event| event.bytes).collect(),
+            pace,
+        );
+    }
+    if window.is_some() {
+        bail!("structured pointer recording is currently supported only by direct named sessions");
+    }
+    request(
+        name,
+        Request::Mouse {
+            input,
+            pace_ms: pace.as_millis() as u64,
+            pane,
+        },
+    )?;
+    Ok(())
 }
 
 #[doc(hidden)]
@@ -2068,6 +2179,9 @@ mod implementation {
             .arg(options.cell_height.to_string())
             .arg("--max-bytes")
             .arg(options.max_bytes.to_string());
+        if options.pointer_recording {
+            daemon.arg("--pointer-recording");
+        }
         if !options.inherit_env {
             daemon.env_clear();
         }
@@ -3011,6 +3125,16 @@ mod implementation {
                 }
                 session.send_all(&input, Duration::from_millis(pace_ms))?;
             }
+            Request::Mouse {
+                input,
+                pace_ms,
+                pane,
+            } => {
+                if pane.is_some_and(|pane| pane != 0) {
+                    bail!("single sessions only contain pane 0");
+                }
+                session.send_mouse_all(&input, Duration::from_millis(pace_ms))?;
+            }
             Request::Wait {
                 text,
                 timeout_ms,
@@ -3137,6 +3261,11 @@ mod implementation {
                 workspace.send_all(pane, &input, Duration::from_millis(pace_ms), |workspace| {
                     terminal.tick(workspace)
                 })?;
+            }
+            Request::Mouse { .. } => {
+                bail!(
+                    "structured pointer recording is currently supported only by direct named sessions"
+                )
             }
             Request::Wait {
                 text,
@@ -3747,9 +3876,16 @@ mod tests {
                 .is_err()
         );
         assert!(ProtocolCapability::Semantic.require(&version_four).is_err());
+        assert!(
+            ProtocolCapability::Pointer
+                .require(&response)
+                .unwrap_err()
+                .to_string()
+                .contains("predates structured pointer recording")
+        );
         assert_eq!(
             Response::default().protocol_version,
-            SEMANTIC_PROTOCOL_VERSION
+            POINTER_PROTOCOL_VERSION
         );
     }
 
@@ -3803,6 +3939,15 @@ mod tests {
                     window: None,
                 },
                 Some(ProtocolCapability::Semantic),
+                false,
+            ),
+            (
+                Request::Mouse {
+                    input: Vec::new(),
+                    pace_ms: 0,
+                    pane: None,
+                },
+                Some(ProtocolCapability::Pointer),
                 false,
             ),
             (Request::Status, None, false),

--- a/src/shot.rs
+++ b/src/shot.rs
@@ -7,6 +7,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::frame::{Color, Frame, indexed_color};
+use crate::recording::PointerSnapshot;
 use crate::terminal_core::TerminalCore;
 use crate::terminal_theme::TerminalTheme;
 use anyhow::{Context, Result, bail};
@@ -39,6 +40,8 @@ pub struct Options {
     pub env: BTreeMap<String, String>,
     /// Whether the terminal application inherits the parent process environment.
     pub inherit_env: bool,
+    /// Write version 2 recordings with structured pointer events.
+    pub pointer_recording: bool,
 }
 
 impl Default for Options {
@@ -58,8 +61,13 @@ impl Default for Options {
             color: ColorMode::Auto,
             env: BTreeMap::new(),
             inherit_env: true,
+            pointer_recording: false,
         }
     }
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 /// A visible terminal frame together with its source ANSI/VT stream.
@@ -67,6 +75,10 @@ impl Default for Options {
 pub struct Shot {
     pub frame: Frame,
     pub ansi: Vec<u8>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub pointer_recording: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pointer: Option<PointerSnapshot>,
 }
 
 /// Environment policy applied to a launched command's color configuration.
@@ -89,6 +101,8 @@ pub fn from_ansi(bytes: Vec<u8>, rows: u16, cols: u16, max_bytes: usize) -> Resu
     Ok(Shot {
         frame: terminal.frame()?,
         ansi: bytes,
+        pointer_recording: false,
+        pointer: None,
     })
 }
 
@@ -187,6 +201,8 @@ pub fn from_command(command: &[String], cwd: Option<&Path>, options: &Options) -
         Ok(Shot {
             frame: terminal.frame()?,
             ansi,
+            pointer_recording: false,
+            pointer: None,
         })
     })();
     #[cfg(unix)]
@@ -294,6 +310,8 @@ pub fn from_pipe_command(
         Ok(Shot {
             frame: terminal.frame()?,
             ansi,
+            pointer_recording: false,
+            pointer: None,
         })
     })();
     #[cfg(unix)]
@@ -845,6 +863,7 @@ mod tests {
                 color: ColorMode::Auto,
                 env: BTreeMap::new(),
                 inherit_env: true,
+                pointer_recording: false,
             },
         )
         .unwrap();
@@ -971,6 +990,7 @@ mod tests {
                 color: ColorMode::Auto,
                 env: BTreeMap::new(),
                 inherit_env: true,
+                pointer_recording: false,
             },
         );
 

--- a/src/tape.rs
+++ b/src/tape.rs
@@ -32,6 +32,7 @@ struct Tape {
     cwd: PathBuf,
     cwd_line: Option<usize>,
     record: Option<PathBuf>,
+    pointer_recording: bool,
     env: BTreeMap<String, String>,
     opentui_host: bool,
     color: shot::ColorMode,
@@ -158,6 +159,7 @@ fn parse(source: &Path, text: &str) -> Result<Tape> {
     let mut max_bytes: Option<Located<usize>> = None;
     let mut cwd: Option<Located<PathBuf>> = None;
     let mut record: Option<Located<PathBuf>> = None;
+    let mut pointer: Option<Located<bool>> = None;
     let mut host: Option<Located<bool>> = None;
     let mut color: Option<Located<shot::ColorMode>> = None;
     let mut env = BTreeMap::new();
@@ -252,6 +254,16 @@ fn parse(source: &Path, text: &str) -> Result<Tape> {
                     "Record",
                     resolve_path(base, &tokens[1]),
                 )?;
+            }
+            "Pointer" => {
+                require_header(source, line, command, before_launch)?;
+                exact_args(source, line, &tokens, 1, "Pointer on|off")?;
+                let value = match tokens[1].as_str() {
+                    "on" => true,
+                    "off" => false,
+                    _ => return line_error(source, line, "Pointer must be 'on' or 'off'"),
+                };
+                set_once(source, &mut pointer, line, "Pointer", value)?;
             }
             "Env" => {
                 require_header(source, line, command, before_launch)?;
@@ -471,6 +483,13 @@ fn parse(source: &Path, text: &str) -> Result<Tape> {
             source.display()
         );
     }
+    let pointer_recording = pointer.is_some_and(|value| value.value);
+    if pointer_recording && record.is_none() {
+        bail!(
+            "{}: Pointer on requires a Record FILE.termctrl directive before Launch",
+            source.display()
+        );
+    }
     let (cell_width, cell_height) = cell.map_or((9, 18), |value| value.value);
     let cwd_line = cwd.as_ref().map(|value| value.line);
     let cwd = cwd.map_or_else(|| base.to_path_buf(), |value| value.value);
@@ -486,6 +505,7 @@ fn parse(source: &Path, text: &str) -> Result<Tape> {
         cwd,
         cwd_line,
         record: record.map(|value| value.value),
+        pointer_recording,
         env,
         opentui_host: host.is_some_and(|value| value.value),
         color: color.map_or(shot::ColorMode::Auto, |value| value.value),
@@ -510,6 +530,7 @@ fn execute(tape: Tape) -> Result<()> {
         color: tape.color,
         env: tape.env.clone(),
         inherit_env: true,
+        pointer_recording: tape.pointer_recording,
     };
     session::start(
         &tape.name,
@@ -566,7 +587,17 @@ fn execute_step(tape: &Tape, step: &Step, owned: &mut OwnedSession) -> Result<()
             session::send(&tape.name, session_input(keys, !pace.is_zero())?, *pace)?;
         }
         Step::Click { x, y, .. } => {
-            session::send(&tape.name, mouse_click(*x, *y)?, Duration::ZERO)?;
+            if tape.pointer_recording {
+                session::mouse_to_in(
+                    &tape.name,
+                    None,
+                    None,
+                    super::mouse_click_events(*x, *y)?,
+                    Duration::ZERO,
+                )?;
+            } else {
+                session::send(&tape.name, mouse_click(*x, *y)?, Duration::ZERO)?;
+            }
         }
         Step::Drag {
             from,
@@ -575,7 +606,17 @@ fn execute_step(tape: &Tape, step: &Step, owned: &mut OwnedSession) -> Result<()
             pace,
             ..
         } => {
-            session::send(&tape.name, mouse_drag(*from, *to, *steps)?, *pace)?;
+            if tape.pointer_recording {
+                session::mouse_to_in(
+                    &tape.name,
+                    None,
+                    None,
+                    super::mouse_drag_events(*from, *to, *steps)?,
+                    *pace,
+                )?;
+            } else {
+                session::send(&tape.name, mouse_drag(*from, *to, *steps)?, *pace)?;
+            }
         }
         Step::Mark { name, .. } => session::mark(&tape.name, name.clone())?,
         Step::Sleep { duration, .. } => thread::sleep(*duration),

--- a/src/tape.rs
+++ b/src/tape.rs
@@ -78,6 +78,12 @@ enum Step {
         x: u16,
         y: u16,
     },
+    Move {
+        line: usize,
+        to: (u16, u16),
+        steps: u16,
+        pace: Duration,
+    },
     Drag {
         line: usize,
         from: (u16, u16),
@@ -109,6 +115,7 @@ impl Step {
             | Self::Type { line, .. }
             | Self::Key { line, .. }
             | Self::Click { line, .. }
+            | Self::Move { line, .. }
             | Self::Drag { line, .. }
             | Self::Mark { line, .. }
             | Self::Sleep { line, .. }
@@ -123,6 +130,7 @@ impl Step {
             Self::Type { .. } => "Type",
             Self::Key { .. } => "Key",
             Self::Click { .. } => "Click",
+            Self::Move { .. } => "Move",
             Self::Drag { .. } => "Drag",
             Self::Mark { .. } => "Mark",
             Self::Sleep { .. } => "Sleep",
@@ -395,6 +403,25 @@ fn parse(source: &Path, text: &str) -> Result<Tape> {
                     .map_err(|error| located_error(source, line, "invalid Click", error))?;
                 steps.push(Step::Click { line, x, y });
             }
+            "Move" => {
+                require_step(source, line, command, before_launch)?;
+                if tokens.len() < 3 {
+                    return line_error(source, line, "usage: Move X Y [Steps N] [Pace DURATION]");
+                }
+                let to = (
+                    number::<u16>(source, line, &tokens[1], "move x")?,
+                    number::<u16>(source, line, &tokens[2], "move y")?,
+                );
+                let (move_steps, pace) = motion_options(source, line, &tokens, 3, "Move")?;
+                super::mouse_move(None, to, move_steps)
+                    .map_err(|error| located_error(source, line, "invalid Move", error))?;
+                steps.push(Step::Move {
+                    line,
+                    to,
+                    steps: move_steps,
+                    pace,
+                });
+            }
             "Drag" => {
                 require_step(source, line, command, before_launch)?;
                 if tokens.len() < 5 {
@@ -412,44 +439,7 @@ fn parse(source: &Path, text: &str) -> Result<Tape> {
                     number::<u16>(source, line, &tokens[3], "drag to x")?,
                     number::<u16>(source, line, &tokens[4], "drag to y")?,
                 );
-                let mut drag_steps = 10;
-                let mut pace = Duration::from_millis(8);
-                let mut saw_steps = false;
-                let mut saw_pace = false;
-                let mut option = 5;
-                while option < tokens.len() {
-                    if option + 1 >= tokens.len() {
-                        return line_error(source, line, "Drag options require a value");
-                    }
-                    match tokens[option].as_str() {
-                        "Steps" if !saw_steps => {
-                            drag_steps =
-                                number::<u16>(source, line, &tokens[option + 1], "drag steps")?;
-                            if !(1..=1000).contains(&drag_steps) {
-                                return line_error(
-                                    source,
-                                    line,
-                                    "drag Steps must be between 1 and 1000",
-                                );
-                            }
-                            saw_steps = true;
-                        }
-                        "Pace" if !saw_pace => {
-                            pace = duration(source, line, &tokens[option + 1], true)?;
-                            saw_pace = true;
-                        }
-                        "Steps" => return line_error(source, line, "duplicate Drag Steps option"),
-                        "Pace" => return line_error(source, line, "duplicate Drag Pace option"),
-                        other => {
-                            return line_error(
-                                source,
-                                line,
-                                format!("unknown Drag option {other:?}"),
-                            );
-                        }
-                    }
-                    option += 2;
-                }
+                let (drag_steps, pace) = motion_options(source, line, &tokens, 5, "Drag")?;
                 mouse_drag(from, to, drag_steps)
                     .map_err(|error| located_error(source, line, "invalid Drag", error))?;
                 steps.push(Step::Drag {
@@ -601,8 +591,9 @@ fn execute(tape: Tape) -> Result<()> {
 
     if primary.is_none() {
         let owned = owned.as_mut().expect("successful launch owns a session");
+        let mut pointer_position = None;
         for step in &tape.steps {
-            if let Err(error) = execute_step(&tape, step, owned) {
+            if let Err(error) = execute_step(&tape, step, owned, &mut pointer_position) {
                 primary = Some(located_error(
                     &tape.source,
                     step.line(),
@@ -644,7 +635,12 @@ fn execute(tape: Tape) -> Result<()> {
     finish_lifecycle(primary, additional)
 }
 
-fn execute_step(tape: &Tape, step: &Step, owned: &mut OwnedSession) -> Result<()> {
+fn execute_step(
+    tape: &Tape,
+    step: &Step,
+    owned: &mut OwnedSession,
+    pointer_position: &mut Option<(u16, u16)>,
+) -> Result<()> {
     match step {
         Step::Wait { text, timeout, .. } => {
             if let Err(error) = session::wait(&tape.name, text.clone(), *timeout) {
@@ -678,6 +674,27 @@ fn execute_step(tape: &Tape, step: &Step, owned: &mut OwnedSession) -> Result<()
             } else {
                 session::send(&tape.name, mouse_click(*x, *y)?, Duration::ZERO)?;
             }
+            *pointer_position = Some((*x, *y));
+        }
+        Step::Move {
+            to, steps, pace, ..
+        } => {
+            if tape.pointer_recording {
+                session::mouse_to_in(
+                    &tape.name,
+                    None,
+                    None,
+                    super::mouse_move_events(*pointer_position, *to, *steps)?,
+                    *pace,
+                )?;
+            } else {
+                session::send(
+                    &tape.name,
+                    super::mouse_move(*pointer_position, *to, *steps)?,
+                    *pace,
+                )?;
+            }
+            *pointer_position = Some(*to);
         }
         Step::Drag {
             from,
@@ -697,6 +714,7 @@ fn execute_step(tape: &Tape, step: &Step, owned: &mut OwnedSession) -> Result<()
             } else {
                 session::send(&tape.name, mouse_drag(*from, *to, *steps)?, *pace)?;
             }
+            *pointer_position = Some(*to);
         }
         Step::Mark { name, .. } => session::mark(&tape.name, name.clone())?,
         Step::Sleep { duration, .. } => thread::sleep(*duration),
@@ -1032,6 +1050,60 @@ fn paced_values(
     Ok((tokens[1..].to_vec(), Duration::ZERO))
 }
 
+fn motion_options(
+    source: &Path,
+    line: usize,
+    tokens: &[String],
+    mut option: usize,
+    command: &str,
+) -> Result<(u16, Duration)> {
+    let mut steps = 10;
+    let mut pace = Duration::from_millis(8);
+    let mut saw_steps = false;
+    let mut saw_pace = false;
+    while option < tokens.len() {
+        if option + 1 >= tokens.len() {
+            return line_error(source, line, format!("{command} options require a value"));
+        }
+        match tokens[option].as_str() {
+            "Steps" if !saw_steps => {
+                steps = number::<u16>(
+                    source,
+                    line,
+                    &tokens[option + 1],
+                    &format!("{} steps", command.to_ascii_lowercase()),
+                )?;
+                if !(1..=1000).contains(&steps) {
+                    return line_error(
+                        source,
+                        line,
+                        format!(
+                            "{} Steps must be between 1 and 1000",
+                            command.to_ascii_lowercase()
+                        ),
+                    );
+                }
+                saw_steps = true;
+            }
+            "Pace" if !saw_pace => {
+                pace = duration(source, line, &tokens[option + 1], true)?;
+                saw_pace = true;
+            }
+            "Steps" => {
+                return line_error(source, line, format!("duplicate {command} Steps option"));
+            }
+            "Pace" => {
+                return line_error(source, line, format!("duplicate {command} Pace option"));
+            }
+            other => {
+                return line_error(source, line, format!("unknown {command} option {other:?}"));
+            }
+        }
+        option += 2;
+    }
+    Ok((steps, pace))
+}
+
 fn parse_action(source: &Path, line: usize, tokens: &[String], name: &str) -> Result<ActionSpec> {
     at_least_args(
         source,
@@ -1262,8 +1334,11 @@ Launch "demo-app" "--mode" 'literal # argument'
 Wait "Ready #1" Timeout 2s
 Type "hello \"tape\"" Pace 35ms
 Key ctrl-p down enter Pace 10ms
+Move 4 2 Steps 8 Pace 0ms
+Move 8 2 Steps 2 Pace 4ms
 Click 12 4
 Drag 12 4 30 4 Pace 0ms Steps 6
+Move 34 4 Steps 2 Pace 0ms
 Mark "after-input"
 Sleep 250ms
 Action "/usr/bin/touch" "fixture ready" Timeout 3s
@@ -1289,7 +1364,7 @@ Stop
         assert_eq!(tape.setup[0].value.timeout, Duration::from_secs(2));
         assert_eq!(tape.cleanup.len(), 1);
         assert_eq!(tape.cleanup[0].value.timeout, DEFAULT_ACTION_TIMEOUT);
-        assert_eq!(tape.steps.len(), 9);
+        assert_eq!(tape.steps.len(), 12);
         assert!(matches!(
             &tape.steps[1],
             Step::Type { text, pace, .. }
@@ -1297,11 +1372,16 @@ Stop
         ));
         assert!(matches!(
             &tape.steps[4],
+            Step::Move { to, steps, pace, .. }
+                if *to == (8, 2) && *steps == 2 && *pace == Duration::from_millis(4)
+        ));
+        assert!(matches!(
+            &tape.steps[6],
             Step::Drag { steps, pace, .. }
                 if *steps == 6 && pace.is_zero()
         ));
         assert!(matches!(
-            &tape.steps[7],
+            &tape.steps[10],
             Step::Action { action, .. } if action.timeout == Duration::from_secs(3)
         ));
     }
@@ -1342,6 +1422,20 @@ Stop
             parse(
                 Path::new("demo.tape"),
                 "Session demo\nViewport 80 24\nLaunch app\nKey unsupported\nStop\n"
+            )
+            .is_err()
+        );
+        assert!(
+            parse(
+                Path::new("demo.tape"),
+                "Session demo\nViewport 80 24\nLaunch app\nMove 1 2 Steps 0\nStop\n"
+            )
+            .is_err()
+        );
+        assert!(
+            parse(
+                Path::new("demo.tape"),
+                "Session demo\nViewport 80 24\nLaunch app\nMove 1 2 Pace 1ms Pace 2ms\nStop\n"
             )
             .is_err()
         );

--- a/src/tape.rs
+++ b/src/tape.rs
@@ -1,9 +1,13 @@
 use std::collections::{BTreeMap, HashSet};
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Child, Command, ExitStatus, Stdio};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
+
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 
 use anyhow::{Context, Result, anyhow, bail};
 use terminal_control::{session, shot};
@@ -13,6 +17,10 @@ use super::{mouse_click, mouse_drag, session_input};
 const MAX_TAPE_BYTES: usize = 1024 * 1024;
 const MAX_DURATION_MS: u64 = 10 * 60 * 1000;
 const MAX_DIAGNOSTIC_CHARS: usize = 4000;
+const DEFAULT_ACTION_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_ACTION_OUTPUT_BYTES: usize = 64 * 1024;
+const ACTION_POLL: Duration = Duration::from_millis(10);
+const ACTION_TERMINATION_GRACE: Duration = Duration::from_millis(250);
 
 #[derive(Debug)]
 struct Located<T> {
@@ -36,8 +44,16 @@ struct Tape {
     env: BTreeMap<String, String>,
     opentui_host: bool,
     color: shot::ColorMode,
+    setup: Vec<Located<ActionSpec>>,
     launch: Located<Vec<String>>,
     steps: Vec<Step>,
+    cleanup: Vec<Located<ActionSpec>>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ActionSpec {
+    command: Vec<String>,
+    timeout: Duration,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -79,7 +95,7 @@ enum Step {
     },
     Action {
         line: usize,
-        command: Vec<String>,
+        action: ActionSpec,
     },
     Stop {
         line: usize,
@@ -163,8 +179,10 @@ fn parse(source: &Path, text: &str) -> Result<Tape> {
     let mut host: Option<Located<bool>> = None;
     let mut color: Option<Located<shot::ColorMode>> = None;
     let mut env = BTreeMap::new();
+    let mut setup = Vec::new();
     let mut launch: Option<Located<Vec<String>>> = None;
     let mut steps = Vec::new();
+    let mut cleanup = Vec::new();
     let mut stopped = false;
     let mut markers = HashSet::new();
 
@@ -299,6 +317,20 @@ fn parse(source: &Path, text: &str) -> Result<Tape> {
                     }
                 };
                 set_once(source, &mut color, line, "Color", value)?;
+            }
+            "Setup" => {
+                require_header(source, line, command, before_launch)?;
+                setup.push(Located {
+                    line,
+                    value: parse_action(source, line, &tokens, "Setup")?,
+                });
+            }
+            "Cleanup" => {
+                require_header(source, line, command, before_launch)?;
+                cleanup.push(Located {
+                    line,
+                    value: parse_action(source, line, &tokens, "Cleanup")?,
+                });
             }
             "Launch" => {
                 require_header(source, line, command, before_launch)?;
@@ -452,11 +484,9 @@ fn parse(source: &Path, text: &str) -> Result<Tape> {
             }
             "Action" => {
                 require_step(source, line, command, before_launch)?;
-                at_least_args(source, line, &tokens, 1, "Action PROGRAM [ARG ...]")?;
-                validate_argv(source, line, &tokens[1..])?;
                 steps.push(Step::Action {
                     line,
-                    command: tokens[1..].to_vec(),
+                    action: parse_action(source, line, &tokens, "Action")?,
                 });
             }
             "Stop" => {
@@ -509,8 +539,10 @@ fn parse(source: &Path, text: &str) -> Result<Tape> {
         env,
         opentui_host: host.is_some_and(|value| value.value),
         color: color.map_or(shot::ColorMode::Auto, |value| value.value),
+        setup,
         launch,
         steps,
+        cleanup,
     })
 }
 
@@ -532,36 +564,84 @@ fn execute(tape: Tape) -> Result<()> {
         inherit_env: true,
         pointer_recording: tape.pointer_recording,
     };
-    session::start(
-        &tape.name,
-        &tape.launch.value,
-        Some(&tape.cwd),
-        tape.record.as_deref(),
-        &options,
-    )
-    .map_err(|error| located_error(&tape.source, tape.launch.line, "Launch failed", error))?;
-
-    let mut owned = OwnedSession::new(tape.name.clone());
-    for step in &tape.steps {
-        let result = execute_step(&tape, step, &mut owned);
-        if let Err(error) = result {
-            let error = located_error(
+    let mut primary = None;
+    let mut additional = Vec::new();
+    for setup in &tape.setup {
+        if let Err(error) = run_action(&tape, &setup.value) {
+            primary = Some(located_error(
                 &tape.source,
-                step.line(),
-                format!("{} failed", step.name()),
+                setup.line,
+                "Setup failed",
                 error,
-            );
-            if let Err(cleanup) = owned.stop() {
-                return Err(error.context(format!(
-                    "also failed to stop owned session {:?}: {cleanup:#}",
-                    tape.name
-                )));
-            }
-            return Err(error);
+            ));
+            break;
         }
     }
-    debug_assert!(!owned.active);
-    Ok(())
+
+    let mut owned = None;
+    if primary.is_none() {
+        match session::start(
+            &tape.name,
+            &tape.launch.value,
+            Some(&tape.cwd),
+            tape.record.as_deref(),
+            &options,
+        ) {
+            Ok(()) => owned = Some(OwnedSession::new(tape.name.clone())),
+            Err(error) => {
+                primary = Some(located_error(
+                    &tape.source,
+                    tape.launch.line,
+                    "Launch failed",
+                    error,
+                ));
+            }
+        }
+    }
+
+    if primary.is_none() {
+        let owned = owned.as_mut().expect("successful launch owns a session");
+        for step in &tape.steps {
+            if let Err(error) = execute_step(&tape, step, owned) {
+                primary = Some(located_error(
+                    &tape.source,
+                    step.line(),
+                    format!("{} failed", step.name()),
+                    error,
+                ));
+                break;
+            }
+        }
+    }
+
+    let mut cleanup_safe = true;
+    if let Some(owned) = &mut owned
+        && owned.active
+        && let Err(error) = owned.stop()
+    {
+        additional.push(anyhow!(
+            "failed to stop owned session {:?}: {error:#}",
+            tape.name
+        ));
+        cleanup_safe = false;
+    }
+    if cleanup_safe {
+        for cleanup in tape.cleanup.iter().rev() {
+            if let Err(error) = run_action(&tape, &cleanup.value) {
+                additional.push(located_error(
+                    &tape.source,
+                    cleanup.line,
+                    "Cleanup failed",
+                    error,
+                ));
+            }
+        }
+    } else if !tape.cleanup.is_empty() {
+        additional.push(anyhow!(
+            "skipped Cleanup because the owned session could not be confirmed stopped"
+        ));
+    }
+    finish_lifecycle(primary, additional)
 }
 
 fn execute_step(tape: &Tape, step: &Step, owned: &mut OwnedSession) -> Result<()> {
@@ -620,35 +700,192 @@ fn execute_step(tape: &Tape, step: &Step, owned: &mut OwnedSession) -> Result<()
         }
         Step::Mark { name, .. } => session::mark(&tape.name, name.clone())?,
         Step::Sleep { duration, .. } => thread::sleep(*duration),
-        Step::Action { command, .. } => run_action(tape, command)?,
+        Step::Action { action, .. } => run_action(tape, action)?,
         Step::Stop { .. } => owned.stop()?,
     }
     Ok(())
 }
 
-fn run_action(tape: &Tape, command: &[String]) -> Result<()> {
-    let output = Command::new(&command[0])
+fn finish_lifecycle(
+    primary: Option<anyhow::Error>,
+    mut additional: Vec<anyhow::Error>,
+) -> Result<()> {
+    let primary = match primary {
+        Some(error) => error,
+        None if additional.is_empty() => return Ok(()),
+        None => additional.remove(0),
+    };
+    if additional.is_empty() {
+        return Err(primary);
+    }
+    let detail = additional
+        .iter()
+        .map(|error| format!("- {error:#}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    Err(anyhow!(
+        "{primary:#}\nadditional lifecycle failures:\n{detail}"
+    ))
+}
+
+fn run_action(tape: &Tape, action: &ActionSpec) -> Result<()> {
+    let command = &action.command;
+    let mut process = Command::new(&command[0]);
+    process
         .args(&command[1..])
         .current_dir(&tape.cwd)
         .envs(&tape.env)
-        .output()
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    #[cfg(unix)]
+    unsafe {
+        process.pre_exec(|| {
+            if libc::setsid() < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut child = process
+        .spawn()
         .with_context(|| format!("run host action argv {command:?}"))?;
-    if output.status.success() {
+    let stdout = child.stdout.take().context("capture host action stdout")?;
+    let stderr = child.stderr.take().context("capture host action stderr")?;
+    let stdout = thread::spawn(move || read_action_output(stdout));
+    let stderr = thread::spawn(move || read_action_output(stderr));
+    let outcome = wait_for_action(&mut child, action.timeout);
+    if outcome.is_err() {
+        let _ = terminate_action_group(child.id());
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+    let stdout = stdout
+        .join()
+        .map_err(|_| anyhow!("host action stdout reader panicked"))??;
+    let stderr = stderr
+        .join()
+        .map_err(|_| anyhow!("host action stderr reader panicked"))??;
+    let (status, timed_out) = outcome?;
+    if timed_out {
+        bail!(
+            "host action argv {command:?} timed out after {}; output:\n{}",
+            display_duration(action.timeout),
+            action_output(&stdout, &stderr)
+        );
+    }
+    if status.success() {
         return Ok(());
     }
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let detail = if !stderr.trim().is_empty() {
-        diagnostic_text(&stderr)
-    } else if !stdout.trim().is_empty() {
-        diagnostic_text(&stdout)
-    } else {
-        "<no output>".to_owned()
-    };
     bail!(
-        "host action argv {command:?} exited with {}; output:\n{detail}",
-        output.status
+        "host action argv {command:?} exited with {status}; output:\n{}",
+        action_output(&stdout, &stderr)
     )
+}
+
+struct ActionOutput {
+    bytes: Vec<u8>,
+    truncated: bool,
+}
+
+fn read_action_output(mut reader: impl Read) -> std::io::Result<ActionOutput> {
+    let mut bytes = Vec::with_capacity(MAX_ACTION_OUTPUT_BYTES);
+    let mut truncated = false;
+    let mut buffer = [0_u8; 8192];
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        let remaining = MAX_ACTION_OUTPUT_BYTES.saturating_sub(bytes.len());
+        bytes.extend_from_slice(&buffer[..read.min(remaining)]);
+        truncated |= read > remaining;
+    }
+    Ok(ActionOutput { bytes, truncated })
+}
+
+fn action_output(stdout: &ActionOutput, stderr: &ActionOutput) -> String {
+    let mut sections = Vec::new();
+    for (name, output) in [("stderr", stderr), ("stdout", stdout)] {
+        if output.bytes.is_empty() && !output.truncated {
+            continue;
+        }
+        let mut text = diagnostic_text(&String::from_utf8_lossy(&output.bytes));
+        if output.truncated && !text.ends_with("<truncated>") {
+            text.push_str("\n<truncated>");
+        }
+        sections.push(format!("{name}:\n{text}"));
+    }
+    if sections.is_empty() {
+        "<no output>".to_owned()
+    } else {
+        sections.join("\n")
+    }
+}
+
+fn wait_for_action(child: &mut Child, timeout: Duration) -> Result<(ExitStatus, bool)> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait().context("wait for host action")? {
+            terminate_action_group(child.id())?;
+            return Ok((status, false));
+        }
+        if Instant::now() >= deadline {
+            terminate_action_group(child.id())?;
+            let status = child.wait().context("reap timed-out host action")?;
+            return Ok((status, true));
+        }
+        thread::sleep(ACTION_POLL);
+    }
+}
+
+#[cfg(unix)]
+fn terminate_action_group(id: u32) -> Result<()> {
+    let group = id as libc::pid_t;
+    if !process_group_exists(group)? {
+        return Ok(());
+    }
+    signal_process_group(group, libc::SIGTERM)?;
+    let deadline = Instant::now() + ACTION_TERMINATION_GRACE;
+    while Instant::now() < deadline {
+        if !process_group_exists(group)? {
+            return Ok(());
+        }
+        thread::sleep(ACTION_POLL);
+    }
+    signal_process_group(group, libc::SIGKILL)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn process_group_exists(group: libc::pid_t) -> Result<bool> {
+    if unsafe { libc::killpg(group, 0) } == 0 {
+        return Ok(true);
+    }
+    let error = std::io::Error::last_os_error();
+    if error.raw_os_error() == Some(libc::ESRCH) {
+        Ok(false)
+    } else {
+        Err(error).context("inspect host action process group")
+    }
+}
+
+#[cfg(unix)]
+fn signal_process_group(group: libc::pid_t, signal: libc::c_int) -> Result<()> {
+    if unsafe { libc::killpg(group, signal) } == 0 {
+        return Ok(());
+    }
+    let error = std::io::Error::last_os_error();
+    if error.raw_os_error() == Some(libc::ESRCH) {
+        Ok(())
+    } else {
+        Err(error).context("terminate host action process group")
+    }
+}
+
+#[cfg(not(unix))]
+fn terminate_action_group(_id: u32) -> Result<()> {
+    bail!("tape actions require Unix process-group control")
 }
 
 struct OwnedSession {
@@ -793,6 +1030,33 @@ fn paced_values(
         return Ok((tokens[1..tokens.len() - 2].to_vec(), pace));
     }
     Ok((tokens[1..].to_vec(), Duration::ZERO))
+}
+
+fn parse_action(source: &Path, line: usize, tokens: &[String], name: &str) -> Result<ActionSpec> {
+    at_least_args(
+        source,
+        line,
+        tokens,
+        1,
+        &format!("{name} PROGRAM [ARG ...] [Timeout DURATION]"),
+    )?;
+    if tokens.last().is_some_and(|token| token == "Timeout") {
+        return line_error(
+            source,
+            line,
+            format!("usage: {name} PROGRAM [ARG ...] [Timeout DURATION]"),
+        );
+    }
+    let (command, timeout) = if tokens.len() >= 4 && tokens[tokens.len() - 2] == "Timeout" {
+        (
+            tokens[1..tokens.len() - 2].to_vec(),
+            duration(source, line, &tokens[tokens.len() - 1], false)?,
+        )
+    } else {
+        (tokens[1..].to_vec(), DEFAULT_ACTION_TIMEOUT)
+    };
+    validate_argv(source, line, &command)?;
+    Ok(ActionSpec { command, timeout })
 }
 
 fn duration(source: &Path, line: usize, value: &str, allow_zero: bool) -> Result<Duration> {
@@ -991,6 +1255,8 @@ Env DEMO_VALUE "quoted # value\nnext"
 Record "artifacts/demo.termctrl"
 Host opentui
 Color always
+Setup "/usr/bin/touch" "fixture ready" Timeout 2s
+Cleanup "/usr/bin/rm" "-f" "fixture ready"
 Launch "demo-app" "--mode" 'literal # argument'
 
 Wait "Ready #1" Timeout 2s
@@ -1000,7 +1266,7 @@ Click 12 4
 Drag 12 4 30 4 Pace 0ms Steps 6
 Mark "after-input"
 Sleep 250ms
-Action "/usr/bin/touch" "fixture ready"
+Action "/usr/bin/touch" "fixture ready" Timeout 3s
 Stop
 "#;
 
@@ -1019,6 +1285,10 @@ Stop
             tape.launch.value,
             ["demo-app", "--mode", "literal # argument"]
         );
+        assert_eq!(tape.setup.len(), 1);
+        assert_eq!(tape.setup[0].value.timeout, Duration::from_secs(2));
+        assert_eq!(tape.cleanup.len(), 1);
+        assert_eq!(tape.cleanup[0].value.timeout, DEFAULT_ACTION_TIMEOUT);
         assert_eq!(tape.steps.len(), 9);
         assert!(matches!(
             &tape.steps[1],
@@ -1029,6 +1299,10 @@ Stop
             &tape.steps[4],
             Step::Drag { steps, pace, .. }
                 if *steps == 6 && pace.is_zero()
+        ));
+        assert!(matches!(
+            &tape.steps[7],
+            Step::Action { action, .. } if action.timeout == Duration::from_secs(3)
         ));
     }
 
@@ -1075,6 +1349,13 @@ Stop
             parse(
                 Path::new("demo.tape"),
                 "Session demo\nViewport 80 24\nLaunch app\nStop\nSleep 1s\n"
+            )
+            .is_err()
+        );
+        assert!(
+            parse(
+                Path::new("demo.tape"),
+                "Session demo\nViewport 80 24\nSetup touch Timeout nope\nLaunch app\nStop\n"
             )
             .is_err()
         );

--- a/src/tape.rs
+++ b/src/tape.rs
@@ -12,7 +12,7 @@ use std::os::unix::process::CommandExt;
 use anyhow::{Context, Result, anyhow, bail};
 use terminal_control::{session, shot};
 
-use super::{mouse_click, mouse_drag, session_input};
+use super::{mouse_click, mouse_drag, mouse_secondary_click, session_input};
 
 const MAX_TAPE_BYTES: usize = 1024 * 1024;
 const MAX_DURATION_MS: u64 = 10 * 60 * 1000;
@@ -56,12 +56,26 @@ struct ActionSpec {
     timeout: Duration,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum WaitMatch {
+    Substring,
+    Line,
+}
+
+#[derive(Debug)]
+pub(super) struct PlayReceipt {
+    pub source: PathBuf,
+    pub session: String,
+    pub recording: Option<PathBuf>,
+}
+
 #[derive(Debug, PartialEq, Eq)]
 enum Step {
     Wait {
         line: usize,
         text: String,
         timeout: Duration,
+        match_kind: WaitMatch,
     },
     Type {
         line: usize,
@@ -74,6 +88,11 @@ enum Step {
         pace: Duration,
     },
     Click {
+        line: usize,
+        x: u16,
+        y: u16,
+    },
+    RightClick {
         line: usize,
         x: u16,
         y: u16,
@@ -115,6 +134,7 @@ impl Step {
             | Self::Type { line, .. }
             | Self::Key { line, .. }
             | Self::Click { line, .. }
+            | Self::RightClick { line, .. }
             | Self::Move { line, .. }
             | Self::Drag { line, .. }
             | Self::Mark { line, .. }
@@ -130,6 +150,7 @@ impl Step {
             Self::Type { .. } => "Type",
             Self::Key { .. } => "Key",
             Self::Click { .. } => "Click",
+            Self::RightClick { .. } => "RightClick",
             Self::Move { .. } => "Move",
             Self::Drag { .. } => "Drag",
             Self::Mark { .. } => "Mark",
@@ -140,7 +161,7 @@ impl Step {
     }
 }
 
-pub(super) fn play(path: &Path) -> Result<()> {
+pub(super) fn play(path: &Path) -> Result<PlayReceipt> {
     if path.extension().and_then(|extension| extension.to_str()) != Some("tape") {
         bail!(
             "tape source must use the .tape extension; .termctrl is reserved for recording output"
@@ -155,7 +176,13 @@ pub(super) fn play(path: &Path) -> Result<()> {
         .with_context(|| format!("tape {} is not valid UTF-8", source.display()))?;
     let tape = parse(&source, &text)?;
     tape.validate_paths()?;
-    execute(tape)
+    let receipt = PlayReceipt {
+        source: tape.source.clone(),
+        session: tape.name.clone(),
+        recording: tape.record.clone(),
+    };
+    execute(tape)?;
+    Ok(receipt)
 }
 
 impl Tape {
@@ -351,24 +378,22 @@ fn parse(source: &Path, text: &str) -> Result<Tape> {
             }
             "Wait" => {
                 require_step(source, line, command, before_launch)?;
-                if tokens.len() != 2 && tokens.len() != 4 {
-                    return line_error(source, line, "usage: Wait TEXT [Timeout DURATION]");
+                if tokens.len() < 2 {
+                    return line_error(
+                        source,
+                        line,
+                        "usage: Wait TEXT [Match substring|line] [Timeout DURATION]",
+                    );
                 }
                 if tokens[1].is_empty() {
                     return line_error(source, line, "Wait text must not be empty");
                 }
-                let timeout = if tokens.len() == 4 {
-                    if tokens[2] != "Timeout" {
-                        return line_error(source, line, "usage: Wait TEXT [Timeout DURATION]");
-                    }
-                    duration(source, line, &tokens[3], false)?
-                } else {
-                    Duration::from_secs(5)
-                };
+                let (match_kind, timeout) = wait_options(source, line, &tokens)?;
                 steps.push(Step::Wait {
                     line,
                     text: tokens[1].clone(),
                     timeout,
+                    match_kind,
                 });
             }
             "Type" => {
@@ -402,6 +427,15 @@ fn parse(source: &Path, text: &str) -> Result<Tape> {
                 mouse_click(x, y)
                     .map_err(|error| located_error(source, line, "invalid Click", error))?;
                 steps.push(Step::Click { line, x, y });
+            }
+            "RightClick" => {
+                require_step(source, line, command, before_launch)?;
+                exact_args(source, line, &tokens, 2, "RightClick X Y")?;
+                let x = number::<u16>(source, line, &tokens[1], "right-click x")?;
+                let y = number::<u16>(source, line, &tokens[2], "right-click y")?;
+                mouse_secondary_click(x, y)
+                    .map_err(|error| located_error(source, line, "invalid RightClick", error))?;
+                steps.push(Step::RightClick { line, x, y });
             }
             "Move" => {
                 require_step(source, line, command, before_launch)?;
@@ -642,8 +676,17 @@ fn execute_step(
     pointer_position: &mut Option<(u16, u16)>,
 ) -> Result<()> {
     match step {
-        Step::Wait { text, timeout, .. } => {
-            if let Err(error) = session::wait(&tape.name, text.clone(), *timeout) {
+        Step::Wait {
+            text,
+            timeout,
+            match_kind,
+            ..
+        } => {
+            let wait = match match_kind {
+                WaitMatch::Substring => session::wait(&tape.name, text.clone(), *timeout),
+                WaitMatch::Line => wait_for_line(&tape.name, text, *timeout),
+            };
+            if let Err(error) = wait {
                 let screen = session::show(&tape.name, Duration::ZERO, Duration::ZERO)
                     .map(|shot| diagnostic_text(&shot.frame.text()))
                     .unwrap_or_else(|screen_error| {
@@ -673,6 +716,24 @@ fn execute_step(
                 )?;
             } else {
                 session::send(&tape.name, mouse_click(*x, *y)?, Duration::ZERO)?;
+            }
+            *pointer_position = Some((*x, *y));
+        }
+        Step::RightClick { x, y, .. } => {
+            if tape.pointer_recording {
+                session::mouse_to_in(
+                    &tape.name,
+                    None,
+                    None,
+                    super::mouse_click_events_with_button(
+                        *x,
+                        *y,
+                        terminal_control::recording::PointerButton::Secondary,
+                    )?,
+                    Duration::ZERO,
+                )?;
+            } else {
+                session::send(&tape.name, mouse_secondary_click(*x, *y)?, Duration::ZERO)?;
             }
             *pointer_position = Some((*x, *y));
         }
@@ -722,6 +783,23 @@ fn execute_step(
         Step::Stop { .. } => owned.stop()?,
     }
     Ok(())
+}
+
+fn wait_for_line(name: &str, text: &str, timeout: Duration) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let screen = session::show(name, Duration::ZERO, Duration::ZERO)?;
+        if screen.frame.text().lines().any(|line| line == text) {
+            return Ok(());
+        }
+        if session::status(name)?.state == session::SessionState::Exited {
+            bail!("session ended before a visible line exactly matched {text:?}");
+        }
+        if Instant::now() >= deadline {
+            bail!("timed out waiting for a visible line exactly matching {text:?}");
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
 }
 
 fn finish_lifecycle(
@@ -1050,6 +1128,44 @@ fn paced_values(
     Ok((tokens[1..].to_vec(), Duration::ZERO))
 }
 
+fn wait_options(source: &Path, line: usize, tokens: &[String]) -> Result<(WaitMatch, Duration)> {
+    let mut match_kind = WaitMatch::Substring;
+    let mut timeout = Duration::from_secs(5);
+    let mut saw_match = false;
+    let mut saw_timeout = false;
+    let mut option = 2;
+    while option < tokens.len() {
+        if option + 1 >= tokens.len() {
+            return line_error(source, line, "Wait options require a value");
+        }
+        match tokens[option].as_str() {
+            "Match" if !saw_match => {
+                match_kind = match tokens[option + 1].as_str() {
+                    "substring" => WaitMatch::Substring,
+                    "line" => WaitMatch::Line,
+                    _ => {
+                        return line_error(
+                            source,
+                            line,
+                            "Wait Match must be 'substring' or 'line'",
+                        );
+                    }
+                };
+                saw_match = true;
+            }
+            "Timeout" if !saw_timeout => {
+                timeout = duration(source, line, &tokens[option + 1], false)?;
+                saw_timeout = true;
+            }
+            "Match" => return line_error(source, line, "duplicate Wait Match option"),
+            "Timeout" => return line_error(source, line, "duplicate Wait Timeout option"),
+            other => return line_error(source, line, format!("unknown Wait option {other:?}")),
+        }
+        option += 2;
+    }
+    Ok((match_kind, timeout))
+}
+
 fn motion_options(
     source: &Path,
     line: usize,
@@ -1331,12 +1447,13 @@ Setup "/usr/bin/touch" "fixture ready" Timeout 2s
 Cleanup "/usr/bin/rm" "-f" "fixture ready"
 Launch "demo-app" "--mode" 'literal # argument'
 
-Wait "Ready #1" Timeout 2s
+Wait "Ready #1" Match line Timeout 2s
 Type "hello \"tape\"" Pace 35ms
-Key ctrl-p down enter Pace 10ms
+Key ctrl-p down shift+enter Pace 10ms
 Move 4 2 Steps 8 Pace 0ms
 Move 8 2 Steps 2 Pace 4ms
 Click 12 4
+RightClick 13 4
 Drag 12 4 30 4 Pace 0ms Steps 6
 Move 34 4 Steps 2 Pace 0ms
 Mark "after-input"
@@ -1364,7 +1481,15 @@ Stop
         assert_eq!(tape.setup[0].value.timeout, Duration::from_secs(2));
         assert_eq!(tape.cleanup.len(), 1);
         assert_eq!(tape.cleanup[0].value.timeout, DEFAULT_ACTION_TIMEOUT);
-        assert_eq!(tape.steps.len(), 12);
+        assert_eq!(tape.steps.len(), 13);
+        assert!(matches!(
+            &tape.steps[0],
+            Step::Wait {
+                match_kind: WaitMatch::Line,
+                timeout,
+                ..
+            } if *timeout == Duration::from_secs(2)
+        ));
         assert!(matches!(
             &tape.steps[1],
             Step::Type { text, pace, .. }
@@ -1376,12 +1501,12 @@ Stop
                 if *to == (8, 2) && *steps == 2 && *pace == Duration::from_millis(4)
         ));
         assert!(matches!(
-            &tape.steps[6],
+            &tape.steps[7],
             Step::Drag { steps, pace, .. }
                 if *steps == 6 && pace.is_zero()
         ));
         assert!(matches!(
-            &tape.steps[10],
+            &tape.steps[11],
             Step::Action { action, .. } if action.timeout == Duration::from_secs(3)
         ));
     }
@@ -1412,6 +1537,33 @@ Stop
         .unwrap_err();
 
         assert_eq!(error.to_string(), "broken.tape:5: usage: Stop");
+    }
+
+    #[test]
+    fn wait_defaults_to_substring_and_validates_match_modifiers() {
+        let tape = parse(
+            Path::new("demo.tape"),
+            "Session demo\nViewport 80 24\nLaunch app\nWait ready Timeout 2s\nStop\n",
+        )
+        .unwrap();
+        assert!(matches!(
+            &tape.steps[0],
+            Step::Wait {
+                match_kind: WaitMatch::Substring,
+                timeout,
+                ..
+            } if *timeout == Duration::from_secs(2)
+        ));
+
+        for invalid in [
+            "Wait ready Match exact",
+            "Wait ready Match line Match substring",
+            "Wait ready Timeout 1s Timeout 2s",
+            "Wait ready Unknown line",
+        ] {
+            let source = format!("Session demo\nViewport 80 24\nLaunch app\n{invalid}\nStop\n");
+            assert!(parse(Path::new("demo.tape"), &source).is_err(), "{invalid}");
+        }
     }
 
     #[test]

--- a/src/tape.rs
+++ b/src/tape.rs
@@ -1,0 +1,1041 @@
+use std::collections::{BTreeMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow, bail};
+use terminal_control::{session, shot};
+
+use super::{mouse_click, mouse_drag, session_input};
+
+const MAX_TAPE_BYTES: usize = 1024 * 1024;
+const MAX_DURATION_MS: u64 = 10 * 60 * 1000;
+const MAX_DIAGNOSTIC_CHARS: usize = 4000;
+
+#[derive(Debug)]
+struct Located<T> {
+    line: usize,
+    value: T,
+}
+
+#[derive(Debug)]
+struct Tape {
+    source: PathBuf,
+    name: String,
+    cols: u16,
+    rows: u16,
+    cell_width: u16,
+    cell_height: u16,
+    max_bytes: usize,
+    cwd: PathBuf,
+    cwd_line: Option<usize>,
+    record: Option<PathBuf>,
+    env: BTreeMap<String, String>,
+    opentui_host: bool,
+    color: shot::ColorMode,
+    launch: Located<Vec<String>>,
+    steps: Vec<Step>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum Step {
+    Wait {
+        line: usize,
+        text: String,
+        timeout: Duration,
+    },
+    Type {
+        line: usize,
+        text: String,
+        pace: Duration,
+    },
+    Key {
+        line: usize,
+        keys: Vec<String>,
+        pace: Duration,
+    },
+    Click {
+        line: usize,
+        x: u16,
+        y: u16,
+    },
+    Drag {
+        line: usize,
+        from: (u16, u16),
+        to: (u16, u16),
+        steps: u16,
+        pace: Duration,
+    },
+    Mark {
+        line: usize,
+        name: String,
+    },
+    Sleep {
+        line: usize,
+        duration: Duration,
+    },
+    Action {
+        line: usize,
+        command: Vec<String>,
+    },
+    Stop {
+        line: usize,
+    },
+}
+
+impl Step {
+    fn line(&self) -> usize {
+        match self {
+            Self::Wait { line, .. }
+            | Self::Type { line, .. }
+            | Self::Key { line, .. }
+            | Self::Click { line, .. }
+            | Self::Drag { line, .. }
+            | Self::Mark { line, .. }
+            | Self::Sleep { line, .. }
+            | Self::Action { line, .. }
+            | Self::Stop { line } => *line,
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Wait { .. } => "Wait",
+            Self::Type { .. } => "Type",
+            Self::Key { .. } => "Key",
+            Self::Click { .. } => "Click",
+            Self::Drag { .. } => "Drag",
+            Self::Mark { .. } => "Mark",
+            Self::Sleep { .. } => "Sleep",
+            Self::Action { .. } => "Action",
+            Self::Stop { .. } => "Stop",
+        }
+    }
+}
+
+pub(super) fn play(path: &Path) -> Result<()> {
+    if path.extension().and_then(|extension| extension.to_str()) != Some("tape") {
+        bail!(
+            "tape source must use the .tape extension; .termctrl is reserved for recording output"
+        );
+    }
+    let source = fs::canonicalize(path).with_context(|| format!("open tape {}", path.display()))?;
+    let bytes = fs::read(&source).with_context(|| format!("read tape {}", source.display()))?;
+    if bytes.len() > MAX_TAPE_BYTES {
+        bail!("tape {} exceeds the 1 MiB source limit", source.display());
+    }
+    let text = String::from_utf8(bytes)
+        .with_context(|| format!("tape {} is not valid UTF-8", source.display()))?;
+    let tape = parse(&source, &text)?;
+    tape.validate_paths()?;
+    execute(tape)
+}
+
+impl Tape {
+    fn validate_paths(&self) -> Result<()> {
+        if !self.cwd.is_dir() {
+            let line = self.cwd_line.unwrap_or(1);
+            bail!(
+                "{}:{line}: Cwd is not a directory: {}",
+                self.source.display(),
+                self.cwd.display()
+            );
+        }
+        Ok(())
+    }
+}
+
+fn parse(source: &Path, text: &str) -> Result<Tape> {
+    if text.contains('\0') {
+        bail!("{}:1: tape source contains a NUL byte", source.display());
+    }
+    let base = source.parent().unwrap_or_else(|| Path::new("."));
+    let mut name: Option<Located<String>> = None;
+    let mut viewport: Option<Located<(u16, u16)>> = None;
+    let mut cell: Option<Located<(u16, u16)>> = None;
+    let mut max_bytes: Option<Located<usize>> = None;
+    let mut cwd: Option<Located<PathBuf>> = None;
+    let mut record: Option<Located<PathBuf>> = None;
+    let mut host: Option<Located<bool>> = None;
+    let mut color: Option<Located<shot::ColorMode>> = None;
+    let mut env = BTreeMap::new();
+    let mut launch: Option<Located<Vec<String>>> = None;
+    let mut steps = Vec::new();
+    let mut stopped = false;
+    let mut markers = HashSet::new();
+
+    for (index, raw) in text.lines().enumerate() {
+        let line = index + 1;
+        let tokens = lex_line(source, line, raw)?;
+        if tokens.is_empty() {
+            continue;
+        }
+        let command = tokens[0].as_str();
+        if stopped {
+            return line_error(source, line, "no commands are allowed after Stop");
+        }
+        let before_launch = launch.is_none();
+        match command {
+            "Session" => {
+                require_header(source, line, command, before_launch)?;
+                exact_args(source, line, &tokens, 1, "Session NAME")?;
+                if !valid_session_name(&tokens[1]) {
+                    return line_error(
+                        source,
+                        line,
+                        "session names may contain only ASCII letters, digits, '.', '-', and '_'",
+                    );
+                }
+                set_once(source, &mut name, line, "Session", tokens[1].clone())?;
+            }
+            "Viewport" => {
+                require_header(source, line, command, before_launch)?;
+                exact_args(source, line, &tokens, 2, "Viewport COLS ROWS")?;
+                let cols = number::<u16>(source, line, &tokens[1], "viewport columns")?;
+                let rows = number::<u16>(source, line, &tokens[2], "viewport rows")?;
+                if cols == 0 || rows == 0 {
+                    return line_error(
+                        source,
+                        line,
+                        "viewport dimensions must be greater than zero",
+                    );
+                }
+                set_once(source, &mut viewport, line, "Viewport", (cols, rows))?;
+            }
+            "Cell" => {
+                require_header(source, line, command, before_launch)?;
+                exact_args(source, line, &tokens, 2, "Cell WIDTH HEIGHT")?;
+                let width = number::<u16>(source, line, &tokens[1], "cell width")?;
+                let height = number::<u16>(source, line, &tokens[2], "cell height")?;
+                if width == 0 || height == 0 {
+                    return line_error(source, line, "cell dimensions must be greater than zero");
+                }
+                set_once(source, &mut cell, line, "Cell", (width, height))?;
+            }
+            "MaxBytes" => {
+                require_header(source, line, command, before_launch)?;
+                exact_args(source, line, &tokens, 1, "MaxBytes BYTES")?;
+                let bytes = number::<usize>(source, line, &tokens[1], "MaxBytes")?;
+                if bytes == 0 {
+                    return line_error(source, line, "MaxBytes must be greater than zero");
+                }
+                set_once(source, &mut max_bytes, line, "MaxBytes", bytes)?;
+            }
+            "Cwd" => {
+                require_header(source, line, command, before_launch)?;
+                exact_args(source, line, &tokens, 1, "Cwd PATH")?;
+                set_once(
+                    source,
+                    &mut cwd,
+                    line,
+                    "Cwd",
+                    resolve_path(base, &tokens[1]),
+                )?;
+            }
+            "Record" => {
+                require_header(source, line, command, before_launch)?;
+                exact_args(source, line, &tokens, 1, "Record FILE.termctrl")?;
+                let path = PathBuf::from(&tokens[1]);
+                if path.extension().and_then(|extension| extension.to_str()) != Some("termctrl") {
+                    return line_error(
+                        source,
+                        line,
+                        "Record output must use the .termctrl extension",
+                    );
+                }
+                set_once(
+                    source,
+                    &mut record,
+                    line,
+                    "Record",
+                    resolve_path(base, &tokens[1]),
+                )?;
+            }
+            "Env" => {
+                require_header(source, line, command, before_launch)?;
+                exact_args(source, line, &tokens, 2, "Env KEY VALUE")?;
+                validate_env_key(source, line, &tokens[1])?;
+                if env.insert(tokens[1].clone(), tokens[2].clone()).is_some() {
+                    return line_error(source, line, format!("duplicate Env key {:?}", tokens[1]));
+                }
+            }
+            "Host" => {
+                require_header(source, line, command, before_launch)?;
+                exact_args(source, line, &tokens, 1, "Host none|opentui")?;
+                let value = match tokens[1].as_str() {
+                    "none" => false,
+                    "opentui" => true,
+                    _ => return line_error(source, line, "Host must be 'none' or 'opentui'"),
+                };
+                set_once(source, &mut host, line, "Host", value)?;
+            }
+            "Color" => {
+                require_header(source, line, command, before_launch)?;
+                exact_args(source, line, &tokens, 1, "Color auto|always|never")?;
+                let value = match tokens[1].as_str() {
+                    "auto" => shot::ColorMode::Auto,
+                    "always" => shot::ColorMode::Always,
+                    "never" => shot::ColorMode::Never,
+                    _ => {
+                        return line_error(
+                            source,
+                            line,
+                            "Color must be 'auto', 'always', or 'never'",
+                        );
+                    }
+                };
+                set_once(source, &mut color, line, "Color", value)?;
+            }
+            "Launch" => {
+                require_header(source, line, command, before_launch)?;
+                at_least_args(source, line, &tokens, 1, "Launch PROGRAM [ARG ...]")?;
+                validate_argv(source, line, &tokens[1..])?;
+                launch = Some(Located {
+                    line,
+                    value: tokens[1..].to_vec(),
+                });
+            }
+            "Wait" => {
+                require_step(source, line, command, before_launch)?;
+                if tokens.len() != 2 && tokens.len() != 4 {
+                    return line_error(source, line, "usage: Wait TEXT [Timeout DURATION]");
+                }
+                if tokens[1].is_empty() {
+                    return line_error(source, line, "Wait text must not be empty");
+                }
+                let timeout = if tokens.len() == 4 {
+                    if tokens[2] != "Timeout" {
+                        return line_error(source, line, "usage: Wait TEXT [Timeout DURATION]");
+                    }
+                    duration(source, line, &tokens[3], false)?
+                } else {
+                    Duration::from_secs(5)
+                };
+                steps.push(Step::Wait {
+                    line,
+                    text: tokens[1].clone(),
+                    timeout,
+                });
+            }
+            "Type" => {
+                require_step(source, line, command, before_launch)?;
+                let (values, pace) =
+                    paced_values(source, line, &tokens, "Type TEXT [Pace DURATION]")?;
+                if values.len() != 1 {
+                    return line_error(source, line, "usage: Type TEXT [Pace DURATION]");
+                }
+                let text = values[0].clone();
+                session_input(&[format!("text:{text}")], !pace.is_zero())
+                    .map_err(|error| located_error(source, line, "invalid Type", error))?;
+                steps.push(Step::Type { line, text, pace });
+            }
+            "Key" => {
+                require_step(source, line, command, before_launch)?;
+                let (keys, pace) =
+                    paced_values(source, line, &tokens, "Key KEY [KEY ...] [Pace DURATION]")?;
+                if keys.is_empty() {
+                    return line_error(source, line, "usage: Key KEY [KEY ...] [Pace DURATION]");
+                }
+                session_input(&keys, !pace.is_zero())
+                    .map_err(|error| located_error(source, line, "invalid Key", error))?;
+                steps.push(Step::Key { line, keys, pace });
+            }
+            "Click" => {
+                require_step(source, line, command, before_launch)?;
+                exact_args(source, line, &tokens, 2, "Click X Y")?;
+                let x = number::<u16>(source, line, &tokens[1], "click x")?;
+                let y = number::<u16>(source, line, &tokens[2], "click y")?;
+                mouse_click(x, y)
+                    .map_err(|error| located_error(source, line, "invalid Click", error))?;
+                steps.push(Step::Click { line, x, y });
+            }
+            "Drag" => {
+                require_step(source, line, command, before_launch)?;
+                if tokens.len() < 5 {
+                    return line_error(
+                        source,
+                        line,
+                        "usage: Drag FROM_X FROM_Y TO_X TO_Y [Steps N] [Pace DURATION]",
+                    );
+                }
+                let from = (
+                    number::<u16>(source, line, &tokens[1], "drag from x")?,
+                    number::<u16>(source, line, &tokens[2], "drag from y")?,
+                );
+                let to = (
+                    number::<u16>(source, line, &tokens[3], "drag to x")?,
+                    number::<u16>(source, line, &tokens[4], "drag to y")?,
+                );
+                let mut drag_steps = 10;
+                let mut pace = Duration::from_millis(8);
+                let mut saw_steps = false;
+                let mut saw_pace = false;
+                let mut option = 5;
+                while option < tokens.len() {
+                    if option + 1 >= tokens.len() {
+                        return line_error(source, line, "Drag options require a value");
+                    }
+                    match tokens[option].as_str() {
+                        "Steps" if !saw_steps => {
+                            drag_steps =
+                                number::<u16>(source, line, &tokens[option + 1], "drag steps")?;
+                            if !(1..=1000).contains(&drag_steps) {
+                                return line_error(
+                                    source,
+                                    line,
+                                    "drag Steps must be between 1 and 1000",
+                                );
+                            }
+                            saw_steps = true;
+                        }
+                        "Pace" if !saw_pace => {
+                            pace = duration(source, line, &tokens[option + 1], true)?;
+                            saw_pace = true;
+                        }
+                        "Steps" => return line_error(source, line, "duplicate Drag Steps option"),
+                        "Pace" => return line_error(source, line, "duplicate Drag Pace option"),
+                        other => {
+                            return line_error(
+                                source,
+                                line,
+                                format!("unknown Drag option {other:?}"),
+                            );
+                        }
+                    }
+                    option += 2;
+                }
+                mouse_drag(from, to, drag_steps)
+                    .map_err(|error| located_error(source, line, "invalid Drag", error))?;
+                steps.push(Step::Drag {
+                    line,
+                    from,
+                    to,
+                    steps: drag_steps,
+                    pace,
+                });
+            }
+            "Mark" => {
+                require_step(source, line, command, before_launch)?;
+                exact_args(source, line, &tokens, 1, "Mark NAME")?;
+                if tokens[1].is_empty() {
+                    return line_error(source, line, "marker name must not be empty");
+                }
+                if !markers.insert(tokens[1].clone()) {
+                    return line_error(source, line, format!("duplicate marker {:?}", tokens[1]));
+                }
+                steps.push(Step::Mark {
+                    line,
+                    name: tokens[1].clone(),
+                });
+            }
+            "Sleep" => {
+                require_step(source, line, command, before_launch)?;
+                exact_args(source, line, &tokens, 1, "Sleep DURATION")?;
+                steps.push(Step::Sleep {
+                    line,
+                    duration: duration(source, line, &tokens[1], false)?,
+                });
+            }
+            "Action" => {
+                require_step(source, line, command, before_launch)?;
+                at_least_args(source, line, &tokens, 1, "Action PROGRAM [ARG ...]")?;
+                validate_argv(source, line, &tokens[1..])?;
+                steps.push(Step::Action {
+                    line,
+                    command: tokens[1..].to_vec(),
+                });
+            }
+            "Stop" => {
+                require_step(source, line, command, before_launch)?;
+                exact_args(source, line, &tokens, 0, "Stop")?;
+                steps.push(Step::Stop { line });
+                stopped = true;
+            }
+            _ => {
+                return line_error(source, line, format!("unknown tape command {command:?}"));
+            }
+        }
+    }
+
+    let name = required(source, name, "Session")?.value;
+    let (cols, rows) = required(source, viewport, "Viewport")?.value;
+    let launch = required(source, launch, "Launch")?;
+    if !stopped {
+        bail!("{}: missing required final Stop command", source.display());
+    }
+    if !markers.is_empty() && record.is_none() {
+        bail!(
+            "{}: Mark requires a Record FILE.termctrl directive before Launch",
+            source.display()
+        );
+    }
+    let (cell_width, cell_height) = cell.map_or((9, 18), |value| value.value);
+    let cwd_line = cwd.as_ref().map(|value| value.line);
+    let cwd = cwd.map_or_else(|| base.to_path_buf(), |value| value.value);
+
+    Ok(Tape {
+        source: source.to_path_buf(),
+        name,
+        cols,
+        rows,
+        cell_width,
+        cell_height,
+        max_bytes: max_bytes.map_or(16 * 1024 * 1024, |value| value.value),
+        cwd,
+        cwd_line,
+        record: record.map(|value| value.value),
+        env,
+        opentui_host: host.is_some_and(|value| value.value),
+        color: color.map_or(shot::ColorMode::Auto, |value| value.value),
+        launch,
+        steps,
+    })
+}
+
+fn execute(tape: Tape) -> Result<()> {
+    let options = shot::Options {
+        cols: tape.cols,
+        rows: tape.rows,
+        cell_width: tape.cell_width,
+        cell_height: tape.cell_height,
+        settle: Duration::ZERO,
+        deadline: Duration::ZERO,
+        input: Vec::new(),
+        initial_delay: Duration::ZERO,
+        wait_for: None,
+        max_bytes: tape.max_bytes,
+        opentui_host: tape.opentui_host,
+        color: tape.color,
+        env: tape.env.clone(),
+        inherit_env: true,
+    };
+    session::start(
+        &tape.name,
+        &tape.launch.value,
+        Some(&tape.cwd),
+        tape.record.as_deref(),
+        &options,
+    )
+    .map_err(|error| located_error(&tape.source, tape.launch.line, "Launch failed", error))?;
+
+    let mut owned = OwnedSession::new(tape.name.clone());
+    for step in &tape.steps {
+        let result = execute_step(&tape, step, &mut owned);
+        if let Err(error) = result {
+            let error = located_error(
+                &tape.source,
+                step.line(),
+                format!("{} failed", step.name()),
+                error,
+            );
+            if let Err(cleanup) = owned.stop() {
+                return Err(error.context(format!(
+                    "also failed to stop owned session {:?}: {cleanup:#}",
+                    tape.name
+                )));
+            }
+            return Err(error);
+        }
+    }
+    debug_assert!(!owned.active);
+    Ok(())
+}
+
+fn execute_step(tape: &Tape, step: &Step, owned: &mut OwnedSession) -> Result<()> {
+    match step {
+        Step::Wait { text, timeout, .. } => {
+            if let Err(error) = session::wait(&tape.name, text.clone(), *timeout) {
+                let screen = session::show(&tape.name, Duration::ZERO, Duration::ZERO)
+                    .map(|shot| diagnostic_text(&shot.frame.text()))
+                    .unwrap_or_else(|screen_error| {
+                        format!("<screen unavailable: {screen_error:#}>")
+                    });
+                bail!(
+                    "{error:#}\nlast visible screen after {}:\n{screen}",
+                    display_duration(*timeout)
+                );
+            }
+        }
+        Step::Type { text, pace, .. } => {
+            let input = session_input(&[format!("text:{text}")], !pace.is_zero())?;
+            session::send(&tape.name, input, *pace)?;
+        }
+        Step::Key { keys, pace, .. } => {
+            session::send(&tape.name, session_input(keys, !pace.is_zero())?, *pace)?;
+        }
+        Step::Click { x, y, .. } => {
+            session::send(&tape.name, mouse_click(*x, *y)?, Duration::ZERO)?;
+        }
+        Step::Drag {
+            from,
+            to,
+            steps,
+            pace,
+            ..
+        } => {
+            session::send(&tape.name, mouse_drag(*from, *to, *steps)?, *pace)?;
+        }
+        Step::Mark { name, .. } => session::mark(&tape.name, name.clone())?,
+        Step::Sleep { duration, .. } => thread::sleep(*duration),
+        Step::Action { command, .. } => run_action(tape, command)?,
+        Step::Stop { .. } => owned.stop()?,
+    }
+    Ok(())
+}
+
+fn run_action(tape: &Tape, command: &[String]) -> Result<()> {
+    let output = Command::new(&command[0])
+        .args(&command[1..])
+        .current_dir(&tape.cwd)
+        .envs(&tape.env)
+        .output()
+        .with_context(|| format!("run host action argv {command:?}"))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let detail = if !stderr.trim().is_empty() {
+        diagnostic_text(&stderr)
+    } else if !stdout.trim().is_empty() {
+        diagnostic_text(&stdout)
+    } else {
+        "<no output>".to_owned()
+    };
+    bail!(
+        "host action argv {command:?} exited with {}; output:\n{detail}",
+        output.status
+    )
+}
+
+struct OwnedSession {
+    name: String,
+    active: bool,
+}
+
+impl OwnedSession {
+    fn new(name: String) -> Self {
+        Self { name, active: true }
+    }
+
+    fn stop(&mut self) -> Result<()> {
+        if !self.active {
+            return Ok(());
+        }
+        session::stop(&self.name)?;
+        self.active = false;
+        Ok(())
+    }
+}
+
+impl Drop for OwnedSession {
+    fn drop(&mut self) {
+        if self.active {
+            let _ = session::stop(&self.name);
+        }
+    }
+}
+
+fn lex_line(source: &Path, line: usize, input: &str) -> Result<Vec<String>> {
+    let chars: Vec<char> = input.chars().collect();
+    let mut tokens = Vec::new();
+    let mut index = 0;
+    while index < chars.len() {
+        while index < chars.len() && chars[index].is_whitespace() {
+            index += 1;
+        }
+        if index == chars.len() || chars[index] == '#' {
+            break;
+        }
+        let mut token = String::new();
+        let mut started = false;
+        let mut comment = false;
+        while index < chars.len() {
+            match chars[index] {
+                value if value.is_whitespace() => break,
+                '#' => {
+                    comment = true;
+                    break;
+                }
+                '\'' | '"' => {
+                    let quote = chars[index];
+                    let column = index + 1;
+                    started = true;
+                    index += 1;
+                    let mut closed = false;
+                    while index < chars.len() {
+                        let value = chars[index];
+                        if value == quote {
+                            closed = true;
+                            index += 1;
+                            break;
+                        }
+                        if value == '\\' && quote == '"' {
+                            index += 1;
+                            if index == chars.len() {
+                                return line_error(
+                                    source,
+                                    line,
+                                    "trailing escape in double-quoted text",
+                                );
+                            }
+                            token.push(escaped(source, line, chars[index])?);
+                            index += 1;
+                            continue;
+                        }
+                        token.push(value);
+                        index += 1;
+                    }
+                    if !closed {
+                        return line_error(
+                            source,
+                            line,
+                            format!("unterminated {quote} quote beginning at column {column}"),
+                        );
+                    }
+                }
+                '\\' => {
+                    started = true;
+                    index += 1;
+                    if index == chars.len() {
+                        return line_error(source, line, "trailing escape in unquoted text");
+                    }
+                    token.push(chars[index]);
+                    index += 1;
+                }
+                value => {
+                    started = true;
+                    token.push(value);
+                    index += 1;
+                }
+            }
+        }
+        if started {
+            tokens.push(token);
+        }
+        if comment {
+            break;
+        }
+    }
+    Ok(tokens)
+}
+
+fn escaped(source: &Path, line: usize, value: char) -> Result<char> {
+    match value {
+        '\\' => Ok('\\'),
+        '"' => Ok('"'),
+        '\'' => Ok('\''),
+        'n' => Ok('\n'),
+        'r' => Ok('\r'),
+        't' => Ok('\t'),
+        other => line_error(
+            source,
+            line,
+            format!("unsupported escape \\{other}; use \\\\, \\\", \\n, \\r, or \\t"),
+        ),
+    }
+}
+
+fn paced_values(
+    source: &Path,
+    line: usize,
+    tokens: &[String],
+    usage: &str,
+) -> Result<(Vec<String>, Duration)> {
+    if tokens.len() < 2 {
+        return line_error(source, line, format!("usage: {usage}"));
+    }
+    if tokens.len() >= 3 && tokens[tokens.len() - 2] == "Pace" {
+        let pace = duration(source, line, &tokens[tokens.len() - 1], true)?;
+        return Ok((tokens[1..tokens.len() - 2].to_vec(), pace));
+    }
+    Ok((tokens[1..].to_vec(), Duration::ZERO))
+}
+
+fn duration(source: &Path, line: usize, value: &str, allow_zero: bool) -> Result<Duration> {
+    let split = value
+        .find(|character: char| !character.is_ascii_digit())
+        .unwrap_or(value.len());
+    let (number, unit) = value.split_at(split);
+    if number.is_empty() || unit.is_empty() {
+        return line_error(
+            source,
+            line,
+            format!("invalid duration {value:?}; use 250ms, 2s, or 1m"),
+        );
+    }
+    let number = number
+        .parse::<u64>()
+        .map_err(|_| anyhow!("invalid duration number"))
+        .map_err(|error| {
+            located_error(source, line, format!("invalid duration {value:?}"), error)
+        })?;
+    let multiplier = match unit {
+        "ms" => 1,
+        "s" => 1000,
+        "m" => 60_000,
+        _ => {
+            return line_error(
+                source,
+                line,
+                format!("invalid duration unit in {value:?}; use ms, s, or m"),
+            );
+        }
+    };
+    let milliseconds = number
+        .checked_mul(multiplier)
+        .filter(|value| *value <= MAX_DURATION_MS)
+        .ok_or_else(|| anyhow!("{}:{line}: duration exceeds 10 minutes", source.display()))?;
+    if milliseconds == 0 && !allow_zero {
+        return line_error(source, line, "duration must be greater than zero");
+    }
+    Ok(Duration::from_millis(milliseconds))
+}
+
+fn display_duration(duration: Duration) -> String {
+    format!("{}ms", duration.as_millis())
+}
+
+fn diagnostic_text(value: &str) -> String {
+    let mut output: String = value.chars().take(MAX_DIAGNOSTIC_CHARS).collect();
+    if value.chars().count() > MAX_DIAGNOSTIC_CHARS {
+        output.push_str("\n<truncated>");
+    }
+    if output.trim().is_empty() {
+        "<empty>".to_owned()
+    } else {
+        output
+    }
+}
+
+fn resolve_path(base: &Path, value: &str) -> PathBuf {
+    let path = PathBuf::from(value);
+    if path.is_absolute() {
+        path
+    } else {
+        base.join(path)
+    }
+}
+
+fn validate_env_key(source: &Path, line: usize, key: &str) -> Result<()> {
+    if key.is_empty() || key.contains('=') || key.contains('\0') {
+        return line_error(
+            source,
+            line,
+            "Env keys must be non-empty and cannot contain '=' or NUL",
+        );
+    }
+    Ok(())
+}
+
+fn validate_argv(source: &Path, line: usize, command: &[String]) -> Result<()> {
+    if command[0].is_empty() {
+        return line_error(source, line, "program name must not be empty");
+    }
+    if command.iter().any(|value| value.contains('\0')) {
+        return line_error(source, line, "argv values cannot contain NUL");
+    }
+    Ok(())
+}
+
+fn valid_session_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+}
+
+fn number<T>(source: &Path, line: usize, value: &str, label: &str) -> Result<T>
+where
+    T: std::str::FromStr,
+{
+    value
+        .parse()
+        .map_err(|_| anyhow!("{}:{line}: invalid {label} {value:?}", source.display()))
+}
+
+fn require_header(source: &Path, line: usize, command: &str, before_launch: bool) -> Result<()> {
+    if !before_launch {
+        return line_error(source, line, format!("{command} must appear before Launch"));
+    }
+    Ok(())
+}
+
+fn require_step(source: &Path, line: usize, command: &str, before_launch: bool) -> Result<()> {
+    if before_launch {
+        return line_error(
+            source,
+            line,
+            format!("{command} requires a preceding Launch"),
+        );
+    }
+    Ok(())
+}
+
+fn exact_args(
+    source: &Path,
+    line: usize,
+    tokens: &[String],
+    count: usize,
+    usage: &str,
+) -> Result<()> {
+    if tokens.len() != count + 1 {
+        return line_error(source, line, format!("usage: {usage}"));
+    }
+    Ok(())
+}
+
+fn at_least_args(
+    source: &Path,
+    line: usize,
+    tokens: &[String],
+    count: usize,
+    usage: &str,
+) -> Result<()> {
+    if tokens.len() < count + 1 {
+        return line_error(source, line, format!("usage: {usage}"));
+    }
+    Ok(())
+}
+
+fn set_once<T>(
+    source: &Path,
+    target: &mut Option<Located<T>>,
+    line: usize,
+    name: &str,
+    value: T,
+) -> Result<()> {
+    if let Some(previous) = target {
+        return line_error(
+            source,
+            line,
+            format!("duplicate {name}; first declared on line {}", previous.line),
+        );
+    }
+    *target = Some(Located { line, value });
+    Ok(())
+}
+
+fn required<T>(source: &Path, value: Option<Located<T>>, name: &str) -> Result<Located<T>> {
+    value.ok_or_else(|| anyhow!("{}: missing required {name} directive", source.display()))
+}
+
+fn located_error(
+    source: &Path,
+    line: usize,
+    message: impl std::fmt::Display,
+    error: anyhow::Error,
+) -> anyhow::Error {
+    error.context(format!("{}:{line}: {message}", source.display()))
+}
+
+fn line_error<T>(source: &Path, line: usize, message: impl std::fmt::Display) -> Result<T> {
+    Err(anyhow!("{}:{line}: {message}", source.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FULL_TAPE: &str = r#"
+# source comments stay out of quoted text
+Session "demo-session"
+Viewport 112 34
+Cell 9 18
+MaxBytes 4096
+Cwd "."
+Env DEMO_VALUE "quoted # value\nnext"
+Record "artifacts/demo.termctrl"
+Host opentui
+Color always
+Launch "demo-app" "--mode" 'literal # argument'
+
+Wait "Ready #1" Timeout 2s
+Type "hello \"tape\"" Pace 35ms
+Key ctrl-p down enter Pace 10ms
+Click 12 4
+Drag 12 4 30 4 Pace 0ms Steps 6
+Mark "after-input"
+Sleep 250ms
+Action "/usr/bin/touch" "fixture ready"
+Stop
+"#;
+
+    #[test]
+    fn parses_complete_state_aware_tape() {
+        let tape = parse(Path::new("/tmp/demo.tape"), FULL_TAPE).unwrap();
+
+        assert_eq!(tape.name, "demo-session");
+        assert_eq!((tape.cols, tape.rows), (112, 34));
+        assert_eq!((tape.cell_width, tape.cell_height), (9, 18));
+        assert_eq!(tape.max_bytes, 4096);
+        assert_eq!(tape.env["DEMO_VALUE"], "quoted # value\nnext");
+        assert!(tape.opentui_host);
+        assert_eq!(tape.color, shot::ColorMode::Always);
+        assert_eq!(
+            tape.launch.value,
+            ["demo-app", "--mode", "literal # argument"]
+        );
+        assert_eq!(tape.steps.len(), 9);
+        assert!(matches!(
+            &tape.steps[1],
+            Step::Type { text, pace, .. }
+                if text == "hello \"tape\"" && *pace == Duration::from_millis(35)
+        ));
+        assert!(matches!(
+            &tape.steps[4],
+            Step::Drag { steps, pace, .. }
+                if *steps == 6 && pace.is_zero()
+        ));
+    }
+
+    #[test]
+    fn reports_quote_and_validation_errors_at_the_source_line() {
+        let error = parse(
+            Path::new("broken.tape"),
+            "Session demo\nViewport 80 24\nLaunch \"unterminated\nStop\n",
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("broken.tape:3: unterminated"));
+
+        let error = parse(
+            Path::new("broken.tape"),
+            "Session demo\nViewport 80 24\nLaunch app\nMark done\nStop\n",
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("Mark requires a Record"));
+    }
+
+    #[test]
+    fn validates_every_command_before_execution() {
+        let error = parse(
+            Path::new("broken.tape"),
+            "Session demo\nViewport 80 24\nLaunch app\nAction touch changed\nStop extra\n",
+        )
+        .unwrap_err();
+
+        assert_eq!(error.to_string(), "broken.tape:5: usage: Stop");
+    }
+
+    #[test]
+    fn rejects_invalid_durations_keys_and_post_stop_commands() {
+        assert!(duration(Path::new("demo.tape"), 2, "1.5s", false).is_err());
+        assert!(duration(Path::new("demo.tape"), 2, "11m", false).is_err());
+        assert!(
+            parse(
+                Path::new("demo.tape"),
+                "Session demo\nViewport 80 24\nLaunch app\nKey unsupported\nStop\n"
+            )
+            .is_err()
+        );
+        assert!(
+            parse(
+                Path::new("demo.tape"),
+                "Session demo\nViewport 80 24\nLaunch app\nStop\nSleep 1s\n"
+            )
+            .is_err()
+        );
+    }
+}

--- a/src/tape.rs
+++ b/src/tape.rs
@@ -7,9 +7,12 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 #[cfg(unix)]
+use std::os::fd::AsRawFd;
+#[cfg(unix)]
 use std::os::unix::process::CommandExt;
 
 use anyhow::{Context, Result, anyhow, bail};
+use serde::Serialize;
 use terminal_control::{session, shot};
 
 use super::{mouse_click, mouse_drag, mouse_secondary_click, session_input};
@@ -19,8 +22,10 @@ const MAX_DURATION_MS: u64 = 10 * 60 * 1000;
 const MAX_DIAGNOSTIC_CHARS: usize = 4000;
 const DEFAULT_ACTION_TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_ACTION_OUTPUT_BYTES: usize = 64 * 1024;
+const ACTION_DRAIN_BURST_BYTES: usize = 64 * 1024;
 const ACTION_POLL: Duration = Duration::from_millis(10);
 const ACTION_TERMINATION_GRACE: Duration = Duration::from_millis(250);
+const ACTION_DRAIN_GRACE: Duration = Duration::from_millis(250);
 
 #[derive(Debug)]
 struct Located<T> {
@@ -62,8 +67,10 @@ enum WaitMatch {
     Line,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub(super) struct PlayReceipt {
+    pub status: &'static str,
+    #[serde(rename = "tape")]
     pub source: PathBuf,
     pub session: String,
     pub recording: Option<PathBuf>,
@@ -161,7 +168,7 @@ impl Step {
     }
 }
 
-pub(super) fn play(path: &Path) -> Result<PlayReceipt> {
+pub(super) fn play(path: &Path, json_receipt: bool) -> Result<PlayReceipt> {
     if path.extension().and_then(|extension| extension.to_str()) != Some("tape") {
         bail!(
             "tape source must use the .tape extension; .termctrl is reserved for recording output"
@@ -177,12 +184,36 @@ pub(super) fn play(path: &Path) -> Result<PlayReceipt> {
     let tape = parse(&source, &text)?;
     tape.validate_paths()?;
     let receipt = PlayReceipt {
+        status: "ok",
         source: tape.source.clone(),
         session: tape.name.clone(),
         recording: tape.record.clone(),
     };
+    if json_receipt {
+        receipt.validate_json_paths()?;
+    }
     execute(tape)?;
     Ok(receipt)
+}
+
+impl PlayReceipt {
+    fn validate_json_paths(&self) -> Result<()> {
+        if self.source.to_str().is_none() {
+            bail!(
+                "play --json requires a UTF-8 tape path before lifecycle side effects: {}",
+                self.source.display()
+            );
+        }
+        if let Some(recording) = &self.recording
+            && recording.to_str().is_none()
+        {
+            bail!(
+                "play --json requires a UTF-8 recording path before lifecycle side effects: {}",
+                recording.display()
+            );
+        }
+        Ok(())
+    }
 }
 
 impl Tape {
@@ -528,6 +559,7 @@ fn parse(source: &Path, text: &str) -> Result<Tape> {
     let name = required(source, name, "Session")?.value;
     let (cols, rows) = required(source, viewport, "Viewport")?.value;
     let launch = required(source, launch, "Launch")?;
+    validate_mouse_coordinates(source, &steps, cols, rows)?;
     if !stopped {
         bail!("{}: missing required final Stop command", source.display());
     }
@@ -568,6 +600,30 @@ fn parse(source: &Path, text: &str) -> Result<Tape> {
         steps,
         cleanup,
     })
+}
+
+fn validate_mouse_coordinates(source: &Path, steps: &[Step], cols: u16, rows: u16) -> Result<()> {
+    for step in steps {
+        let coordinates: &[(&str, (u16, u16))] = match step {
+            Step::Click { x, y, .. } => &[("Click", (*x, *y))],
+            Step::RightClick { x, y, .. } => &[("RightClick", (*x, *y))],
+            Step::Move { to, .. } => &[("Move", *to)],
+            Step::Drag { from, to, .. } => &[("Drag start", *from), ("Drag end", *to)],
+            _ => continue,
+        };
+        for (label, (x, y)) in coordinates {
+            if *x >= cols || *y >= rows {
+                return line_error(
+                    source,
+                    step.line(),
+                    format!(
+                        "{label} coordinate ({x}, {y}) is outside Viewport {cols}x{rows}; coordinates must satisfy X < {cols} and Y < {rows}"
+                    ),
+                );
+            }
+        }
+    }
+    Ok(())
 }
 
 fn execute(tape: Tape) -> Result<()> {
@@ -706,55 +762,39 @@ fn execute_step(
             session::send(&tape.name, session_input(keys, !pace.is_zero())?, *pace)?;
         }
         Step::Click { x, y, .. } => {
-            if tape.pointer_recording {
-                session::mouse_to_in(
-                    &tape.name,
-                    None,
-                    None,
-                    super::mouse_click_events(*x, *y)?,
-                    Duration::ZERO,
-                )?;
-            } else {
-                session::send(&tape.name, mouse_click(*x, *y)?, Duration::ZERO)?;
-            }
+            session::mouse_to_in(
+                &tape.name,
+                None,
+                None,
+                super::mouse_click_events(*x, *y)?,
+                Duration::ZERO,
+            )?;
             *pointer_position = Some((*x, *y));
         }
         Step::RightClick { x, y, .. } => {
-            if tape.pointer_recording {
-                session::mouse_to_in(
-                    &tape.name,
-                    None,
-                    None,
-                    super::mouse_click_events_with_button(
-                        *x,
-                        *y,
-                        terminal_control::recording::PointerButton::Secondary,
-                    )?,
-                    Duration::ZERO,
-                )?;
-            } else {
-                session::send(&tape.name, mouse_secondary_click(*x, *y)?, Duration::ZERO)?;
-            }
+            session::mouse_to_in(
+                &tape.name,
+                None,
+                None,
+                super::mouse_click_events_with_button(
+                    *x,
+                    *y,
+                    terminal_control::recording::PointerButton::Secondary,
+                )?,
+                Duration::ZERO,
+            )?;
             *pointer_position = Some((*x, *y));
         }
         Step::Move {
             to, steps, pace, ..
         } => {
-            if tape.pointer_recording {
-                session::mouse_to_in(
-                    &tape.name,
-                    None,
-                    None,
-                    super::mouse_move_events(*pointer_position, *to, *steps)?,
-                    *pace,
-                )?;
-            } else {
-                session::send(
-                    &tape.name,
-                    super::mouse_move(*pointer_position, *to, *steps)?,
-                    *pace,
-                )?;
-            }
+            session::mouse_to_in(
+                &tape.name,
+                None,
+                None,
+                super::mouse_move_events(*pointer_position, *to, *steps)?,
+                *pace,
+            )?;
             *pointer_position = Some(*to);
         }
         Step::Drag {
@@ -764,17 +804,13 @@ fn execute_step(
             pace,
             ..
         } => {
-            if tape.pointer_recording {
-                session::mouse_to_in(
-                    &tape.name,
-                    None,
-                    None,
-                    super::mouse_drag_events(*from, *to, *steps)?,
-                    *pace,
-                )?;
-            } else {
-                session::send(&tape.name, mouse_drag(*from, *to, *steps)?, *pace)?;
-            }
+            session::mouse_to_in(
+                &tape.name,
+                None,
+                None,
+                super::mouse_drag_events(*from, *to, *steps)?,
+                *pace,
+            )?;
             *pointer_position = Some(*to);
         }
         Step::Mark { name, .. } => session::mark(&tape.name, name.clone())?,
@@ -825,6 +861,9 @@ fn finish_lifecycle(
 }
 
 fn run_action(tape: &Tape, action: &ActionSpec) -> Result<()> {
+    #[cfg(not(unix))]
+    bail!("tape actions require Unix process-group control");
+
     let command = &action.command;
     let mut process = Command::new(&command[0]);
     process
@@ -846,28 +885,45 @@ fn run_action(tape: &Tape, action: &ActionSpec) -> Result<()> {
     let mut child = process
         .spawn()
         .with_context(|| format!("run host action argv {command:?}"))?;
-    let stdout = child.stdout.take().context("capture host action stdout")?;
-    let stderr = child.stderr.take().context("capture host action stderr")?;
-    let stdout = thread::spawn(move || read_action_output(stdout));
-    let stderr = thread::spawn(move || read_action_output(stderr));
-    let outcome = wait_for_action(&mut child, action.timeout);
+    let mut stdout = child.stdout.take().context("capture host action stdout")?;
+    let mut stderr = child.stderr.take().context("capture host action stderr")?;
+    let nonblocking = set_nonblocking(&stdout)
+        .context("bound host action stdout drain")
+        .and_then(|()| set_nonblocking(&stderr).context("bound host action stderr drain"));
+    if let Err(error) = nonblocking {
+        let _ = terminate_action_group(child.id());
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(error);
+    }
+    let mut stdout_output = ActionOutput::default();
+    let mut stderr_output = ActionOutput::default();
+    let outcome = wait_for_action(
+        &mut child,
+        action.timeout,
+        &mut stdout,
+        &mut stderr,
+        &mut stdout_output,
+        &mut stderr_output,
+    );
     if outcome.is_err() {
         let _ = terminate_action_group(child.id());
         let _ = child.kill();
         let _ = child.wait();
     }
-    let stdout = stdout
-        .join()
-        .map_err(|_| anyhow!("host action stdout reader panicked"))??;
-    let stderr = stderr
-        .join()
-        .map_err(|_| anyhow!("host action stderr reader panicked"))??;
-    let (status, timed_out) = outcome?;
+    let (status, timed_out, drain) = outcome?;
     if timed_out {
         bail!(
             "host action argv {command:?} timed out after {}; output:\n{}",
             display_duration(action.timeout),
-            action_output(&stdout, &stderr)
+            action_output(&stdout_output, &stderr_output, drain)
+        );
+    }
+    if drain.incomplete() {
+        bail!(
+            "host action argv {command:?} left output pipes open after {}; detached descendants may still be running; output:\n{}",
+            display_duration(ACTION_DRAIN_GRACE),
+            action_output(&stdout_output, &stderr_output, drain)
         );
     }
     if status.success() {
@@ -875,32 +931,54 @@ fn run_action(tape: &Tape, action: &ActionSpec) -> Result<()> {
     }
     bail!(
         "host action argv {command:?} exited with {status}; output:\n{}",
-        action_output(&stdout, &stderr)
+        action_output(&stdout_output, &stderr_output, drain)
     )
 }
 
+#[derive(Default)]
 struct ActionOutput {
     bytes: Vec<u8>,
     truncated: bool,
 }
 
-fn read_action_output(mut reader: impl Read) -> std::io::Result<ActionOutput> {
-    let mut bytes = Vec::with_capacity(MAX_ACTION_OUTPUT_BYTES);
-    let mut truncated = false;
-    let mut buffer = [0_u8; 8192];
-    loop {
-        let read = reader.read(&mut buffer)?;
-        if read == 0 {
-            break;
-        }
-        let remaining = MAX_ACTION_OUTPUT_BYTES.saturating_sub(bytes.len());
-        bytes.extend_from_slice(&buffer[..read.min(remaining)]);
-        truncated |= read > remaining;
-    }
-    Ok(ActionOutput { bytes, truncated })
+#[derive(Clone, Copy)]
+struct ActionDrain {
+    stdout_open: bool,
+    stderr_open: bool,
 }
 
-fn action_output(stdout: &ActionOutput, stderr: &ActionOutput) -> String {
+impl ActionDrain {
+    fn incomplete(self) -> bool {
+        self.stdout_open || self.stderr_open
+    }
+}
+
+fn drain_action_output(reader: &mut impl Read, output: &mut ActionOutput) -> std::io::Result<bool> {
+    let mut buffer = [0_u8; 8192];
+    let mut drained = 0;
+    loop {
+        let read = match reader.read(&mut buffer) {
+            Ok(0) => return Ok(false),
+            Ok(read) => read,
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => return Ok(true),
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(error) => return Err(error),
+        };
+        let remaining = MAX_ACTION_OUTPUT_BYTES.saturating_sub(output.bytes.len());
+        output
+            .bytes
+            .extend_from_slice(&buffer[..read.min(remaining)]);
+        if read > remaining {
+            output.truncated = true;
+        }
+        drained += read;
+        if drained >= ACTION_DRAIN_BURST_BYTES {
+            return Ok(true);
+        }
+    }
+}
+
+fn action_output(stdout: &ActionOutput, stderr: &ActionOutput, drain: ActionDrain) -> String {
     let mut sections = Vec::new();
     for (name, output) in [("stderr", stderr), ("stdout", stdout)] {
         if output.bytes.is_empty() && !output.truncated {
@@ -912,6 +990,18 @@ fn action_output(stdout: &ActionOutput, stderr: &ActionOutput) -> String {
         }
         sections.push(format!("{name}:\n{text}"));
     }
+    if drain.incomplete() {
+        let pipes = match (drain.stdout_open, drain.stderr_open) {
+            (true, true) => "stdout and stderr",
+            (true, false) => "stdout",
+            (false, true) => "stderr",
+            (false, false) => unreachable!(),
+        };
+        sections.push(format!(
+            "drain:\n<{pipes} remained open after {}>",
+            display_duration(ACTION_DRAIN_GRACE)
+        ));
+    }
     if sections.is_empty() {
         "<no output>".to_owned()
     } else {
@@ -919,20 +1009,98 @@ fn action_output(stdout: &ActionOutput, stderr: &ActionOutput) -> String {
     }
 }
 
-fn wait_for_action(child: &mut Child, timeout: Duration) -> Result<(ExitStatus, bool)> {
+fn wait_for_action(
+    child: &mut Child,
+    timeout: Duration,
+    stdout: &mut impl Read,
+    stderr: &mut impl Read,
+    stdout_output: &mut ActionOutput,
+    stderr_output: &mut ActionOutput,
+) -> Result<(ExitStatus, bool, ActionDrain)> {
     let deadline = Instant::now() + timeout;
     loop {
+        let stdout_open =
+            drain_action_output(stdout, stdout_output).context("drain host action stdout")?;
+        let stderr_open =
+            drain_action_output(stderr, stderr_output).context("drain host action stderr")?;
         if let Some(status) = child.try_wait().context("wait for host action")? {
             terminate_action_group(child.id())?;
-            return Ok((status, false));
+            let drain = finish_action_drain(
+                stdout,
+                stderr,
+                stdout_output,
+                stderr_output,
+                stdout_open,
+                stderr_open,
+            )?;
+            return Ok((status, false, drain));
         }
         if Instant::now() >= deadline {
             terminate_action_group(child.id())?;
             let status = child.wait().context("reap timed-out host action")?;
-            return Ok((status, true));
+            let drain = finish_action_drain(
+                stdout,
+                stderr,
+                stdout_output,
+                stderr_output,
+                stdout_open,
+                stderr_open,
+            )?;
+            return Ok((status, true, drain));
         }
         thread::sleep(ACTION_POLL);
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn finish_action_drain(
+    stdout: &mut impl Read,
+    stderr: &mut impl Read,
+    stdout_output: &mut ActionOutput,
+    stderr_output: &mut ActionOutput,
+    mut stdout_open: bool,
+    mut stderr_open: bool,
+) -> Result<ActionDrain> {
+    let deadline = Instant::now() + ACTION_DRAIN_GRACE;
+    while stdout_open || stderr_open {
+        if stdout_open {
+            stdout_open = drain_action_output(stdout, stdout_output)
+                .context("finish host action stdout drain")?;
+        }
+        if stderr_open {
+            stderr_open = drain_action_output(stderr, stderr_output)
+                .context("finish host action stderr drain")?;
+        }
+        if !stdout_open && !stderr_open || Instant::now() >= deadline {
+            break;
+        }
+        thread::sleep(ACTION_POLL);
+    }
+    Ok(ActionDrain {
+        stdout_open,
+        stderr_open,
+    })
+}
+
+#[cfg(unix)]
+fn set_nonblocking(file: &impl AsRawFd) -> std::io::Result<()> {
+    let descriptor = file.as_raw_fd();
+    let flags = unsafe { libc::fcntl(descriptor, libc::F_GETFL) };
+    if flags < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if unsafe { libc::fcntl(descriptor, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_nonblocking(_file: &impl Read) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "tape actions require Unix process-group control",
+    ))
 }
 
 #[cfg(unix)]
@@ -1605,5 +1773,25 @@ Stop
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn rejects_every_mouse_endpoint_outside_the_declared_viewport() {
+        for (line, label) in [
+            ("Click 2 0", "Click coordinate (2, 0)"),
+            ("RightClick 0 1", "RightClick coordinate (0, 1)"),
+            ("Move 2 0", "Move coordinate (2, 0)"),
+            ("Drag 0 0 2 0", "Drag end coordinate (2, 0)"),
+            ("Drag 0 1 1 0", "Drag start coordinate (0, 1)"),
+        ] {
+            let source = format!("Session demo\nViewport 2 1\nLaunch app\n{line}\nStop\n");
+            let error = parse(Path::new("bounds.tape"), &source).unwrap_err();
+            let message = error.to_string();
+            assert!(message.contains(label), "{line}: {message}");
+            assert!(
+                message.contains("outside Viewport 2x1"),
+                "{line}: {message}"
+            );
+        }
     }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -753,6 +753,16 @@ impl Workspace {
         self.send_all(Some(pane), input, pace, tick)
     }
 
+    pub(crate) fn send_mouse_input_all_in(
+        &mut self,
+        name: &str,
+        input: &[crate::session::MouseInput],
+        pace: Duration,
+    ) -> Result<()> {
+        let index = self.window_index(name)?;
+        self.windows[index].send_mouse_input_all(None, input, pace)
+    }
+
     pub(crate) fn wait_for_text_in(
         &mut self,
         name: &str,
@@ -1361,6 +1371,23 @@ impl Workspace {
             }
         }
         Ok(())
+    }
+
+    pub(crate) fn send_mouse_input_all(
+        &mut self,
+        pane: Option<PaneId>,
+        input: &[crate::session::MouseInput],
+        pace: Duration,
+    ) -> Result<()> {
+        let window = match pane {
+            Some(pane) => self
+                .pane_window_index(pane)
+                .ok_or_else(|| anyhow::anyhow!("workspace has no pane {pane}"))?,
+            None => self
+                .active_window_index()
+                .context("workspace has no active window")?,
+        };
+        self.windows[window].send_mouse_input_all(pane, input, pace)
     }
 
     pub(crate) fn capture(
@@ -2333,6 +2360,16 @@ impl Window {
     pub(crate) fn send(&mut self, pane: Option<PaneId>, input: &[u8]) -> Result<()> {
         let index = self.resolve_pane(pane)?;
         self.panes[index].session.send_current(input)
+    }
+
+    fn send_mouse_input_all(
+        &mut self,
+        pane: Option<PaneId>,
+        input: &[crate::session::MouseInput],
+        pace: Duration,
+    ) -> Result<()> {
+        let index = self.resolve_pane(pane)?;
+        self.panes[index].session.send_mouse_input_all(input, pace)
     }
 
     pub(crate) fn send_active_if_open(&mut self, input: &[u8]) -> Result<bool> {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1443,7 +1443,12 @@ impl Workspace {
         let mut frame = self.windows[window].frame()?;
         self.add_tab_strip(&mut frame, selected);
         let ansi = frame_ansi(&frame)?;
-        Ok(Shot { frame, ansi })
+        Ok(Shot {
+            frame,
+            ansi,
+            pointer_recording: false,
+            pointer: None,
+        })
     }
 
     pub(crate) fn wait_for_text(
@@ -2480,7 +2485,12 @@ impl Window {
         }
         let frame = self.frame()?;
         let ansi = frame_ansi(&frame)?;
-        Ok(Shot { frame, ansi })
+        Ok(Shot {
+            frame,
+            ansi,
+            pointer_recording: false,
+            pointer: None,
+        })
     }
 
     pub(crate) fn panes(&mut self) -> Result<Vec<PaneStatus>> {
@@ -4846,6 +4856,7 @@ mod tests {
                 max_bytes: 1024,
                 opentui_host: false,
                 color: crate::shot::ColorMode::Auto,
+                pointer_recording: false,
             },
         }
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -174,6 +174,84 @@ fn click_and_drag_send_exact_sgr_mouse_events() {
 }
 
 #[test]
+fn pointer_enabled_session_records_structured_events_and_renders_live_and_replay() {
+    let session = NamedSession::new("pointer-recording", "pointer-recording-test");
+    let recording = session.runtime.join("pointer.termctrl");
+    let live = session.runtime.join("live.svg");
+    let replay = session.runtime.join("replay.svg");
+    let output = session.output(&[
+        "start",
+        session.name,
+        "--record",
+        recording.to_str().unwrap(),
+        "--record-pointer",
+        "--",
+        "/bin/sh",
+        "-c",
+        "stty raw -echo; printf READY; cat >/dev/null",
+    ]);
+    assert_success(&output);
+    assert_success(&session.output(&["wait", session.name, "READY"]));
+    assert_success(&session.output(&["click", session.name, "12", "4"]));
+    assert_success(&session.output(&[
+        "drag",
+        session.name,
+        "0",
+        "0",
+        "2",
+        "0",
+        "--steps",
+        "2",
+        "--pace-ms",
+        "0",
+    ]));
+    assert_success(&session.output(&["mark", session.name, "pointer-final"]));
+    assert_success(&session.output(&[
+        "save",
+        session.name,
+        "--format",
+        "svg",
+        "--pointer",
+        "--out",
+        live.to_str().unwrap(),
+    ]));
+    assert_success(&session.output(&["stop", session.name]));
+    assert_success(&session.output(&[
+        "save",
+        "--recording",
+        recording.to_str().unwrap(),
+        "--at-marker",
+        "pointer-final",
+        "--format",
+        "svg",
+        "--pointer",
+        "--out",
+        replay.to_str().unwrap(),
+    ]));
+
+    let entries: Vec<serde_json::Value> = fs::read_to_string(&recording)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert_eq!(entries[0]["version"], 2);
+    let phases = entries
+        .iter()
+        .filter(|entry| entry["type"] == "pointer")
+        .map(|entry| entry["phase"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        phases,
+        ["press", "release", "press", "move", "move", "release"]
+    );
+    for path in [live, replay] {
+        let svg = fs::read_to_string(path).unwrap();
+        assert!(svg.contains("#f9fafb"), "{svg}");
+        assert!(svg.contains("#111827"), "{svg}");
+    }
+}
+
+#[test]
 fn tape_play_runs_state_aware_demo_and_records_exact_input() {
     let session = NamedSession::new("tape-play", "tape-play-test");
     let tape = session.runtime.join("demo.tape");
@@ -188,6 +266,7 @@ MaxBytes 1048576
 Cwd "."
 Env DEMO_ENV "quoted # value"
 Record "demo.termctrl"
+Pointer on
 Color never
 Launch "/bin/sh" "-c" "stty raw -echo; printf READY:%s:%s \"$DEMO_ENV\" \"$PWD\"; od -An -tx1 -v -N 64; while [ ! -f action-ready ]; do sleep 0.01; done; printf FIXTURE; sleep 30"
 Wait "READY:quoted # value" Timeout 2s
@@ -216,6 +295,7 @@ Stop
         .map(|line| serde_json::from_str(line).unwrap())
         .collect();
     assert_eq!(entries[0]["type"], "header");
+    assert_eq!(entries[0]["version"], 2);
     assert_eq!(entries[0]["cols"], 72);
     assert_eq!(entries[0]["rows"], 12);
     assert!(
@@ -223,6 +303,7 @@ Stop
             .iter()
             .any(|entry| { entry["type"] == "marker" && entry["name"] == "complete" })
     );
+    assert!(entries.iter().any(|entry| entry["type"] == "pointer"));
     let client_input: Vec<u8> = entries
         .iter()
         .filter(|entry| entry["type"] == "input" && entry["origin"] == "client")

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -42,7 +42,7 @@ impl NamedSession {
 
 impl Drop for NamedSession {
     fn drop(&mut self) {
-        let _ = self.command().args(["stop", self.name]).status();
+        let _ = self.command().args(["stop", self.name]).output();
         let _ = fs::remove_dir_all(&self.runtime);
     }
 }
@@ -171,4 +171,127 @@ fn click_and_drag_send_exact_sgr_mouse_events() {
         ]
         .concat()
     );
+}
+
+#[test]
+fn tape_play_runs_state_aware_demo_and_records_exact_input() {
+    let session = NamedSession::new("tape-play", "tape-play-test");
+    let tape = session.runtime.join("demo.tape");
+    let recording = session.runtime.join("demo.termctrl");
+    fs::write(
+        &tape,
+        r#"# comments and quoted # text are both supported
+Session tape-play-test
+Viewport 72 12
+Cell 8 16
+MaxBytes 1048576
+Cwd "."
+Env DEMO_ENV "quoted # value"
+Record "demo.termctrl"
+Color never
+Launch "/bin/sh" "-c" "stty raw -echo; printf READY:%s:%s \"$DEMO_ENV\" \"$PWD\"; od -An -tx1 -v -N 64; while [ ! -f action-ready ]; do sleep 0.01; done; printf FIXTURE; sleep 30"
+Wait "READY:quoted # value" Timeout 2s
+Type "hello" Pace 1ms
+Key enter
+Click 12 4
+Drag 0 0 2 0 Steps 2 Pace 0ms
+Action "/usr/bin/touch" "action-ready"
+Wait FIXTURE Timeout 2s
+Mark complete
+Sleep 10ms
+Stop
+"#,
+    )
+    .unwrap();
+
+    let output = session.output(&["play", tape.to_str().unwrap()]);
+    assert_success(&output);
+    assert!(session.runtime.join("action-ready").exists());
+    assert!(recording.exists());
+    assert!(!session.output(&["status", session.name]).status.success());
+
+    let entries: Vec<serde_json::Value> = fs::read_to_string(&recording)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert_eq!(entries[0]["type"], "header");
+    assert_eq!(entries[0]["cols"], 72);
+    assert_eq!(entries[0]["rows"], 12);
+    assert!(
+        entries
+            .iter()
+            .any(|entry| { entry["type"] == "marker" && entry["name"] == "complete" })
+    );
+    let client_input: Vec<u8> = entries
+        .iter()
+        .filter(|entry| entry["type"] == "input" && entry["origin"] == "client")
+        .flat_map(|entry| {
+            entry["bytes"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|byte| byte.as_u64().unwrap() as u8)
+        })
+        .collect();
+    assert_eq!(
+        client_input,
+        [
+            b"hello\r".as_slice(),
+            b"\x1b[<0;13;5M".as_slice(),
+            b"\x1b[<0;13;5m".as_slice(),
+            b"\x1b[<0;1;1M".as_slice(),
+            b"\x1b[<32;2;1M".as_slice(),
+            b"\x1b[<32;3;1M".as_slice(),
+            b"\x1b[<0;3;1m".as_slice(),
+        ]
+        .concat()
+    );
+}
+
+#[test]
+fn tape_play_validates_before_launch_or_action_side_effects() {
+    let session = NamedSession::new("tape-validate", "tape-validate-test");
+    let tape = session.runtime.join("invalid.tape");
+    fs::write(
+        &tape,
+        r#"Session tape-validate-test
+Viewport 80 24
+Cwd "."
+Launch "/usr/bin/touch" "launched"
+Action "/usr/bin/touch" "acted"
+Stop extra
+"#,
+    )
+    .unwrap();
+
+    let output = session.output(&["play", tape.to_str().unwrap()]);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("invalid.tape:6: usage: Stop"));
+    assert!(!session.runtime.join("launched").exists());
+    assert!(!session.runtime.join("acted").exists());
+}
+
+#[test]
+fn tape_wait_failure_reports_screen_and_cleans_up_owned_session() {
+    let session = NamedSession::new("tape-timeout", "tape-timeout-test");
+    let tape = session.runtime.join("timeout.tape");
+    fs::write(
+        &tape,
+        r#"Session tape-timeout-test
+Viewport 80 24
+Launch "/bin/sh" "-c" "printf ACTUAL; sleep 30"
+Wait MISSING Timeout 20ms
+Stop
+"#,
+    )
+    .unwrap();
+
+    let output = session.output(&["play", tape.to_str().unwrap()]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("timeout.tape:4: Wait failed"), "{stderr}");
+    assert!(stderr.contains("last visible screen"), "{stderr}");
+    assert!(stderr.contains("ACTUAL"), "{stderr}");
+    assert!(!session.output(&["status", session.name]).status.success());
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,159 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::process::{CommandExt, ExitStatusExt};
+use std::path::PathBuf;
+use std::process::{Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+struct NamedSession {
+    binary: &'static str,
+    runtime: PathBuf,
+    name: &'static str,
+}
+
+impl NamedSession {
+    fn new(label: &str, name: &'static str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let runtime =
+            std::env::temp_dir().join(format!("termctrl-{label}-{}-{nonce}", std::process::id()));
+        fs::create_dir(&runtime).unwrap();
+        Self {
+            binary: env!("CARGO_BIN_EXE_termctrl"),
+            runtime,
+            name,
+        }
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new(self.binary);
+        command.env("TERMCTRL_RUNTIME_DIR", &self.runtime);
+        command
+    }
+
+    fn output(&self, args: &[&str]) -> Output {
+        self.command().args(args).output().unwrap()
+    }
+}
+
+impl Drop for NamedSession {
+    fn drop(&mut self) {
+        let _ = self.command().args(["stop", self.name]).status();
+        let _ = fs::remove_dir_all(&self.runtime);
+    }
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn parsed_hex(output: &[u8]) -> Vec<u8> {
+    String::from_utf8_lossy(output)
+        .split_ascii_whitespace()
+        .filter(|token| token.len() == 2 && token.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        .map(|token| u8::from_str_radix(token, 16).unwrap())
+        .collect()
+}
+
+fn wait_for_logs(session: &NamedSession, expected_len: usize) -> Output {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let output = session.output(&["logs", session.name, "--ansi"]);
+        if output.status.success() && parsed_hex(&output.stdout).len() == expected_len {
+            return output;
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "session did not emit {expected_len} expected bytes; last output: {:?}",
+                (
+                    output.status,
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr),
+                    parsed_hex(&output.stdout).len(),
+                )
+            );
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[test]
+fn named_session_survives_launcher_process_group_hangup() {
+    let session = NamedSession::new("daemon-detach", "detach-test");
+    let mut launcher = Command::new("/bin/sh");
+    launcher
+        .arg("-c")
+        .arg("\"$1\" start \"$2\" -- /bin/sh -c 'printf READY; sleep 30'; kill -HUP -- -$$")
+        .arg("termctrl-launcher")
+        .arg(session.binary)
+        .arg(session.name)
+        .env("TERMCTRL_RUNTIME_DIR", &session.runtime)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    unsafe {
+        launcher.pre_exec(|| {
+            if libc::setsid() < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    let status = launcher.status().unwrap();
+    assert_eq!(status.signal(), Some(libc::SIGHUP));
+
+    let output = session.output(&["status", session.name, "--json"]);
+    assert_success(&output);
+    assert!(String::from_utf8_lossy(&output.stdout).contains("\"state\": \"running\""));
+}
+
+#[test]
+fn click_and_drag_send_exact_sgr_mouse_events() {
+    let session = NamedSession::new("mouse-input", "mouse-test");
+    let output = session.output(&[
+        "start",
+        session.name,
+        "--",
+        "/bin/sh",
+        "-c",
+        "stty raw -echo; printf READY; od -An -tx1 -v -N 58",
+    ]);
+    assert_success(&output);
+    assert_success(&session.output(&["wait", session.name, "READY"]));
+    assert_success(&session.output(&["click", session.name, "12", "4"]));
+    assert_success(&session.output(&[
+        "drag",
+        session.name,
+        "0",
+        "0",
+        "2",
+        "0",
+        "--steps",
+        "2",
+        "--pace-ms",
+        "0",
+    ]));
+
+    let output = wait_for_logs(&session, 58);
+    assert_eq!(
+        parsed_hex(&output.stdout),
+        [
+            b"\x1b[<0;13;5M".as_slice(),
+            b"\x1b[<0;13;5m".as_slice(),
+            b"\x1b[<0;1;1M".as_slice(),
+            b"\x1b[<32;2;1M".as_slice(),
+            b"\x1b[<32;3;1M".as_slice(),
+            b"\x1b[<0;3;1m".as_slice(),
+        ]
+        .concat()
+    );
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -88,13 +88,15 @@ fn wait_for_logs(session: &NamedSession, expected_len: usize) -> Output {
 #[test]
 fn named_session_survives_launcher_process_group_hangup() {
     let session = NamedSession::new("daemon-detach", "detach-test");
+    let ready = session.runtime.join("launcher-ready");
     let mut launcher = Command::new("/bin/sh");
     launcher
         .arg("-c")
-        .arg("\"$1\" start \"$2\" -- /bin/sh -c 'printf READY; sleep 30'; kill -HUP -- -$$")
+        .arg("\"$1\" start \"$2\" -- /bin/sh -c 'printf READY; sleep 30' && : > \"$3\" && sleep 30")
         .arg("termctrl-launcher")
         .arg(session.binary)
         .arg(session.name)
+        .arg(&ready)
         .env("TERMCTRL_RUNTIME_DIR", &session.runtime)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -108,7 +110,20 @@ fn named_session_survives_launcher_process_group_hangup() {
         });
     }
 
-    let status = launcher.status().unwrap();
+    let mut launcher = launcher.spawn().unwrap();
+    let process_group = launcher.id() as libc::pid_t;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !ready.exists() {
+        assert!(
+            launcher.try_wait().unwrap().is_none(),
+            "launcher exited before starting the named session"
+        );
+        assert!(Instant::now() < deadline, "launcher did not become ready");
+        thread::sleep(Duration::from_millis(10));
+    }
+    assert_eq!(unsafe { libc::killpg(process_group, libc::SIGHUP) }, 0);
+
+    let status = launcher.wait().unwrap();
     assert_eq!(status.signal(), Some(libc::SIGHUP));
 
     let output = session.output(&["status", session.name, "--json"]);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -177,8 +177,13 @@ fn click_and_drag_send_exact_sgr_mouse_events() {
 fn pointer_enabled_session_records_structured_events_and_renders_live_and_replay() {
     let session = NamedSession::new("pointer-recording", "pointer-recording-test");
     let recording = session.runtime.join("pointer.termctrl");
+    let before = session.runtime.join("before.svg");
     let live = session.runtime.join("live.svg");
     let replay = session.runtime.join("replay.svg");
+    let live_faded = session.runtime.join("live-faded.svg");
+    let live_persistent = session.runtime.join("live-persistent.svg");
+    let replay_faded = session.runtime.join("replay-faded.svg");
+    let replay_persistent = session.runtime.join("replay-persistent.svg");
     let output = session.output(&[
         "start",
         session.name,
@@ -192,6 +197,20 @@ fn pointer_enabled_session_records_structured_events_and_renders_live_and_replay
     ]);
     assert_success(&output);
     assert_success(&session.output(&["wait", session.name, "READY"]));
+    assert_success(&session.output(&[
+        "save",
+        session.name,
+        "--format",
+        "svg",
+        "--pointer=persistent",
+        "--out",
+        before.to_str().unwrap(),
+    ]));
+    assert!(
+        !fs::read_to_string(before)
+            .unwrap()
+            .contains("data-termctrl-pointer=\"true\"")
+    );
     assert_success(&session.output(&["click", session.name, "12", "4"]));
     assert_success(&session.output(&[
         "drag",
@@ -215,6 +234,26 @@ fn pointer_enabled_session_records_structured_events_and_renders_live_and_replay
         "--out",
         live.to_str().unwrap(),
     ]));
+    thread::sleep(Duration::from_millis(1_300));
+    assert_success(&session.output(&["mark", session.name, "pointer-idle"]));
+    assert_success(&session.output(&[
+        "save",
+        session.name,
+        "--format",
+        "svg",
+        "--pointer",
+        "--out",
+        live_faded.to_str().unwrap(),
+    ]));
+    assert_success(&session.output(&[
+        "save",
+        session.name,
+        "--format",
+        "svg",
+        "--pointer=persistent",
+        "--out",
+        live_persistent.to_str().unwrap(),
+    ]));
     assert_success(&session.output(&["stop", session.name]));
     assert_success(&session.output(&[
         "save",
@@ -227,6 +266,30 @@ fn pointer_enabled_session_records_structured_events_and_renders_live_and_replay
         "--pointer",
         "--out",
         replay.to_str().unwrap(),
+    ]));
+    assert_success(&session.output(&[
+        "save",
+        "--recording",
+        recording.to_str().unwrap(),
+        "--at-marker",
+        "pointer-idle",
+        "--format",
+        "svg",
+        "--pointer",
+        "--out",
+        replay_faded.to_str().unwrap(),
+    ]));
+    assert_success(&session.output(&[
+        "save",
+        "--recording",
+        recording.to_str().unwrap(),
+        "--at-marker",
+        "pointer-idle",
+        "--format",
+        "svg",
+        "--pointer=persistent",
+        "--out",
+        replay_persistent.to_str().unwrap(),
     ]));
 
     let entries: Vec<serde_json::Value> = fs::read_to_string(&recording)
@@ -246,8 +309,23 @@ fn pointer_enabled_session_records_structured_events_and_renders_live_and_replay
     );
     for path in [live, replay] {
         let svg = fs::read_to_string(path).unwrap();
-        assert!(svg.contains("#f9fafb"), "{svg}");
-        assert!(svg.contains("#111827"), "{svg}");
+        assert!(svg.contains("data-termctrl-pointer=\"true\""), "{svg}");
+        assert!(
+            svg.contains("data-termctrl-pointer-click=\"true\""),
+            "{svg}"
+        );
+    }
+    for path in [live_faded, replay_faded] {
+        let svg = fs::read_to_string(path).unwrap();
+        assert!(!svg.contains("data-termctrl-pointer=\"true\""), "{svg}");
+    }
+    for path in [live_persistent, replay_persistent] {
+        let svg = fs::read_to_string(path).unwrap();
+        assert!(svg.contains("data-termctrl-pointer=\"true\""), "{svg}");
+        assert!(
+            !svg.contains("data-termctrl-pointer-click=\"true\""),
+            "{svg}"
+        );
     }
 }
 
@@ -268,12 +346,16 @@ Env DEMO_ENV "quoted # value"
 Record "demo.termctrl"
 Pointer on
 Color never
-Launch "/bin/sh" "-c" "stty raw -echo; printf READY:%s:%s \"$DEMO_ENV\" \"$PWD\"; od -An -tx1 -v -N 64; while [ ! -f action-ready ]; do sleep 0.01; done; printf FIXTURE; sleep 30"
+Launch "/bin/sh" "-c" "stty raw -echo; printf READY:%s:%s \"$DEMO_ENV\" \"$PWD\"; (while [ ! -f action-ready ]; do sleep 0.01; done; printf FIXTURE) & od -An -tx1 -v"
 Wait "READY:quoted # value" Timeout 2s
 Type "hello" Pace 1ms
 Key enter
+Move 5 2 Steps 4 Pace 0ms
+Move 9 2 Steps 2 Pace 0ms
 Click 12 4
+Move 14 4 Steps 2 Pace 0ms
 Drag 0 0 2 0 Steps 2 Pace 0ms
+Move 4 0 Steps 2 Pace 0ms
 Action "/usr/bin/touch" "action-ready"
 Wait FIXTURE Timeout 2s
 Mark complete
@@ -303,7 +385,35 @@ Stop
             .iter()
             .any(|entry| { entry["type"] == "marker" && entry["name"] == "complete" })
     );
-    assert!(entries.iter().any(|entry| entry["type"] == "pointer"));
+    let pointer_events = entries
+        .iter()
+        .filter(|entry| entry["type"] == "pointer")
+        .map(|entry| {
+            (
+                entry["x"].as_u64().unwrap(),
+                entry["y"].as_u64().unwrap(),
+                entry["phase"].as_str().unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        pointer_events,
+        [
+            (5, 2, "move"),
+            (7, 2, "move"),
+            (9, 2, "move"),
+            (12, 4, "press"),
+            (12, 4, "release"),
+            (13, 4, "move"),
+            (14, 4, "move"),
+            (0, 0, "press"),
+            (1, 0, "move"),
+            (2, 0, "move"),
+            (2, 0, "release"),
+            (3, 0, "move"),
+            (4, 0, "move"),
+        ]
+    );
     let client_input: Vec<u8> = entries
         .iter()
         .filter(|entry| entry["type"] == "input" && entry["origin"] == "client")
@@ -319,15 +429,66 @@ Stop
         client_input,
         [
             b"hello\r".as_slice(),
+            b"\x1b[<35;6;3M".as_slice(),
+            b"\x1b[<35;8;3M".as_slice(),
+            b"\x1b[<35;10;3M".as_slice(),
             b"\x1b[<0;13;5M".as_slice(),
             b"\x1b[<0;13;5m".as_slice(),
+            b"\x1b[<35;14;5M".as_slice(),
+            b"\x1b[<35;15;5M".as_slice(),
             b"\x1b[<0;1;1M".as_slice(),
             b"\x1b[<32;2;1M".as_slice(),
             b"\x1b[<32;3;1M".as_slice(),
             b"\x1b[<0;3;1m".as_slice(),
+            b"\x1b[<35;4;1M".as_slice(),
+            b"\x1b[<35;5;1M".as_slice(),
         ]
         .concat()
     );
+}
+
+#[test]
+fn tape_move_sends_exact_unpressed_motion_without_pointer_recording() {
+    let session = NamedSession::new("tape-move", "tape-move-test");
+    let tape = session.runtime.join("move.tape");
+    let observed = session.runtime.join("observed.hex");
+    let expected = [
+        b"\x1b[<35;2;2M".as_slice(),
+        b"\x1b[<35;4;2M".as_slice(),
+        b"\x1b[<35;6;2M".as_slice(),
+        b"\x1b[<0;3;4M".as_slice(),
+        b"\x1b[<0;3;4m".as_slice(),
+        b"\x1b[<35;4;4M".as_slice(),
+        b"\x1b[<35;5;4M".as_slice(),
+        b"\x1b[<0;1;1M".as_slice(),
+        b"\x1b[<32;2;1M".as_slice(),
+        b"\x1b[<32;3;1M".as_slice(),
+        b"\x1b[<0;3;1m".as_slice(),
+        b"\x1b[<35;4;1M".as_slice(),
+        b"\x1b[<35;5;1M".as_slice(),
+    ]
+    .concat();
+    let source = format!(
+        r#"Session tape-move-test
+Viewport 80 24
+Cwd "."
+Launch "/bin/sh" "-c" "stty raw -echo; printf READY; od -An -tx1 -v -N {} > observed.hex; printf DONE; sleep 30"
+Wait READY Timeout 2s
+Move 1 1 Steps 9 Pace 0ms
+Move 5 1 Steps 2 Pace 0ms
+Click 2 3
+Move 4 3 Steps 2 Pace 0ms
+Drag 0 0 2 0 Steps 2 Pace 0ms
+Move 4 0 Steps 2 Pace 0ms
+Wait DONE Timeout 2s
+Stop
+"#,
+        expected.len()
+    );
+    fs::write(&tape, source).unwrap();
+
+    assert_success(&session.output(&["play", tape.to_str().unwrap()]));
+    assert_eq!(parsed_hex(&fs::read(observed).unwrap()), expected);
 }
 
 #[test]
@@ -343,14 +504,18 @@ Setup "/usr/bin/touch" "setup-ran"
 Cleanup "/usr/bin/touch" "cleanup-ran"
 Launch "/usr/bin/touch" "launched"
 Action "/usr/bin/touch" "acted"
-Stop extra
+Move 1 1 Steps 0
+Stop
 "#,
     )
     .unwrap();
 
     let output = session.output(&["play", tape.to_str().unwrap()]);
     assert!(!output.status.success());
-    assert!(String::from_utf8_lossy(&output.stderr).contains("invalid.tape:8: usage: Stop"));
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("invalid.tape:8: move Steps must be between 1 and 1000")
+    );
     assert!(!session.runtime.join("setup-ran").exists());
     assert!(!session.runtime.join("cleanup-ran").exists());
     assert!(!session.runtime.join("launched").exists());

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -339,6 +339,8 @@ fn tape_play_validates_before_launch_or_action_side_effects() {
         r#"Session tape-validate-test
 Viewport 80 24
 Cwd "."
+Setup "/usr/bin/touch" "setup-ran"
+Cleanup "/usr/bin/touch" "cleanup-ran"
 Launch "/usr/bin/touch" "launched"
 Action "/usr/bin/touch" "acted"
 Stop extra
@@ -348,7 +350,9 @@ Stop extra
 
     let output = session.output(&["play", tape.to_str().unwrap()]);
     assert!(!output.status.success());
-    assert!(String::from_utf8_lossy(&output.stderr).contains("invalid.tape:6: usage: Stop"));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("invalid.tape:8: usage: Stop"));
+    assert!(!session.runtime.join("setup-ran").exists());
+    assert!(!session.runtime.join("cleanup-ran").exists());
     assert!(!session.runtime.join("launched").exists());
     assert!(!session.runtime.join("acted").exists());
 }
@@ -374,5 +378,115 @@ Stop
     assert!(stderr.contains("timeout.tape:4: Wait failed"), "{stderr}");
     assert!(stderr.contains("last visible screen"), "{stderr}");
     assert!(stderr.contains("ACTUAL"), "{stderr}");
+    assert!(!session.output(&["status", session.name]).status.success());
+}
+
+#[test]
+fn tape_setup_and_cleanup_make_repeat_runs_begin_clean() {
+    let session = NamedSession::new("tape-repeat", "tape-repeat-test");
+    let tape = session.runtime.join("repeat.tape");
+    let fixture = session.runtime.join("repeat.fixture");
+    fs::write(
+        &tape,
+        r#"Session tape-repeat-test
+Viewport 80 24
+Cwd "."
+Setup "/usr/bin/test" "!" "-e" "repeat.fixture"
+Setup "/usr/bin/touch" "repeat.fixture"
+Cleanup "/usr/bin/rm" "-f" "repeat.fixture"
+Launch "/bin/sh" "-c" "test -e repeat.fixture && printf READY; sleep 30"
+Wait READY Timeout 2s
+Stop
+"#,
+    )
+    .unwrap();
+
+    for _ in 0..2 {
+        assert_success(&session.output(&["play", tape.to_str().unwrap()]));
+        assert!(!fixture.exists(), "cleanup must restore the fixture");
+    }
+}
+
+#[test]
+fn tape_failure_stops_session_then_cleans_up_without_masking_primary_error() {
+    let session = NamedSession::new("tape-cleanup", "tape-cleanup-test");
+    let tape = session.runtime.join("cleanup.tape");
+    let fixture = session.runtime.join("failure.fixture");
+    fs::write(
+        &tape,
+        r#"Session tape-cleanup-test
+Viewport 80 24
+Cwd "."
+Setup "/usr/bin/touch" "failure.fixture"
+Cleanup "/bin/sh" "-c" "alive=0; kill -0 \"$(cat app.pid)\" 2>/dev/null && alive=1; rm -f failure.fixture app.pid; if [ \"$alive\" -eq 1 ]; then echo session-alive >&2; exit 8; fi; echo cleanup-deliberate >&2; exit 7"
+Launch "/bin/sh" "-c" "echo $$ > app.pid; printf ACTUAL; sleep 30"
+Wait MISSING Timeout 20ms
+Stop
+"#,
+    )
+    .unwrap();
+
+    let output = session.output(&["play", tape.to_str().unwrap()]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let primary = stderr.find("cleanup.tape:7: Wait failed").unwrap();
+    let additional = stderr.find("additional lifecycle failures").unwrap();
+    assert!(primary < additional, "{stderr}");
+    assert!(
+        stderr.contains("cleanup.tape:5: Cleanup failed"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("cleanup-deliberate"), "{stderr}");
+    assert!(!stderr.contains("stderr:\nsession-alive"), "{stderr}");
+    assert!(!fixture.exists(), "cleanup must restore the fixture");
+    assert!(!session.output(&["status", session.name]).status.success());
+}
+
+#[test]
+fn tape_action_timeout_kills_process_group_and_bounds_noisy_diagnostics() {
+    let session = NamedSession::new("tape-action-timeout", "tape-action-timeout-test");
+    let tape = session.runtime.join("action-timeout.tape");
+    let child_pid = session.runtime.join("action-child.pid");
+    fs::write(
+        &tape,
+        r#"Session tape-action-timeout-test
+Viewport 80 24
+Cwd "."
+Launch "/bin/sh" "-c" "printf READY; sleep 30"
+Wait READY Timeout 2s
+Action "/bin/sh" "-c" "sleep 30 & echo $! > action-child.pid; exec /usr/bin/yes noisy" Timeout 50ms
+Stop
+"#,
+    )
+    .unwrap();
+
+    let output = session.output(&["play", tape.to_str().unwrap()]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Action failed"), "{stderr}");
+    assert!(stderr.contains("timed out after 50ms"), "{stderr}");
+    assert!(stderr.contains("<truncated>"), "{stderr}");
+    assert!(
+        stderr.len() < 10_000,
+        "diagnostic was not bounded: {}",
+        stderr.len()
+    );
+    let pid = fs::read_to_string(child_pid)
+        .unwrap()
+        .trim()
+        .parse::<libc::pid_t>()
+        .unwrap();
+    let deadline = Instant::now() + Duration::from_secs(1);
+    loop {
+        let result = unsafe { libc::kill(pid, 0) };
+        if result < 0 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH) {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "action descendant {pid} survived timeout"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
     assert!(!session.output(&["status", session.name]).status.success());
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,6 +1,9 @@
 #![cfg(unix)]
 
+use std::ffi::OsString;
 use std::fs;
+use std::os::unix::ffi::OsStringExt;
+use std::os::unix::fs::PermissionsExt;
 use std::os::unix::process::{CommandExt, ExitStatusExt};
 use std::path::PathBuf;
 use std::process::{Command, Output, Stdio};
@@ -171,6 +174,47 @@ fn click_and_drag_send_exact_sgr_mouse_events() {
         ]
         .concat()
     );
+}
+
+#[test]
+fn live_mouse_rejects_coordinates_outside_the_actual_viewport_before_recording() {
+    let session = NamedSession::new("mouse-bounds", "mouse-bounds-test");
+    let recording = session.runtime.join("mouse-bounds.termctrl");
+    let output = session.output(&[
+        "start",
+        session.name,
+        "--cols",
+        "2",
+        "--rows",
+        "1",
+        "--record",
+        recording.to_str().unwrap(),
+        "--record-pointer",
+        "--",
+        "/bin/sh",
+        "-c",
+        "stty raw -echo; cat >/dev/null",
+    ]);
+    assert_success(&output);
+    thread::sleep(Duration::from_millis(50));
+
+    for args in [
+        vec!["click", session.name, "2", "0"],
+        vec!["drag", session.name, "0", "0", "2", "0", "--pace-ms", "0"],
+    ] {
+        let output = session.output(&args);
+        assert!(!output.status.success());
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("outside target viewport 2x1"),
+            "{args:?}: {stderr}"
+        );
+    }
+
+    assert_success(&session.output(&["stop", session.name]));
+    let entries = fs::read_to_string(recording).unwrap();
+    assert!(!entries.contains("\"type\":\"pointer\""), "{entries}");
+    assert!(!entries.contains("\"origin\":\"client\""), "{entries}");
 }
 
 #[test]
@@ -592,19 +636,59 @@ Stop
 }
 
 #[test]
+fn tape_json_rejects_non_utf8_receipt_paths_before_lifecycle_side_effects() {
+    let session = NamedSession::new("tape-json-path", "tape-json-path-test");
+    let directory = session
+        .runtime
+        .join(OsString::from_vec(b"non-utf8-\xff".to_vec()));
+    fs::create_dir(&directory).unwrap();
+    let tape = directory.join("demo.tape");
+    let setup_marker = directory.join("setup-ran");
+    fs::write(
+        &tape,
+        r#"Session tape-json-path-test
+Viewport 80 24
+Cwd "."
+Setup "/usr/bin/touch" "setup-ran"
+Launch "/bin/sh" "-c" "printf READY; sleep 30"
+Stop
+"#,
+    )
+    .unwrap();
+
+    let output = session
+        .command()
+        .arg("play")
+        .arg(&tape)
+        .arg("--json")
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert_ne!(output.status.code(), Some(101), "process panicked");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("play --json requires a UTF-8 tape path before lifecycle side effects"),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("panicked"), "{stderr}");
+    assert!(!setup_marker.exists());
+    assert!(!session.output(&["status", session.name]).status.success());
+}
+
+#[test]
 fn tape_play_validates_before_launch_or_action_side_effects() {
     let session = NamedSession::new("tape-validate", "tape-validate-test");
     let tape = session.runtime.join("invalid.tape");
     fs::write(
         &tape,
         r#"Session tape-validate-test
-Viewport 80 24
+Viewport 2 1
 Cwd "."
 Setup "/usr/bin/touch" "setup-ran"
 Cleanup "/usr/bin/touch" "cleanup-ran"
 Launch "/usr/bin/touch" "launched"
 Action "/usr/bin/touch" "acted"
-Move 1 1 Steps 0
+Click 65534 0
 Stop
 "#,
     )
@@ -614,7 +698,7 @@ Stop
     assert!(!output.status.success());
     assert!(
         String::from_utf8_lossy(&output.stderr)
-            .contains("invalid.tape:8: move Steps must be between 1 and 1000")
+            .contains("invalid.tape:8: Click coordinate (65534, 0) is outside Viewport 2x1")
     );
     assert!(!session.runtime.join("setup-ran").exists());
     assert!(!session.runtime.join("cleanup-ran").exists());
@@ -753,5 +837,79 @@ Stop
         );
         thread::sleep(Duration::from_millis(10));
     }
+    assert!(!session.output(&["status", session.name]).status.success());
+}
+
+#[test]
+fn tape_action_bounds_drain_when_escaped_descendant_retains_output_pipes() {
+    let session = NamedSession::new("tape-action-drain", "tape-action-drain-test");
+    let helper = session.runtime.join("escape-action.sh");
+    let escaped_pid = session.runtime.join("escaped.pid");
+    let cleanup_marker = session.runtime.join("cleanup-ran");
+    fs::write(
+        &helper,
+        "#!/bin/sh\nsetsid /bin/sh -c 'echo $$ > escaped.pid; sleep 30' &\nexit 0\n",
+    )
+    .unwrap();
+    fs::set_permissions(&helper, fs::Permissions::from_mode(0o755)).unwrap();
+    let tape = session.runtime.join("action-drain.tape");
+    fs::write(
+        &tape,
+        r#"Session tape-action-drain-test
+Viewport 80 24
+Cwd "."
+Cleanup "/usr/bin/touch" "cleanup-ran"
+Launch "/bin/sh" "-c" "printf READY; sleep 30"
+Wait READY Timeout 2s
+Action "./escape-action.sh" Timeout 1s
+Stop
+"#,
+    )
+    .unwrap();
+
+    let started = Instant::now();
+    let mut playback = session
+        .command()
+        .arg("play")
+        .arg(&tape)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        if playback.try_wait().unwrap().is_some() {
+            break;
+        }
+        if Instant::now() >= deadline {
+            let _ = playback.kill();
+            panic!("playback did not bound Action output drain within 3 seconds");
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    let output = playback.wait_with_output().unwrap();
+
+    let pid = fs::read_to_string(&escaped_pid)
+        .unwrap()
+        .trim()
+        .parse::<libc::pid_t>()
+        .unwrap();
+    unsafe {
+        libc::kill(-pid, libc::SIGKILL);
+    }
+
+    assert!(!output.status.success());
+    assert!(started.elapsed() < Duration::from_secs(3));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Action failed"), "{stderr}");
+    assert!(
+        stderr.contains("left output pipes open after 250ms"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("detached descendants may still be running"),
+        "{stderr}"
+    );
+    assert!(cleanup_marker.exists(), "cleanup did not proceed");
     assert!(!session.output(&["status", session.name]).status.success());
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -174,6 +174,24 @@ fn click_and_drag_send_exact_sgr_mouse_events() {
 }
 
 #[test]
+fn live_send_accepts_shift_enter_modifier_chord() {
+    let session = NamedSession::new("modifier-input", "modifier-input-test");
+    assert_success(&session.output(&[
+        "start",
+        session.name,
+        "--",
+        "/bin/sh",
+        "-c",
+        "stty raw -echo; printf READY; od -An -tx1 -v -N 7",
+    ]));
+    assert_success(&session.output(&["wait", session.name, "READY"]));
+    assert_success(&session.output(&["send", session.name, "shift+enter"]));
+
+    let output = wait_for_logs(&session, 7);
+    assert_eq!(parsed_hex(&output.stdout), b"\x1b[13;2u");
+}
+
+#[test]
 fn pointer_enabled_session_records_structured_events_and_renders_live_and_replay() {
     let session = NamedSession::new("pointer-recording", "pointer-recording-test");
     let recording = session.runtime.join("pointer.termctrl");
@@ -349,10 +367,11 @@ Color never
 Launch "/bin/sh" "-c" "stty raw -echo; printf READY:%s:%s \"$DEMO_ENV\" \"$PWD\"; (while [ ! -f action-ready ]; do sleep 0.01; done; printf FIXTURE) & od -An -tx1 -v"
 Wait "READY:quoted # value" Timeout 2s
 Type "hello" Pace 1ms
-Key enter
+Key enter shift+enter
 Move 5 2 Steps 4 Pace 0ms
 Move 9 2 Steps 2 Pace 0ms
 Click 12 4
+RightClick 10 4
 Move 14 4 Steps 2 Pace 0ms
 Drag 0 0 2 0 Steps 2 Pace 0ms
 Move 4 0 Steps 2 Pace 0ms
@@ -367,6 +386,15 @@ Stop
 
     let output = session.output(&["play", tape.to_str().unwrap()]);
     assert_success(&output);
+    let receipt = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        receipt.contains(&format!("played {}", tape.display())),
+        "{receipt}"
+    );
+    assert!(
+        receipt.contains(&format!("recording {}", recording.display())),
+        "{receipt}"
+    );
     assert!(session.runtime.join("action-ready").exists());
     assert!(recording.exists());
     assert!(!session.output(&["status", session.name]).status.success());
@@ -393,25 +421,28 @@ Stop
                 entry["x"].as_u64().unwrap(),
                 entry["y"].as_u64().unwrap(),
                 entry["phase"].as_str().unwrap(),
+                entry["button"].as_str(),
             )
         })
         .collect::<Vec<_>>();
     assert_eq!(
         pointer_events,
         [
-            (5, 2, "move"),
-            (7, 2, "move"),
-            (9, 2, "move"),
-            (12, 4, "press"),
-            (12, 4, "release"),
-            (13, 4, "move"),
-            (14, 4, "move"),
-            (0, 0, "press"),
-            (1, 0, "move"),
-            (2, 0, "move"),
-            (2, 0, "release"),
-            (3, 0, "move"),
-            (4, 0, "move"),
+            (5, 2, "move", None),
+            (7, 2, "move", None),
+            (9, 2, "move", None),
+            (12, 4, "press", None),
+            (12, 4, "release", None),
+            (10, 4, "press", Some("secondary")),
+            (10, 4, "release", Some("secondary")),
+            (12, 4, "move", None),
+            (14, 4, "move", None),
+            (0, 0, "press", None),
+            (1, 0, "move", None),
+            (2, 0, "move", None),
+            (2, 0, "release", None),
+            (3, 0, "move", None),
+            (4, 0, "move", None),
         ]
     );
     let client_input: Vec<u8> = entries
@@ -428,13 +459,15 @@ Stop
     assert_eq!(
         client_input,
         [
-            b"hello\r".as_slice(),
+            b"hello\r\x1b[13;2u".as_slice(),
             b"\x1b[<35;6;3M".as_slice(),
             b"\x1b[<35;8;3M".as_slice(),
             b"\x1b[<35;10;3M".as_slice(),
             b"\x1b[<0;13;5M".as_slice(),
             b"\x1b[<0;13;5m".as_slice(),
-            b"\x1b[<35;14;5M".as_slice(),
+            b"\x1b[<2;11;5M".as_slice(),
+            b"\x1b[<2;11;5m".as_slice(),
+            b"\x1b[<35;13;5M".as_slice(),
             b"\x1b[<35;15;5M".as_slice(),
             b"\x1b[<0;1;1M".as_slice(),
             b"\x1b[<32;2;1M".as_slice(),
@@ -452,10 +485,13 @@ fn tape_move_sends_exact_unpressed_motion_without_pointer_recording() {
     let session = NamedSession::new("tape-move", "tape-move-test");
     let tape = session.runtime.join("move.tape");
     let observed = session.runtime.join("observed.hex");
+    let recording = session.runtime.join("move.termctrl");
     let expected = [
         b"\x1b[<35;2;2M".as_slice(),
         b"\x1b[<35;4;2M".as_slice(),
         b"\x1b[<35;6;2M".as_slice(),
+        b"\x1b[<2;7;2M".as_slice(),
+        b"\x1b[<2;7;2m".as_slice(),
         b"\x1b[<0;3;4M".as_slice(),
         b"\x1b[<0;3;4m".as_slice(),
         b"\x1b[<35;4;4M".as_slice(),
@@ -472,10 +508,12 @@ fn tape_move_sends_exact_unpressed_motion_without_pointer_recording() {
         r#"Session tape-move-test
 Viewport 80 24
 Cwd "."
+Record "move.termctrl"
 Launch "/bin/sh" "-c" "stty raw -echo; printf READY; od -An -tx1 -v -N {} > observed.hex; printf DONE; sleep 30"
 Wait READY Timeout 2s
 Move 1 1 Steps 9 Pace 0ms
 Move 5 1 Steps 2 Pace 0ms
+RightClick 6 1
 Click 2 3
 Move 4 3 Steps 2 Pace 0ms
 Drag 0 0 2 0 Steps 2 Pace 0ms
@@ -489,6 +527,68 @@ Stop
 
     assert_success(&session.output(&["play", tape.to_str().unwrap()]));
     assert_eq!(parsed_hex(&fs::read(observed).unwrap()), expected);
+    let entries = fs::read_to_string(recording).unwrap();
+    assert!(entries.lines().next().unwrap().contains("\"version\":1"));
+    assert!(!entries.contains("\"type\":\"pointer\""));
+}
+
+#[test]
+fn tape_wait_line_match_disambiguates_substrings_and_json_receipt_is_stable() {
+    let substring = NamedSession::new("tape-wait-substring", "tape-wait-substring-test");
+    let substring_tape = substring.runtime.join("substring.tape");
+    fs::write(
+        &substring_tape,
+        r#"Session tape-wait-substring-test
+Viewport 80 8
+Launch "/bin/sh" "-c" "printf 'history entry 10\r\n'; sleep 30"
+Wait "history entry 1" Timeout 200ms
+Stop
+"#,
+    )
+    .unwrap();
+    let output = substring.output(&["play", substring_tape.to_str().unwrap(), "--quiet"]);
+    assert_success(&output);
+    assert!(output.stdout.is_empty());
+
+    let line = NamedSession::new("tape-wait-line", "tape-wait-line-test");
+    let line_tape = line.runtime.join("line.tape");
+    fs::write(
+        &line_tape,
+        r#"Session tape-wait-line-test
+Viewport 80 8
+Launch "/bin/sh" "-c" "printf 'history entry 10\r\n'; sleep 30"
+Wait "history entry 1" Match line Timeout 30ms
+Stop
+"#,
+    )
+    .unwrap();
+    let output = line.output(&["play", line_tape.to_str().unwrap()]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("timed out waiting for a visible line exactly matching"),
+        "{stderr}"
+    );
+
+    let exact = NamedSession::new("tape-wait-exact", "tape-wait-exact-test");
+    let exact_tape = exact.runtime.join("exact.tape");
+    fs::write(
+        &exact_tape,
+        r#"Session tape-wait-exact-test
+Viewport 80 8
+Launch "/bin/sh" "-c" "printf 'history entry 10\r\nhistory entry 1\r\n'; sleep 30"
+Wait "history entry 1" Match line Timeout 200ms
+Stop
+"#,
+    )
+    .unwrap();
+    let output = exact.output(&["play", exact_tape.to_str().unwrap(), "--json"]);
+    assert_success(&output);
+    let receipt: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(receipt["status"], "ok");
+    assert_eq!(receipt["session"], "tape-wait-exact-test");
+    assert_eq!(receipt["tape"], exact_tape.to_str().unwrap());
+    assert!(receipt["recording"].is_null());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- keep named live PTY sessions available across CLI invocations
- add structured click, right-click, move, and drag controls for direct sessions and workspace targets
- add deterministic `.tape` playback with Setup, Launch, Cleanup, waits, receipts, bounded process groups, and stable JSON output
- record and render optional pointer evidence, including persistent cursor overlays and tape movement
- add scripting ergonomics for repeatable demos and automated TUI verification
- validate live mouse targets atomically in the daemon against the current viewport before PTY mutation

## Safety and compatibility

- protocol v9 adds structured mouse mutations without changing legacy raw Send behavior
- older daemons return an actionable restart-required diagnostic instead of silently falling back
- default v1 recordings and pointer-enabled v2 recordings remain compatible
- tape action output is drained fairly, bounded by deadlines, and cleaned up on setup or action failure
- non-UTF-8 JSON receipt paths fail during preflight before lifecycle side effects
- click and drag endpoints are validated for direct sessions, selected panes, stable pane IDs, and named-window active panes

## Verification

Pinned clean-room environment:

- Node 24.19.0
- npm 11.17.0
- Bun 1.3.14
- Rust and Cargo 1.93.1
- Zig 0.15.2

Commands completed successfully:

- `cargo fmt --all -- --check`
- `cargo test --all-targets` (211 passed, 1 manual benchmark ignored)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release`
- `bun run test:npm`
- `bun run build:npm`
- `bun run validate:npm`
- `cargo package --list`
- `cargo package`

Adversarial resize testing verifies that mouse mutations ordered after a resize to a 1x2 viewport are rejected before PTY input, with an empty PTY log. Protocol-v8 compatibility testing verifies the restart diagnostic for structured mouse while unchanged raw Send remains accepted.

## Release

Includes a minor changeset describing deterministic playback, structured pointer behavior, bounded actions, and viewport-safe input.