### PR TITLE
fix(render): preserve terminal cursor styles

### DIFF
--- a/.changeset/tidy-cursors-render.md
+++ b/.changeset/tidy-cursors-render.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/terminal-control": patch
+---
+
+Preserve terminal cursor styles in structured frames, screenshots, and videos.

--- a/docs/driver-protocol.md
+++ b/docs/driver-protocol.md
@@ -24,7 +24,7 @@ increment `protocolVersion`; clients reject unsupported versions rather than gue
 ## Example Requests
 
 ```json
-{"type":"hello","protocolVersion":1,"terminalControlVersion":"<installed-version>"}
+{"type":"hello","protocolVersion":2,"terminalControlVersion":"<installed-version>"}
 {"id":1,"method":"launch","sessionId":"app","params":{"command":["my-terminal-app"],"cols":100,"rows":30,"inheritEnv":false,"env":{"TERM":"xterm-256color"}}}
 {"id":2,"method":"waitForText","sessionId":"app","params":{"text":"Ready","timeoutMs":5000}}
 {"id":3,"method":"send","sessionId":"app","params":{"input":[{"type":"text","value":"help"},{"type":"key","value":"enter"}]}}

--- a/docs/rust-library.md
+++ b/docs/rust-library.md
@@ -57,6 +57,6 @@ No connected provider returns `termctrl-semantic-snapshot-v1` with an empty `nod
 
 ## Versioned Structured Output
 
-- A `save --format json` capture is a `Frame` object with `version: 1`, described by `schemas/frame-v1.schema.json`.
+- A `save --format json` capture is a `Frame` object with `version: 2`, described by `schemas/frame-v2.schema.json`.
 - A `.termctrl` recording is JSON Lines: its first line is a versioned header and subsequent lines are timed output, input, resize, or marker entries, each described by `schemas/recording-entry-v1.schema.json`.
 - Recording byte arrays contain the original terminal or input bytes as integers from `0` to `255`; recordings can contain sensitive text or input.

--- a/packages/test/src/index.test.ts
+++ b/packages/test/src/index.test.ts
@@ -49,6 +49,8 @@ describe("isolated terminal sessions", () => {
     await session.resize({ cols: 30, rows: 5 })
 
     const capture = await session.screen.capture({ settleMs: 10, deadlineMs: 2_000 })
+    expect(capture.frame.version).toBe(2)
+    expect(capture.frame.cursor?.style).toBe("block")
     expect(capture.frame.cols).toBe(30)
     expect(capture.text).toMatchInlineSnapshot(`
       "readyhello

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -37,10 +37,11 @@ export type Cursor = {
   y: number
   color: Color
   blinking: boolean
+  style: "block" | "hollow" | "underline" | "bar"
 }
 
 export type Frame = {
-  version: 1
+  version: 2
   cols: number
   rows: number
   foreground: Color
@@ -312,7 +313,7 @@ export class TerminalControl implements AsyncDisposable {
             this.abort(new Error("termctrl driver sent more than one hello message"))
             return
           }
-          if (message.protocolVersion !== 1) {
+          if (message.protocolVersion !== 2) {
             this.abort(new Error(`unsupported termctrl protocol version ${message.protocolVersion}`))
             return
           }

--- a/schemas/frame-v2.schema.json
+++ b/schemas/frame-v2.schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/anomalyco/terminal-control/schemas/frame-v2.schema.json",
+  "title": "Terminal Control structured terminal frame v2",
+  "type": "object",
+  "required": ["version", "cols", "rows", "foreground", "background", "cursor", "cells"],
+  "additionalProperties": false,
+  "properties": {
+    "version": { "const": 2 },
+    "cols": { "$ref": "#/$defs/terminalDimension" },
+    "rows": { "$ref": "#/$defs/terminalDimension" },
+    "foreground": { "$ref": "#/$defs/color" },
+    "background": { "$ref": "#/$defs/color" },
+    "cursor": {
+      "oneOf": [
+        { "type": "null" },
+        { "$ref": "#/$defs/cursor" }
+      ]
+    },
+    "cells": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/cell" }
+    }
+  },
+  "$defs": {
+    "dimension": { "type": "integer", "minimum": 0, "maximum": 65535 },
+    "terminalDimension": { "type": "integer", "minimum": 1, "maximum": 65535 },
+    "channel": { "type": "integer", "minimum": 0, "maximum": 255 },
+    "color": {
+      "type": "object",
+      "required": ["r", "g", "b"],
+      "additionalProperties": false,
+      "properties": {
+        "r": { "$ref": "#/$defs/channel" },
+        "g": { "$ref": "#/$defs/channel" },
+        "b": { "$ref": "#/$defs/channel" }
+      }
+    },
+    "attributes": {
+      "type": "object",
+      "required": ["bold", "italic", "faint", "invisible", "strikethrough", "overline", "underline"],
+      "additionalProperties": false,
+      "properties": {
+        "bold": { "type": "boolean" },
+        "italic": { "type": "boolean" },
+        "faint": { "type": "boolean" },
+        "invisible": { "type": "boolean" },
+        "strikethrough": { "type": "boolean" },
+        "overline": { "type": "boolean" },
+        "underline": {
+          "oneOf": [
+            { "type": "null" },
+            { "enum": ["single"] }
+          ]
+        }
+      }
+    },
+    "cursor": {
+      "type": "object",
+      "required": ["x", "y", "color", "blinking", "style"],
+      "additionalProperties": false,
+      "properties": {
+        "x": { "$ref": "#/$defs/dimension" },
+        "y": { "$ref": "#/$defs/dimension" },
+        "color": { "$ref": "#/$defs/color" },
+        "blinking": { "type": "boolean" },
+        "style": { "enum": ["block", "hollow", "underline", "bar"] }
+      }
+    },
+    "cell": {
+      "type": "object",
+      "required": ["x", "y", "text", "width", "foreground", "background", "attributes"],
+      "additionalProperties": false,
+      "properties": {
+        "x": { "$ref": "#/$defs/dimension" },
+        "y": { "$ref": "#/$defs/dimension" },
+        "text": { "type": "string" },
+        "width": { "type": "integer", "minimum": 1, "maximum": 2 },
+        "foreground": { "$ref": "#/$defs/color" },
+        "background": { "$ref": "#/$defs/color" },
+        "attributes": { "$ref": "#/$defs/attributes" }
+      }
+    }
+  }
+}

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -17,7 +17,7 @@ use crate::session::Session;
 use crate::shot::{ColorMode, Options};
 
 /// Current JSON Lines protocol version spoken by `termctrl driver`.
-pub const PROTOCOL_VERSION: u8 = 1;
+pub const PROTOCOL_VERSION: u8 = 2;
 
 /// Serve isolated embedded sessions over newline-delimited JSON requests and responses.
 ///

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -61,6 +61,7 @@ pub struct Cursor {
     pub y: u16,
     pub color: Color,
     pub blinking: bool,
+    #[serde(default)]
     pub style: CursorStyle,
 }
 
@@ -283,6 +284,19 @@ mod tests {
                 b: 128
             }
         );
+    }
+
+    #[test]
+    fn defaults_cursor_style_for_older_frames() {
+        let cursor: Cursor = serde_json::from_value(serde_json::json!({
+            "x": 1,
+            "y": 2,
+            "color": { "r": 3, "g": 4, "b": 5 },
+            "blinking": false
+        }))
+        .unwrap();
+
+        assert_eq!(cursor.style, CursorStyle::Block);
     }
 
     #[test]

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Schema version written in every structured terminal frame.
-pub const FORMAT_VERSION: u8 = 1;
+pub const FORMAT_VERSION: u8 = 2;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
 pub struct Color {
@@ -61,6 +61,18 @@ pub struct Cursor {
     pub y: u16,
     pub color: Color,
     pub blinking: bool,
+    #[serde(default)]
+    pub style: CursorStyle,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CursorStyle {
+    #[default]
+    Block,
+    Hollow,
+    Underline,
+    Bar,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
@@ -272,6 +284,16 @@ mod tests {
                 b: 128
             }
         );
+    }
+
+    #[test]
+    fn reads_v1_cursor_as_block_style() {
+        let cursor = serde_json::from_str::<Cursor>(
+            r#"{"x":0,"y":0,"color":{"r":1,"g":2,"b":3},"blinking":false}"#,
+        )
+        .unwrap();
+
+        assert_eq!(cursor.style, CursorStyle::Block);
     }
 
     #[test]

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -61,7 +61,6 @@ pub struct Cursor {
     pub y: u16,
     pub color: Color,
     pub blinking: bool,
-    #[serde(default)]
     pub style: CursorStyle,
 }
 
@@ -284,16 +283,6 @@ mod tests {
                 b: 128
             }
         );
-    }
-
-    #[test]
-    fn reads_v1_cursor_as_block_style() {
-        let cursor = serde_json::from_str::<Cursor>(
-            r#"{"x":0,"y":0,"color":{"r":1,"g":2,"b":3},"blinking":false}"#,
-        )
-        .unwrap();
-
-        assert_eq!(cursor.style, CursorStyle::Block);
     }
 
     #[test]

--- a/src/render.rs
+++ b/src/render.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 
-use crate::frame::{Cell, Frame, Underline};
+use crate::frame::{Cell, CursorStyle, Frame, Underline};
 
 mod box_drawing;
 
@@ -62,12 +62,37 @@ pub fn svg(frame: &Frame, options: &Options) -> String {
     {
         let x = options.padding + f32::from(cursor.x) * options.cell_width;
         let y = options.padding + f32::from(cursor.y) * options.cell_height;
-        output.push_str(&format!(
-            r#"<rect x="{x}" y="{y}" width="{}" height="{}" fill="{}" opacity="0.32"/>"#,
-            options.cell_width,
-            options.cell_height,
-            cursor.color.css(),
-        ));
+        let (x, y, width, height) = match cursor.style {
+            CursorStyle::Block | CursorStyle::Hollow => {
+                (x, y, options.cell_width, options.cell_height)
+            }
+            CursorStyle::Underline => {
+                let height = (options.cell_height * 0.15).max(1.0);
+                (
+                    x,
+                    y + options.cell_height - height,
+                    options.cell_width,
+                    height,
+                )
+            }
+            CursorStyle::Bar => (
+                x,
+                y,
+                (options.cell_width * 0.15).max(1.0),
+                options.cell_height,
+            ),
+        };
+        if cursor.style == CursorStyle::Hollow {
+            output.push_str(&format!(
+                r#"<rect x="{x}" y="{y}" width="{width}" height="{height}" fill="none" stroke="{}" stroke-width="1" opacity="0.32"/>"#,
+                cursor.color.css(),
+            ));
+        } else {
+            output.push_str(&format!(
+                r#"<rect x="{x}" y="{y}" width="{width}" height="{height}" fill="{}" opacity="0.32"/>"#,
+                cursor.color.css(),
+            ));
+        }
     }
     output.push_str("</g></svg>");
     output
@@ -415,7 +440,42 @@ fn xml(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::frame::{Attributes, Color, Frame, Underline};
+    use crate::frame::{Attributes, Color, CursorStyle, Frame, Underline};
+    use crate::shot;
+
+    #[test]
+    fn renders_bar_cursor_from_terminal_state() {
+        let shot = shot::from_ansi(b"\x1b[6 q".to_vec(), 1, 1, 1024).unwrap();
+
+        let output = svg(&shot.frame, &Options::default());
+
+        assert!(output.contains(
+            r##"<rect x="18" y="18" width="1.35" height="18" fill="#c9d1d9" opacity="0.32"/>"##
+        ));
+    }
+
+    #[test]
+    fn renders_underline_cursor_from_terminal_state() {
+        let shot = shot::from_ansi(b"\x1b[4 q".to_vec(), 1, 1, 1024).unwrap();
+
+        let output = svg(&shot.frame, &Options::default());
+
+        assert!(output.contains(
+            r##"<rect x="18" y="33.3" width="9" height="2.7" fill="#c9d1d9" opacity="0.32"/>"##
+        ));
+    }
+
+    #[test]
+    fn renders_hollow_cursor_as_an_outline() {
+        let mut shot = shot::from_ansi(Vec::new(), 1, 1, 1024).unwrap();
+        shot.frame.cursor.as_mut().unwrap().style = CursorStyle::Hollow;
+
+        let output = svg(&shot.frame, &Options::default());
+
+        assert!(output.contains(
+            r##"<rect x="18" y="18" width="9" height="18" fill="none" stroke="#c9d1d9" stroke-width="1" opacity="0.32"/>"##
+        ));
+    }
 
     #[test]
     fn rejects_png_allocations_above_the_pixel_limit() {

--- a/src/shot.rs
+++ b/src/shot.rs
@@ -995,7 +995,7 @@ mod tests {
     }
 
     #[test]
-    fn ghostty_ansi_shots_preserve_frame_v1_colors_and_attributes() {
+    fn ghostty_ansi_shots_preserve_frame_colors_and_attributes() {
         let shot = from_ansi(
             b"\x1b[1;3;4;38;5;214;48;2;30;34;42mwide: ".to_vec(),
             2,

--- a/src/terminal_core.rs
+++ b/src/terminal_core.rs
@@ -3,14 +3,14 @@ use std::rc::Rc;
 
 use anyhow::{Context, Result};
 use libghostty_vt::fmt::{Format, Formatter, FormatterOptions};
-use libghostty_vt::render::{CellIterator, Dirty, RowIterator};
+use libghostty_vt::render::{CellIterator, CursorVisualStyle, Dirty, RowIterator};
 use libghostty_vt::screen::CellWide;
 use libghostty_vt::style::{PaletteIndex, RgbColor, Underline as GhosttyUnderline};
 use libghostty_vt::{RenderState, Terminal, TerminalOptions};
 
 use crate::frame::{
-    Attributes, Cell, Color, Cursor, DEFAULT_BACKGROUND, DEFAULT_FOREGROUND, FORMAT_VERSION, Frame,
-    Underline, indexed_color,
+    Attributes, Cell, Color, Cursor, CursorStyle, DEFAULT_BACKGROUND, DEFAULT_FOREGROUND,
+    FORMAT_VERSION, Frame, Underline, indexed_color,
 };
 
 pub(crate) const SCROLLBACK_ROWS: usize = 10_000;
@@ -21,6 +21,7 @@ pub(crate) struct TerminalCore {
     rows: RowIterator<'static>,
     cells: CellIterator<'static>,
     responses: Rc<RefCell<Vec<u8>>>,
+    cursor_style: CursorVisualStyle,
     cached_frame: Option<Frame>,
 }
 
@@ -47,6 +48,7 @@ impl TerminalCore {
             rows: RowIterator::new().context("create Ghostty row iterator")?,
             cells: CellIterator::new().context("create Ghostty cell iterator")?,
             responses,
+            cursor_style: CursorVisualStyle::Block,
             cached_frame: None,
         })
     }
@@ -92,7 +94,13 @@ impl TerminalCore {
             .update(&self.terminal)
             .context("update Ghostty render state")?;
         let dirty = snapshot.dirty().context("read Ghostty dirty state")?;
+        let next_cursor_style = snapshot
+            .cursor_visual_style()
+            .context("read Ghostty cursor style")?;
+        let cursor_style_changed = self.cursor_style != next_cursor_style;
+        self.cursor_style = next_cursor_style;
         if dirty == Dirty::Clean
+            && !cursor_style_changed
             && let Some(frame) = &self.cached_frame
         {
             return Ok(frame.clone());
@@ -114,6 +122,7 @@ impl TerminalCore {
                     y: cursor.y,
                     color: from_ghostty_color(colors.cursor.unwrap_or(colors.foreground)),
                     blinking: snapshot.cursor_blinking().unwrap_or(false),
+                    style: frame_cursor_style(self.cursor_style),
                 })
         } else {
             None
@@ -271,16 +280,37 @@ fn from_ghostty_color(color: RgbColor) -> Color {
     }
 }
 
+fn frame_cursor_style(style: CursorVisualStyle) -> CursorStyle {
+    match style {
+        CursorVisualStyle::Block => CursorStyle::Block,
+        CursorVisualStyle::BlockHollow => CursorStyle::Hollow,
+        CursorVisualStyle::Underline => CursorStyle::Underline,
+        CursorVisualStyle::Bar => CursorStyle::Bar,
+        _ => CursorStyle::Block,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::TerminalCore;
-    use crate::frame::{DEFAULT_BACKGROUND, DEFAULT_FOREGROUND, indexed_color};
+    use crate::frame::{CursorStyle, DEFAULT_BACKGROUND, DEFAULT_FOREGROUND, indexed_color};
 
     #[test]
     fn captures_terminal_responses() {
         let mut terminal = TerminalCore::new(1, 20, 0).unwrap();
 
         assert_eq!(terminal.apply_output(b"\x1b[5n"), b"\x1b[0n");
+    }
+
+    #[test]
+    fn updates_cursor_style_without_cell_changes() {
+        let mut terminal = TerminalCore::new(1, 20, 0).unwrap();
+        terminal.frame().unwrap();
+
+        terminal.apply_output(b"\x1b[6 q");
+        let frame = terminal.frame().unwrap();
+
+        assert_eq!(frame.cursor.unwrap().style, CursorStyle::Bar);
     }
 
     #[test]
@@ -306,7 +336,7 @@ mod tests {
     }
 
     #[test]
-    fn preserves_wide_graphemes_in_frame_v1() {
+    fn preserves_wide_graphemes_in_structured_frames() {
         let mut terminal = TerminalCore::new(1, 10, 0).unwrap();
         let _responses = terminal.apply_output("A界e\u{301}".as_bytes());
         let frame = terminal.frame().unwrap();


### PR DESCRIPTION
## What

Preserve block, hollow, underline, and bar cursor styles in structured frames and render each style distinctly in SVG, PNG, screenshots, and video frames.

Supersedes #17 while preserving @rekram1-node's commits and authorship.

## Before / After

**Before:** every visible cursor was serialized and rendered as a filled block, even when the application selected a bar, underline, or hollow cursor.

**After:** Ghostty cursor-style changes invalidate the frame cache, frame v2 records the style, and renderers use matching geometry.

## How

- Add `CursorStyle` to frame v2 and retain the v1 schema.
- Bump the JSON Lines driver protocol to v2 and update the TypeScript client contract.
- Track cursor-only terminal changes even when no cells become dirty.
- Default missing cursor styles to `block` when decoding older named-session responses.
- Remove the obsolete workspace integration from the original branch.
- Add a patch Changeset.

## Testing

- `cargo fmt --all -- --check`
- `cargo test --all-targets` (112 passed, 1 ignored)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `bun run test:npm` (12 client tests, 9 OpenTUI tests)
- `bun run build:npm`
- `git diff --check`
