### PR TITLE
feat: filter session discovery

### DIFF
--- a/.changeset/filter-retained-sessions.md
+++ b/.changeset/filter-retained-sessions.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/terminal-control": minor
+---
+
+Add state, command, and working-directory filters to CLI and MCP session discovery.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,7 +12,7 @@ The versioned structured visible terminal state underlying a shot. A frame conta
 
 ### Session
 
-A named terminal application that remains available across waiting, input, resizing, log inspection, and visible-screen reads or captures. A session is `running` while accepting input, or `exited` when its application has ended but its final screen remains inspectable until explicitly stopped. A session retains bounded readable logs and the most recent bounded ANSI/VT transcript bytes; alternate-screen TUIs are read with `show` rather than logs. A session may write a recording timeline while it runs, including viewport resize events. Named CLI sessions retain non-secret launch settings so status can identify them and restart can reuse their command and working directory.
+A named terminal application that remains available across waiting, input, resizing, log inspection, and visible-screen reads or captures. A session is `running` while accepting input, or `exited` when its application has ended but its final screen remains inspectable until explicitly stopped. Session discovery defaults to running entries and can filter by state, command, or launch working directory. A session retains bounded readable logs and the most recent bounded ANSI/VT transcript bytes; alternate-screen TUIs are read with `show` rather than logs. A session may write a recording timeline while it runs, including viewport resize events. Named CLI sessions retain non-secret launch settings so status can identify them and restart can reuse their command and working directory.
 
 An embedded session owns the same live terminal lifecycle in-process; the named CLI session commands are an adapter for interacting with that lifecycle across invocations.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ termctrl mcp
 
 MCP screen reads and interactions return the current frame immediately. Agents can opt into
 quiet-output settling with `settleMs` and `deadlineMs` when a specific transition requires it.
+`list_sessions` returns running sessions by default and accepts `state`, `command`, and `cwd`
+filters for bounded server-side discovery.
 
 | MCP task | Tools |
 | --- | --- |
@@ -109,7 +111,7 @@ termctrl stop demo
 
 - `send` accepts `text:<value>`, named keys (`enter`, `escape`, arrows, `tab`, `shift-tab`, `backspace`, `delete`, `home`, `end`, `page-up`, `page-down`), and `ctrl-a` through `ctrl-z`. Pipe exact bytes with `--stdin`.
 - `wait` blocks until text is visible; use it instead of sleeping. It defaults to five seconds.
-- `status` reports running/exited state, command, cwd, viewport, and recording path. `list` shows running sessions; `list --all` includes retained exited sessions and stale sockets.
+- `status` reports running/exited state, command, cwd, viewport, and recording path. `list` shows running sessions; use `--state`, `--command`, or `--cwd` to filter discovery, and `--all` to include every retained or unavailable entry.
 - `prune --dry-run` previews retained exited sessions and stale sockets; `prune` removes them without deleting recording artifacts.
 - `resize demo --cols 132 --rows 38` tests responsive layouts.
 - `restart demo` relaunches with the stored command, cwd, viewport, and recording settings.

--- a/skills/terminal-control/SKILL.md
+++ b/skills/terminal-control/SKILL.md
@@ -108,7 +108,7 @@ Treat `.termctrl` recordings, ANSI transcripts, screen artifacts, command argume
 ## Recover From Problems
 
 - Run `termctrl status app` to inspect state and launch settings.
-- Run `termctrl list` to discover retained named sessions.
-- MCP agents can use `list_sessions` for command/cwd discovery and `get_session_status({ name })` for complete structured status without parsing CLI output.
+- Run `termctrl list` to discover running named sessions. Add `--state`, `--command`, or `--cwd` when narrowing discovery; use `--all` only when retained exited or unavailable entries are relevant.
+- MCP agents can pass `state`, `command`, or `cwd` to `list_sessions` and use `get_session_status({ name })` for complete structured status without parsing CLI output.
 - If a session socket path is too long, set `TERMCTRL_RUNTIME_DIR` to a short private directory under `/tmp` before starting sessions.
 - If `termctrl` is unavailable, install Terminal Control with `cargo install terminal-control` or ask the user which installed binary to use.

--- a/src/main.rs
+++ b/src/main.rs
@@ -424,11 +424,42 @@ struct StatusArgs {
 #[derive(Args)]
 struct ListArgs {
     /// Include retained exited sessions and stale sockets.
-    #[arg(long)]
+    #[arg(long, conflicts_with_all = ["running", "state"])]
     all: bool,
+    /// Explicitly select running sessions (the default).
+    #[arg(long, conflicts_with_all = ["all", "state"])]
+    running: bool,
+    /// Select one retained session state.
+    #[arg(long, value_enum, conflicts_with_all = ["all", "running"])]
+    state: Option<ListState>,
+    /// Match a case-sensitive substring in any command argument.
+    #[arg(long, value_name = "TEXT")]
+    command: Option<String>,
+    /// Match the exact launch working directory.
+    #[arg(long, value_name = "PATH")]
+    cwd: Option<PathBuf>,
     /// Write structured JSON entries.
     #[arg(long)]
     json: bool,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum ListState {
+    Running,
+    Exited,
+    Stale,
+    Incompatible,
+}
+
+impl From<ListState> for session::SessionListState {
+    fn from(value: ListState) -> Self {
+        match value {
+            ListState::Running => Self::Running,
+            ListState::Exited => Self::Exited,
+            ListState::Stale => Self::Stale,
+            ListState::Incompatible => Self::Incompatible,
+        }
+    }
 }
 
 #[derive(Args)]
@@ -962,15 +993,29 @@ fn status(args: StatusArgs) -> Result<()> {
 }
 
 fn list(args: ListArgs) -> Result<()> {
+    let cwd = args
+        .cwd
+        .map(fs::canonicalize)
+        .transpose()
+        .context("resolve session list working directory")?;
+    let filter = session::SessionFilter {
+        state: if args.all {
+            None
+        } else if args.running {
+            Some(session::SessionListState::Running)
+        } else {
+            Some(
+                args.state
+                    .map(Into::into)
+                    .unwrap_or(session::SessionListState::Running),
+            )
+        },
+        command: args.command,
+        cwd,
+    };
     let sessions = session::list()?
         .into_iter()
-        .filter(|entry| {
-            args.all
-                || entry
-                    .status
-                    .as_ref()
-                    .is_some_and(|status| status.state == session::SessionState::Running)
-        })
+        .filter(|entry| entry.matches(&filter))
         .collect::<Vec<_>>();
     if args.json {
         println!("{}", serde_json::to_string_pretty(&sessions)?);
@@ -1385,6 +1430,30 @@ mod tests {
         assert!(
             Cli::try_parse_from(["termctrl", "wait", "demo", "ready", "--timeout", "5"]).is_ok()
         );
+    }
+
+    #[test]
+    fn parses_session_list_filters_and_rejects_conflicting_states() {
+        let cli = Cli::try_parse_from([
+            "termctrl",
+            "list",
+            "--state",
+            "exited",
+            "--command",
+            "cargo",
+            "--cwd",
+            ".",
+            "--json",
+        ])
+        .unwrap();
+        let Command::List(args) = cli.command else {
+            panic!("expected list command");
+        };
+        assert!(matches!(args.state, Some(ListState::Exited)));
+        assert_eq!(args.command.as_deref(), Some("cargo"));
+        assert_eq!(args.cwd.as_deref(), Some(Path::new(".")));
+        assert!(Cli::try_parse_from(["termctrl", "list", "--running", "--all"]).is_err());
+        assert!(Cli::try_parse_from(["termctrl", "list", "--state", "stale", "--all"]).is_err());
     }
 
     #[test]

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -25,6 +25,40 @@ struct SessionName {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
+struct ListSessionsRequest {
+    #[serde(default)]
+    #[schemars(description = "Session state; omit to list running sessions")]
+    state: Option<ListState>,
+    #[serde(default)]
+    #[schemars(description = "Case-sensitive substring in any command argument")]
+    command: Option<String>,
+    #[serde(default)]
+    #[schemars(description = "Launch working directory; relative paths resolve from the server")]
+    cwd: Option<PathBuf>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+enum ListState {
+    Running,
+    Exited,
+    Stale,
+    Incompatible,
+}
+
+impl From<ListState> for session::SessionListState {
+    fn from(value: ListState) -> Self {
+        match value {
+            ListState::Running => Self::Running,
+            ListState::Exited => Self::Exited,
+            ListState::Stale => Self::Stale,
+            ListState::Incompatible => Self::Incompatible,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
 struct ScreenRequest {
     name: String,
     #[serde(default)]
@@ -192,19 +226,32 @@ struct ScreenArtifact {
 
 #[tool_router(server_handler)]
 impl TerminalControl {
-    #[tool(description = "List running local Terminal Control sessions")]
-    async fn list_sessions(&self) -> Result<Json<SessionList>, String> {
-        blocking(|| {
+    #[tool(description = "List and filter local Terminal Control sessions")]
+    async fn list_sessions(
+        &self,
+        Parameters(request): Parameters<ListSessionsRequest>,
+    ) -> Result<Json<SessionList>, String> {
+        blocking(move || {
+            let cwd = request
+                .cwd
+                .map(fs::canonicalize)
+                .transpose()
+                .map_err(|error| format!("resolve session list working directory: {error}"))?;
+            let filter = session::SessionFilter {
+                state: Some(
+                    request
+                        .state
+                        .map(Into::into)
+                        .unwrap_or(session::SessionListState::Running),
+                ),
+                command: request.command,
+                cwd,
+            };
             let sessions = session::list().map_err(format_error)?;
             Ok(Json(SessionList {
                 sessions: sessions
                     .into_iter()
-                    .filter(|entry| {
-                        entry
-                            .status
-                            .as_ref()
-                            .is_some_and(|status| status.state == session::SessionState::Running)
-                    })
+                    .filter(|entry| entry.matches(&filter))
                     .map(|entry| {
                         let status = entry.status;
                         SessionSummary {
@@ -505,6 +552,24 @@ mod tests {
         assert_eq!(screen.deadline_ms, 0);
         assert_eq!(interact.settle_ms, 0);
         assert_eq!(interact.deadline_ms, 0);
+    }
+
+    #[test]
+    fn session_list_filters_are_optional_and_typed() {
+        let default: ListSessionsRequest = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert!(default.state.is_none());
+        assert!(default.command.is_none());
+        assert!(default.cwd.is_none());
+
+        let filtered: ListSessionsRequest = serde_json::from_value(serde_json::json!({
+            "state": "exited",
+            "command": "cargo",
+            "cwd": "/repo"
+        }))
+        .unwrap();
+        assert!(matches!(filtered.state, Some(ListState::Exited)));
+        assert_eq!(filtered.command.as_deref(), Some("cargo"));
+        assert_eq!(filtered.cwd.as_deref(), Some(std::path::Path::new("/repo")));
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -138,6 +138,66 @@ pub struct NamedSessionStatus {
     pub unavailable: Option<UnavailableReason>,
 }
 
+impl NamedSessionStatus {
+    /// Whether this discovered entry satisfies a session-list filter.
+    pub fn matches(&self, filter: &SessionFilter) -> bool {
+        if filter.state.is_some_and(|state| !state.matches(self)) {
+            return false;
+        }
+        let Some(status) = &self.status else {
+            return filter.command.is_none() && filter.cwd.is_none();
+        };
+        filter.command.as_ref().is_none_or(|needle| {
+            status
+                .launch
+                .command
+                .iter()
+                .any(|argument| argument.contains(needle))
+        }) && filter
+            .cwd
+            .as_ref()
+            .is_none_or(|cwd| status.launch.cwd == *cwd)
+    }
+}
+
+/// Optional selectors applied to discovered named sessions.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SessionFilter {
+    pub state: Option<SessionListState>,
+    /// Case-sensitive substring matched against each command argument.
+    pub command: Option<String>,
+    /// Exact launch working directory.
+    pub cwd: Option<PathBuf>,
+}
+
+/// States addressable by session discovery filters.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SessionListState {
+    Running,
+    Exited,
+    Stale,
+    Incompatible,
+}
+
+impl SessionListState {
+    fn matches(self, entry: &NamedSessionStatus) -> bool {
+        match self {
+            Self::Running => entry
+                .status
+                .as_ref()
+                .is_some_and(|status| status.state == SessionState::Running),
+            Self::Exited => entry
+                .status
+                .as_ref()
+                .is_some_and(|status| status.state == SessionState::Exited),
+            Self::Stale => entry.unavailable == Some(UnavailableReason::Stale),
+            Self::Incompatible => {
+                entry.unavailable == Some(UnavailableReason::IncompatibleProtocol)
+            }
+        }
+    }
+}
+
 /// Why a named session socket could not report normal status.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -1703,6 +1763,71 @@ mod implementation {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn listed_session(name: &str, state: SessionState, cwd: &str) -> NamedSessionStatus {
+        NamedSessionStatus {
+            name: name.to_owned(),
+            status: Some(SessionStatus {
+                state,
+                exit: None,
+                cols: 80,
+                rows: 24,
+                cell_width: 9,
+                cell_height: 18,
+                idle_for_ms: None,
+                has_visible_content: false,
+                recording: false,
+                logs_truncated: false,
+                launch: SessionLaunch {
+                    command: vec!["nvim".to_owned(), "README.md".to_owned()],
+                    cwd: PathBuf::from(cwd),
+                    record: None,
+                    cols: 80,
+                    rows: 24,
+                    cell_width: 9,
+                    cell_height: 18,
+                    max_bytes: 1024,
+                    opentui_host: false,
+                    color: shot::ColorMode::Auto,
+                },
+            }),
+            error: None,
+            unavailable: None,
+        }
+    }
+
+    #[test]
+    fn filters_discovered_sessions_by_state_command_and_cwd() {
+        let running = listed_session("editor", SessionState::Running, "/repo");
+        assert!(running.matches(&SessionFilter {
+            state: Some(SessionListState::Running),
+            command: Some("README".to_owned()),
+            cwd: Some(PathBuf::from("/repo")),
+        }));
+        assert!(!running.matches(&SessionFilter {
+            state: Some(SessionListState::Exited),
+            ..SessionFilter::default()
+        }));
+        assert!(!running.matches(&SessionFilter {
+            command: Some("cargo".to_owned()),
+            ..SessionFilter::default()
+        }));
+
+        let stale = NamedSessionStatus {
+            name: "old".to_owned(),
+            status: None,
+            error: Some("connection refused".to_owned()),
+            unavailable: Some(UnavailableReason::Stale),
+        };
+        assert!(stale.matches(&SessionFilter {
+            state: Some(SessionListState::Stale),
+            ..SessionFilter::default()
+        }));
+        assert!(!stale.matches(&SessionFilter {
+            command: Some("nvim".to_owned()),
+            ..SessionFilter::default()
+        }));
+    }
 
     #[test]
     fn semantic_request_and_response_preserve_the_session_protocol() {


### PR DESCRIPTION
## What

Complete #6 with state, command, and working-directory filters for CLI and MCP session discovery while preserving running-only defaults and secure pruning.

## How

- Add `termctrl list --running` as the explicit form of the existing default.
- Add `termctrl list --state running|exited|stale|incompatible`.
- Add `--command TEXT` substring filtering and canonical `--cwd PATH` filtering.
- Add equivalent typed `state`, `command`, and `cwd` arguments to MCP `list_sessions`.
- Centralize matching in `SessionFilter` so CLI and MCP behavior stays aligned.
- Keep `list --all`, `prune --dry-run`, and `prune` behavior intact.
- Update README, domain context, agent skill, and add a minor Changeset.

## Testing

- `cargo fmt --all -- --check`
- `cargo test --all-targets` (115 passed, 1 ignored)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release`
- `bun run test:npm` (12 client tests, 9 OpenTUI tests)
- `bun run build:npm`
- `bun run validate:npm`
- `cargo package --list --allow-dirty`
- Live CLI filtering by running/exited state, command, and relative cwd
- Live stdio MCP `list_sessions` filtering by state, command, and relative cwd
