### PR TITLE
chore: release terminal-control 1.1.0

### DIFF
--- a/.changeset/filter-retained-sessions.md
+++ b/.changeset/filter-retained-sessions.md
@@ -1,5 +1,0 @@
----
-"@kitlangton/terminal-control": minor
----
-
-Add state, command, and working-directory filters to CLI and MCP session discovery.

--- a/.changeset/render-powerline-shapes.md
+++ b/.changeset/render-powerline-shapes.md
@@ -1,5 +1,0 @@
----
-"@kitlangton/terminal-control": patch
----
-
-Render shade blocks and Powerline separators as exact SVG geometry for smooth gradients and seam-free captures.

--- a/.changeset/tidy-cursors-render.md
+++ b/.changeset/tidy-cursors-render.md
@@ -1,5 +1,0 @@
----
-"@kitlangton/terminal-control": patch
----
-
-Preserve terminal cursor styles in structured frames, screenshots, and videos.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "terminal-control"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminal-control"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 rust-version = "1.93"
 description = "Control and test terminal applications through stable visible state"

--- a/bun.lock
+++ b/bun.lock
@@ -10,35 +10,35 @@
     },
     "packages/darwin-arm64": {
       "name": "@kitlangton/terminal-control-darwin-arm64",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "bin": {
         "termctrl": "bin/termctrl",
       },
     },
     "packages/darwin-x64": {
       "name": "@kitlangton/terminal-control-darwin-x64",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "bin": {
         "termctrl": "bin/termctrl",
       },
     },
     "packages/linux-arm64-gnu": {
       "name": "@kitlangton/terminal-control-linux-arm64-gnu",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "bin": {
         "termctrl": "bin/termctrl",
       },
     },
     "packages/linux-x64-gnu": {
       "name": "@kitlangton/terminal-control-linux-x64-gnu",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "bin": {
         "termctrl": "bin/termctrl",
       },
     },
     "packages/opentui": {
       "name": "@kitlangton/terminal-control-opentui",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "devDependencies": {
         "@opentui/core": "^0.4.5",
         "@types/bun": "^1.3.0",
@@ -51,7 +51,7 @@
     },
     "packages/test": {
       "name": "@kitlangton/terminal-control",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "devDependencies": {
         "@types/bun": "^1.3.0",
         "@types/node": "^24.0.0",
@@ -59,10 +59,10 @@
         "vitest": "^3.2.4",
       },
       "optionalDependencies": {
-        "@kitlangton/terminal-control-darwin-arm64": "1.0.0",
-        "@kitlangton/terminal-control-darwin-x64": "1.0.0",
-        "@kitlangton/terminal-control-linux-arm64-gnu": "1.0.0",
-        "@kitlangton/terminal-control-linux-x64-gnu": "1.0.0",
+        "@kitlangton/terminal-control-darwin-arm64": "1.1.0",
+        "@kitlangton/terminal-control-darwin-x64": "1.1.0",
+        "@kitlangton/terminal-control-linux-arm64-gnu": "1.1.0",
+        "@kitlangton/terminal-control-linux-x64-gnu": "1.1.0",
       },
       "peerDependencies": {
         "vitest": ">=3.0.0",

--- a/packages/darwin-arm64/CHANGELOG.md
+++ b/packages/darwin-arm64/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @kitlangton/terminal-control-darwin-arm64
 
+## 1.1.0
+
 ## 1.0.0
 
 ## 0.6.0

--- a/packages/darwin-arm64/package.json
+++ b/packages/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control-darwin-arm64",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Native termctrl binary for Terminal Control on macOS arm64",
   "license": "MIT",
   "repository": "https://github.com/anomalyco/terminal-control",

--- a/packages/darwin-x64/CHANGELOG.md
+++ b/packages/darwin-x64/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @kitlangton/terminal-control-darwin-x64
 
+## 1.1.0
+
 ## 1.0.0
 
 ## 0.6.0

--- a/packages/darwin-x64/package.json
+++ b/packages/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control-darwin-x64",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Native termctrl binary for Terminal Control on macOS x64",
   "license": "MIT",
   "repository": "https://github.com/anomalyco/terminal-control",

--- a/packages/linux-arm64-gnu/CHANGELOG.md
+++ b/packages/linux-arm64-gnu/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @kitlangton/terminal-control-linux-arm64-gnu
 
+## 1.1.0
+
 ## 1.0.0
 
 ## 0.6.0

--- a/packages/linux-arm64-gnu/package.json
+++ b/packages/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control-linux-arm64-gnu",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Native termctrl binary for Terminal Control on Linux arm64 GNU",
   "license": "MIT",
   "repository": "https://github.com/anomalyco/terminal-control",

--- a/packages/linux-x64-gnu/CHANGELOG.md
+++ b/packages/linux-x64-gnu/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @kitlangton/terminal-control-linux-x64-gnu
 
+## 1.1.0
+
 ## 1.0.0
 
 ## 0.6.0

--- a/packages/linux-x64-gnu/package.json
+++ b/packages/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control-linux-x64-gnu",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Native termctrl binary for Terminal Control on Linux x64 GNU",
   "license": "MIT",
   "repository": "https://github.com/anomalyco/terminal-control",

--- a/packages/opentui/CHANGELOG.md
+++ b/packages/opentui/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @kitlangton/terminal-control-opentui
 
+## 1.1.0
+
 ## 1.0.0
 
 ## 0.6.0

--- a/packages/opentui/package.json
+++ b/packages/opentui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control-opentui",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Expose consistent OpenTUI semantic snapshots through Terminal Control",
   "license": "MIT",
   "repository": {

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @kitlangton/terminal-control
 
+## 1.1.0
+
+### Minor Changes
+
+- 861ad0f: Add state, command, and working-directory filters to CLI and MCP session discovery.
+
+### Patch Changes
+
+- ca75e4e: Render shade blocks and Powerline separators as exact SVG geometry for smooth gradients and seam-free captures.
+- e54baad: Preserve terminal cursor styles in structured frames, screenshots, and videos.
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Typed terminal application control and testing with snapshots, recordings, and failure artifacts",
   "license": "MIT",
   "repository": {
@@ -38,10 +38,10 @@
     "prepack": "bun run build"
   },
   "optionalDependencies": {
-    "@kitlangton/terminal-control-darwin-arm64": "1.0.0",
-    "@kitlangton/terminal-control-darwin-x64": "1.0.0",
-    "@kitlangton/terminal-control-linux-arm64-gnu": "1.0.0",
-    "@kitlangton/terminal-control-linux-x64-gnu": "1.0.0"
+    "@kitlangton/terminal-control-darwin-arm64": "1.1.0",
+    "@kitlangton/terminal-control-darwin-x64": "1.1.0",
+    "@kitlangton/terminal-control-linux-arm64-gnu": "1.1.0",
+    "@kitlangton/terminal-control-linux-x64-gnu": "1.1.0"
   },
   "peerDependencies": {
     "vitest": ">=3.0.0"


### PR DESCRIPTION
## What

Prepare the aligned Terminal Control `1.1.0` release containing session discovery filters, cursor-style preservation, and exact shade/Powerline rendering.

## How

- Consume the three merged Changesets and generate aligned changelogs.
- Set Cargo, the TypeScript client, OpenTUI adapter, and four native packages to `1.1.0`.
- Align Cargo and Bun lockfile metadata and native optional dependencies.

## Testing

- `bun install --frozen-lockfile`
- `cargo fmt --all -- --check`
- `cargo test --all-targets` (115 passed, 1 ignored)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release`
- `bun run test:npm` (12 client tests, 9 OpenTUI tests)
- `bun run build:npm`
- `bun run validate:npm`
- `cargo package --list --allow-dirty`
- `cargo package --allow-dirty`
- `cargo publish --dry-run --locked --allow-dirty`
- Verified `termctrl --version` reports `1.1.0`
