### PR TITLE
fix(host): preserve query-time cursor replies

### DIFF
--- a/.changeset/quiet-cursor-replies.md
+++ b/.changeset/quiet-cursor-replies.md
@@ -1,0 +1,10 @@
+---
+"@kitlangton/terminal-control": patch
+"@kitlangton/terminal-control-opentui": patch
+"@kitlangton/terminal-control-darwin-arm64": patch
+"@kitlangton/terminal-control-darwin-x64": patch
+"@kitlangton/terminal-control-linux-arm64-gnu": patch
+"@kitlangton/terminal-control-linux-x64-gnu": patch
+---
+
+Answer cursor-position queries with the actual query-time cursor position when using the OpenTUI host profile, including split and repeated queries, without injecting unsolicited startup cursor reports.

--- a/src/shot.rs
+++ b/src/shot.rs
@@ -507,9 +507,29 @@ pub(crate) fn respond_to_output(
     host: &mut Host,
     output: &[u8],
 ) -> Result<Vec<u8>> {
-    let ghostty_response = terminal.apply_output(output);
+    let ghostty_response = terminal
+        .apply_output(output)
+        .into_iter()
+        .filter(|reply| {
+            if !host.is_enabled() {
+                return true;
+            }
+            let Some((row, col)) = std::str::from_utf8(reply)
+                .ok()
+                .and_then(|reply| reply.strip_prefix("\x1b["))
+                .and_then(|reply| reply.strip_suffix('R'))
+                .and_then(|position| position.split_once(';'))
+            else {
+                return false;
+            };
+            [row, col]
+                .into_iter()
+                .all(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+        })
+        .flatten()
+        .collect::<Vec<_>>();
     if host.is_enabled() {
-        host.respond(output)
+        host.respond(output, ghostty_response)
     } else {
         if !ghostty_response.is_empty() && !host.send_if_open(&ghostty_response)? {
             return Ok(Vec::new());
@@ -615,11 +635,10 @@ impl Host {
         self.pixel_height = u32::from(rows) * u32::from(cell_height);
     }
 
-    pub(crate) fn respond(&mut self, output: &[u8]) -> Result<Vec<u8>> {
+    pub(crate) fn respond(&mut self, output: &[u8], mut response: Vec<u8>) -> Result<Vec<u8>> {
         if !self.enabled {
             return Ok(Vec::new());
         }
-        let mut response = Vec::new();
         self.probe.extend_from_slice(output);
         self.color_probe.extend_from_slice(output);
         for query in take_color_queries(&mut self.color_probe) {
@@ -644,7 +663,7 @@ impl Host {
         {
             response.extend_from_slice(
                 format!(
-                        "\x1bP>|termctrl {}\x1b\\\x1b[1;1R\x1b[?1016;0$y\x1b[?2027;0$y\x1b[?2031;2$y\x1b[?1004;1$y\x1b[?2004;2$y\x1b[?2026;2$y\x1b[?0u\x1b[1;1R\x1b[1;1R\x1b[4;{};{}t\x1b[?6c",
+                        "\x1bP>|termctrl {}\x1b\\\x1b[?1016;0$y\x1b[?2027;0$y\x1b[?2031;2$y\x1b[?1004;1$y\x1b[?2004;2$y\x1b[?2026;2$y\x1b[?0u\x1b[4;{};{}t\x1b[?6c",
                         env!("CARGO_PKG_VERSION"),
                         self.pixel_height,
                         self.pixel_width,
@@ -954,10 +973,10 @@ mod tests {
             },
         );
 
-        host.respond(b"\x1b]10;?\x07").unwrap();
-        host.respond(b"\x1b]11;?\x07").unwrap();
-        host.respond(b"\x1b]4;0;?\x07").unwrap();
-        host.respond(b"\x1b_Gi=31337,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\")
+        host.respond(b"\x1b]10;?\x07", Vec::new()).unwrap();
+        host.respond(b"\x1b]11;?\x07", Vec::new()).unwrap();
+        host.respond(b"\x1b]4;0;?\x07", Vec::new()).unwrap();
+        host.respond(b"\x1b_Gi=31337,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\", Vec::new())
             .unwrap();
 
         let output = String::from_utf8(result.lock().unwrap().clone()).unwrap();
@@ -986,6 +1005,137 @@ mod tests {
 
         assert_eq!(foreground_responses, 1);
         assert_eq!(*written.lock().unwrap(), response);
+    }
+
+    #[test]
+    fn cursor_replies_preserve_query_time_positions_across_chunks() {
+        let cases: &[(&str, &[u8], &[u8])] = &[
+            ("initial", b"\x1b[6n", b"\x1b[1;1R"),
+            ("moved", b"\x1b[3;7H\x1b[6n", b"\x1b[3;7R"),
+            ("repeated", b"\x1b[6n\x1b[6n", b"\x1b[1;1R\x1b[1;1R"),
+            ("hidden", b"\x1b[?25l\x1b[4;12H\x1b[6n", b"\x1b[4;12R"),
+            (
+                "origin",
+                b"\x1b[5;20r\x1b[?6h\x1b[3;5H\x1b[6n",
+                b"\x1b[3;5R",
+            ),
+            (
+                "multiple positions",
+                b"\x1b[2;5H\x1b[6n\x1b[8;13H\x1b[6n\x1b[20;30H\x1b[6n\x1b[H",
+                b"\x1b[2;5R\x1b[8;13R\x1b[20;30R",
+            ),
+            (
+                "width probes",
+                b"\x1b[5;9H\x1b7\x1b[6n\x1b[H\x1b]66;w=1; \x1b\\\x1b[6n\x1b[H\x1b]66;s=2; \x1b\\\x1b[6n\x1b8",
+                b"\x1b[5;9R\x1b[1;1R\x1b[1;1R",
+            ),
+        ];
+        for &(name, output, expected) in cases {
+            for opentui_host in [false, true] {
+                let partitions = (0..=output.len())
+                    .map(|split| vec![&output[..split], &output[split..]])
+                    .chain(std::iter::once(output.chunks(1).collect()));
+                for chunks in partitions {
+                    let written = Arc::new(Mutex::new(Vec::new()));
+                    let mut host = Host::new(
+                        Box::new(Writer(Arc::clone(&written))),
+                        &Options {
+                            opentui_host,
+                            ..Options::default()
+                        },
+                    );
+                    let mut terminal = TerminalCore::new(24, 80, 0).unwrap();
+                    let mut response = Vec::new();
+                    let mut consumed = 0;
+                    for chunk in chunks {
+                        response
+                            .extend(respond_to_output(&mut terminal, &mut host, chunk).unwrap());
+                        consumed += chunk.len();
+                        let queries = output[..consumed]
+                            .windows(4)
+                            .filter(|window| *window == b"\x1b[6n")
+                            .count();
+                        assert_eq!(
+                            response.iter().filter(|&&byte| byte == b'R').count(),
+                            queries,
+                            "{name}, host={opentui_host}, consumed={consumed}"
+                        );
+                        assert_eq!(*written.lock().unwrap(), response);
+                    }
+                    assert_eq!(response, expected, "{name}, host={opentui_host}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn cursor_replies_mix_with_host_overrides_without_unsolicited_reports() {
+        let overrides = format!(
+            "\x1b]10;rgb:c9c9/d1d1/d9d9\x1b\\\x1b]11;rgb:0d0d/1111/1717\x1b\\\x1bP>|termctrl {}\x1b\\\x1b[?1016;0$y\x1b[?2027;0$y\x1b[?2031;2$y\x1b[?1004;1$y\x1b[?2004;2$y\x1b[?2026;2$y\x1b[?0u\x1b[4;432;720t\x1b[?6c",
+            env!("CARGO_PKG_VERSION")
+        );
+        let cases: &[(bool, &[u8], Vec<u8>)] = &[
+            (true, OPENTUI_QUERY, overrides.as_bytes().to_vec()),
+            (
+                true,
+                b"\x1b[3;7H\x1b[6n\x1b]10;?\x07\x1b]11;?\x07\x1b[5n\x1b[>0q\x1b[?u\x1b[?1016$p\x1b[H\x1b]66;w=1; \x1b\\\x1b[6n\x1b[H\x1b]66;s=2; \x1b\\\x1b[6n",
+                [b"\x1b[3;7R\x1b[1;1R\x1b[1;1R", overrides.as_bytes()].concat(),
+            ),
+            (
+                false,
+                b"\x1b[5n\x1b[3;7H\x1b[6n\x1b[?7$p",
+                b"\x1b[0n\x1b[3;7R\x1b[?7;1$y".to_vec(),
+            ),
+        ];
+        for (opentui_host, output, expected) in cases {
+            let written = Arc::new(Mutex::new(Vec::new()));
+            let mut host = Host::new(
+                Box::new(Writer(Arc::clone(&written))),
+                &Options {
+                    opentui_host: *opentui_host,
+                    ..Options::default()
+                },
+            );
+            let mut terminal = TerminalCore::new(24, 80, 0).unwrap();
+            let response = respond_to_output(&mut terminal, &mut host, output).unwrap();
+            assert_eq!(&response, expected);
+            assert_eq!(*written.lock().unwrap(), response);
+        }
+    }
+
+    #[test]
+    fn cursor_replies_ignore_only_closed_writer_errors() {
+        struct FailedWriter(std::io::ErrorKind);
+        impl Write for FailedWriter {
+            fn write(&mut self, _: &[u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::from(self.0))
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        for opentui_host in [false, true] {
+            for kind in [
+                std::io::ErrorKind::BrokenPipe,
+                std::io::ErrorKind::PermissionDenied,
+            ] {
+                let mut host = Host::new(
+                    Box::new(FailedWriter(kind)),
+                    &Options {
+                        opentui_host,
+                        ..Options::default()
+                    },
+                );
+                let mut terminal = TerminalCore::new(24, 80, 0).unwrap();
+                let response = respond_to_output(&mut terminal, &mut host, b"\x1b[6n");
+                if kind == std::io::ErrorKind::BrokenPipe {
+                    assert!(response.unwrap().is_empty());
+                } else {
+                    assert!(response.is_err());
+                }
+            }
+        }
     }
 
     #[test]

--- a/src/terminal_core.rs
+++ b/src/terminal_core.rs
@@ -20,7 +20,7 @@ pub(crate) struct TerminalCore {
     render_state: RenderState<'static>,
     rows: RowIterator<'static>,
     cells: CellIterator<'static>,
-    responses: Rc<RefCell<Vec<u8>>>,
+    responses: Rc<RefCell<Vec<Vec<u8>>>>,
     cursor_style: CursorVisualStyle,
     cached_frame: Option<Frame>,
 }
@@ -37,7 +37,8 @@ impl TerminalCore {
         terminal
             .on_pty_write({
                 let responses = Rc::clone(&responses);
-                move |_terminal, bytes| responses.borrow_mut().extend_from_slice(bytes)
+                // Preserve reply boundaries so hosts can select replies without a stream parser.
+                move |_terminal, bytes| responses.borrow_mut().push(bytes.to_vec())
             })
             .context("configure Ghostty PTY responses")?;
         apply_theme(&mut terminal)?;
@@ -53,7 +54,7 @@ impl TerminalCore {
         })
     }
 
-    pub(crate) fn apply_output(&mut self, bytes: &[u8]) -> Vec<u8> {
+    pub(crate) fn apply_output(&mut self, bytes: &[u8]) -> Vec<Vec<u8>> {
         self.terminal.vt_write(bytes);
         std::mem::take(&mut self.responses.borrow_mut())
     }
@@ -299,7 +300,10 @@ mod tests {
     fn captures_terminal_responses() {
         let mut terminal = TerminalCore::new(1, 20, 0).unwrap();
 
-        assert_eq!(terminal.apply_output(b"\x1b[5n"), b"\x1b[0n");
+        assert_eq!(
+            terminal.apply_output(b"\x1b[5n\x1b[6n"),
+            vec![b"\x1b[0n".to_vec(), b"\x1b[1;1R".to_vec()]
+        );
     }
 
     #[test]


### PR DESCRIPTION
**Why**
An application requesting `CSI 6 n` under `--host opentui` receives no standalone cursor-position response, even though Ghostty has already generated the correct reply. The OpenTUI startup bundle instead injects three hardcoded home-position reports, including when no cursor query was sent.

**What Changes**
Forward actual query-time cursor reports while retaining the OpenTUI host's other overrides.

| Output / Current State | Before | After |
| --- | --- | --- |
| `CSI 6 n` at row 3, column 7 | No reply | `ESC[3;7R` |
| Split `CSI 6 n` at row 9, column 11 | No reply | One `ESC[9;11R` on completion |
| Queries at three successive positions in one chunk | No replies | Three ordered query-time reports |
| Startup foreground/background queries only | Three unsolicited `ESC[1;1R` reports | No cursor reports |

Ghostty remains responsible for VT parsing and cursor state, including hidden cursors and origin-relative coordinates. Preserve its callback boundaries, select complete ASCII-digit CPR records for OpenTUI, and seed the existing host response before appending its overrides. The combined response is sent once and returned unchanged for recording. Default hosting still concatenates all Ghostty replies in their original order.

Includes a patch Changeset for the existing fixed six-package release group; no versions are bumped.

**Scope**
This addresses cursor replies in the shared terminal response path. Related #16; this does not implement that PR's Windows session transport or ConPTY teardown work.

**Verification**
```bash
PATH="/opt/homebrew/opt/zig@0.15/bin:$PATH" cargo test --locked --lib cursor_replies -- --nocapture
cargo +1.93.0 fmt --all -- --check
PATH="/opt/homebrew/opt/zig@0.15/bin:$PATH" cargo +1.93.0 test --locked --all-targets
PATH="/opt/homebrew/opt/zig@0.15/bin:$PATH" cargo +1.93.0 test --locked --doc
PATH="/opt/homebrew/opt/zig@0.15/bin:$PATH" cargo +1.93.0 clippy --locked --all-targets --all-features -- -D warnings
PATH="/opt/homebrew/opt/zig@0.15/bin:$PATH" cargo +1.93.0 build --locked --release
bun install --frozen-lockfile
TERMCTRL_TEST_BINARY="$PWD/target/release/termctrl" bun run test:npm
bun run build:npm
bun run validate:npm "$PWD/target/release/termctrl"
cargo +1.93.0 package --locked --list --allow-dirty
PATH="/opt/homebrew/opt/zig@0.15/bin:$PATH" cargo +1.93.0 package --locked
bun run changeset status
```

- Three regression tests at the real `respond_to_output` seam fail before the fix and pass after it on the same Rust 1.95 toolchain.
- Rust 1.93: 118 all-target tests and one doctest pass; one existing manual benchmark remains ignored. Formatting, Clippy, release build, and crate packaging pass.
- Table-driven tests cover whole queries, every two-way split, bytewise feeds, repeated and hidden-cursor queries, origin mode, multiple query-time positions, real width probes, exact mixed startup replies, default reply ordering, written/returned byte equality, and closed versus denied writers.
- Npm typechecks, 21 tests, builds, and packed clean Bun/Node consumers pass using the source release executable.
- Owned disposable PTY fixtures on macOS reproduce missing/canned reports before the fix and verify correct reports afterward for initial, moved, split, repeated/hidden, multiple-position, origin-relative, mixed-startup, and post-startup queries in both host profiles.
- Real OpenTUI 0.4.5 renders readiness and exits normally on `q` before and after. Three received CPRs match three emitted queries and the recorded host CPRs. Non-CPR host bytes are identical between recordings; width, scaling, and pixel-mode capability values remain unchanged. No owned fixture processes remain.

Additional `bun run --cwd packages/opentui release:check` packs successfully but fails at `npm publish --dry-run --access public` because unchanged version `1.1.0` is already published: `You cannot publish over the previously published versions: 1.1.0.` No publish or version change was performed.
