### PR TITLE
fix(session): detach background daemons from launcher groups

### DIFF
--- a/.changeset/detached-sessions-survive.md
+++ b/.changeset/detached-sessions-survive.md
@@ -1,0 +1,10 @@
+---
+"@kitlangton/terminal-control": patch
+"@kitlangton/terminal-control-opentui": patch
+"@kitlangton/terminal-control-darwin-arm64": patch
+"@kitlangton/terminal-control-darwin-x64": patch
+"@kitlangton/terminal-control-linux-arm64-gnu": patch
+"@kitlangton/terminal-control-linux-x64-gnu": patch
+---
+
+Detach background session daemons from their launcher's process group so named sessions started or restarted with the CLI survive launcher-group hangups.

--- a/src/session.rs
+++ b/src/session.rs
@@ -1064,6 +1064,7 @@ mod implementation {
     use std::os::fd::AsRawFd;
     use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
     use std::os::unix::net::{UnixListener, UnixStream};
+    use std::os::unix::process::CommandExt;
     use std::path::{Path, PathBuf};
     use std::process::{Command, Stdio};
     use std::thread;
@@ -1214,6 +1215,15 @@ mod implementation {
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null());
+        // Background sessions must survive hangups of the launcher's terminal/process group.
+        unsafe {
+            daemon.pre_exec(|| {
+                if libc::setsid() < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
         let mut daemon = daemon.spawn().context("start session daemon")?;
         let deadline = Instant::now() + Duration::from_secs(5);
         loop {

--- a/tests/daemon_detach.rs
+++ b/tests/daemon_detach.rs
@@ -1,0 +1,269 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::DirBuilderExt;
+use std::os::unix::process::{CommandExt, ExitStatusExt};
+use std::path::PathBuf;
+use std::process::{Child, Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+struct NamedSession {
+    runtime: PathBuf,
+    launchers: Vec<Child>,
+}
+
+impl NamedSession {
+    fn new(label: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        // Keep the canonical socket path below the portable 100-byte limit on macOS.
+        let runtime = PathBuf::from(format!(
+            "/tmp/termctrl-detach-{label}-{}-{nonce}",
+            std::process::id()
+        ));
+        fs::DirBuilder::new().mode(0o700).create(&runtime).unwrap();
+        Self {
+            runtime,
+            launchers: Vec::new(),
+        }
+    }
+
+    fn output(&self, args: &[&str]) -> std::io::Result<Output> {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_termctrl"));
+        command
+            .args(args)
+            .env("TERMCTRL_RUNTIME_DIR", &self.runtime)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let mut child = command.spawn()?;
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while child.try_wait()?.is_none() {
+            if Instant::now() >= deadline {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    format!("command timed out: {args:?}"),
+                ));
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        child.wait_with_output()
+    }
+
+    fn launch(&mut self, operation: &str) {
+        let ready = self.runtime.join(format!("{operation}.ready"));
+        let pids = self.runtime.join(format!("{operation}.pids"));
+        let mut launcher = Command::new("/bin/sh");
+        launcher
+            .arg("-c")
+            .arg(
+                r#""$1" "$2" demo -- /bin/sh -c 'printf "%s %s\n" "$$" "$PPID" > "$1"; printf READY; exec sleep 30' fixture "$3" && : > "$4" && exec sleep 30"#,
+            )
+            .arg("termctrl-launcher")
+            .arg(env!("CARGO_BIN_EXE_termctrl"))
+            .arg(operation)
+            .arg(&pids)
+            .arg(&ready)
+            .env("TERMCTRL_RUNTIME_DIR", &self.runtime)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::from(
+                fs::File::create(self.runtime.join(format!("{operation}.stderr"))).unwrap(),
+            ));
+        unsafe {
+            launcher.pre_exec(|| {
+                if libc::setsid() < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        self.launchers.push(launcher.spawn().unwrap());
+        let launcher = self.launchers.last_mut().unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !ready.exists() || !pids.exists() {
+            assert!(
+                launcher.try_wait().unwrap().is_none(),
+                "{operation} launcher exited early: {}",
+                fs::read_to_string(self.runtime.join(format!("{operation}.stderr")))
+                    .unwrap_or_default()
+            );
+            assert!(
+                Instant::now() < deadline,
+                "{operation} launcher was not ready"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert_success(
+            self.output(&["wait", "demo", "READY", "--timeout", "2000"])
+                .unwrap(),
+        );
+        eprintln!(
+            "{operation}: launcher group {}, application/daemon {}",
+            self.launchers.last().unwrap().id(),
+            fs::read_to_string(&pids).unwrap().trim()
+        );
+        if operation == "restart" {
+            self.assert_application_stopped("start");
+        }
+    }
+
+    fn assert_application_stopped(&self, operation: &str) {
+        let path = self.runtime.join(format!("{operation}.pids"));
+        let pids = fs::read_to_string(&path).unwrap();
+        let application = pids
+            .split_whitespace()
+            .next()
+            .unwrap()
+            .parse::<libc::pid_t>()
+            .unwrap();
+        assert!(application > 1);
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while unsafe { libc::kill(application, 0) } == 0 {
+            assert!(
+                Instant::now() < deadline,
+                "{operation} application was not stopped"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert_eq!(
+            std::io::Error::last_os_error().raw_os_error(),
+            Some(libc::ESRCH)
+        );
+        fs::remove_file(path).unwrap();
+    }
+}
+
+impl Drop for NamedSession {
+    fn drop(&mut self) {
+        // Only these successfully setsid-isolated launchers receive group signals.
+        // Kill them before reading PID files so no launcher can start another daemon.
+        for launcher in &mut self.launchers {
+            // Do not signal a reaped child's ID, which could have been reused.
+            if launcher.try_wait().is_ok_and(|status| status.is_none()) {
+                unsafe {
+                    libc::killpg(launcher.id() as libc::pid_t, libc::SIGKILL);
+                }
+            }
+            let _ = launcher.wait();
+        }
+        // Prefer normal shutdown so a live daemon reaps its application. This is bounded
+        // even on assertion failures; the PID fallback also covers a daemon killed by SIGHUP.
+        if self
+            .output(&["stop", "demo"])
+            .is_ok_and(|output| output.status.success())
+        {
+            let _ = fs::remove_dir_all(&self.runtime);
+            return;
+        }
+        if let Ok(entries) = fs::read_dir(&self.runtime) {
+            for entry in entries.flatten() {
+                if entry.path().extension().and_then(|value| value.to_str()) != Some("pids") {
+                    continue;
+                }
+                if let Ok(pids) = fs::read_to_string(entry.path()) {
+                    for pid in pids
+                        .split_whitespace()
+                        .filter_map(|value| value.parse::<libc::pid_t>().ok())
+                    {
+                        if pid > 1 && pid != std::process::id() as libc::pid_t {
+                            // The application execs sleep instead of spawning descendants.
+                            // Use individual PIDs: a broken daemon may share the runner's group.
+                            unsafe {
+                                libc::kill(pid, libc::SIGKILL);
+                            }
+                            thread::sleep(Duration::from_millis(20));
+                        }
+                    }
+                }
+            }
+        }
+        let _ = fs::remove_dir_all(&self.runtime);
+    }
+}
+
+fn survives_launcher_hangup(restart: bool) {
+    let operation = if restart { "restart" } else { "start" };
+    let mut session = NamedSession::new(operation);
+    session.launch("start");
+    if restart {
+        session.launch("restart");
+    }
+    let pids = fs::read_to_string(session.runtime.join(format!("{operation}.pids"))).unwrap();
+    let daemon = pids
+        .split_whitespace()
+        .nth(1)
+        .unwrap()
+        .parse::<libc::pid_t>()
+        .unwrap();
+    let launcher = session.launchers.last_mut().unwrap();
+    let group = launcher.id() as libc::pid_t;
+    assert!(group > 1);
+    assert_ne!(group, unsafe { libc::getpgrp() });
+    assert_eq!(unsafe { libc::getpgid(group) }, group);
+    assert_eq!(unsafe { libc::killpg(group, libc::SIGHUP) }, 0);
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let status = loop {
+        if let Some(status) = launcher.try_wait().unwrap() {
+            break status;
+        }
+        assert!(Instant::now() < deadline, "launcher survived SIGHUP");
+        thread::sleep(Duration::from_millis(10));
+    };
+    assert_eq!(status.signal(), Some(libc::SIGHUP));
+
+    let status: serde_json::Value = serde_json::from_slice(
+        &assert_success(session.output(&["status", "demo", "--json"]).unwrap()).stdout,
+    )
+    .unwrap();
+    assert_eq!(status["state"], "running");
+    assert_eq!(unsafe { libc::getsid(daemon) }, daemon);
+    assert_eq!(
+        String::from_utf8(assert_success(session.output(&["show", "demo"]).unwrap()).stdout)
+            .unwrap()
+            .trim(),
+        "READY"
+    );
+    assert_success(session.output(&["stop", "demo"]).unwrap());
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while session.runtime.join("demo.sock").exists() {
+        assert!(
+            Instant::now() < deadline,
+            "stop left the session socket behind"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+    session.assert_application_stopped(operation);
+    assert!(
+        !session
+            .output(&["status", "demo"])
+            .unwrap()
+            .status
+            .success()
+    );
+    eprintln!("launcher SIGHUP: status running, show READY, stop removed socket and application");
+}
+
+fn assert_success(output: Output) -> Output {
+    assert!(
+        output.status.success(),
+        "command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+#[test]
+fn named_session_survives_launcher_process_group_hangup() {
+    survives_launcher_hangup(false);
+}
+
+#[test]
+fn restarted_session_survives_launcher_process_group_hangup() {
+    survives_launcher_hangup(true);
+}

--- a/tests/daemon_detach.rs
+++ b/tests/daemon_detach.rs
@@ -55,14 +55,14 @@ impl NamedSession {
         child.wait_with_output()
     }
 
-    fn launch(&mut self, operation: &str) {
-        let ready = self.runtime.join(format!("{operation}.ready"));
-        let pids = self.runtime.join(format!("{operation}.pids"));
+    fn launch(&mut self, operation: &str, generation: &str) {
+        let ready = self.runtime.join(format!("{generation}.ready"));
+        let pids = self.runtime.join(format!("{generation}.pids"));
         let mut launcher = Command::new("/bin/sh");
         launcher
             .arg("-c")
             .arg(
-                r#""$1" "$2" demo -- /bin/sh -c 'printf "%s %s\n" "$$" "$PPID" > "$1"; printf READY; exec sleep 30' fixture "$3" && : > "$4" && exec sleep 30"#,
+                r#""$1" "$2" demo -- /bin/sh -c 'printf "%s %s\n" "$$" "$PPID" > "$1"; printf READY; read -r ignored' fixture "$3" && : > "$4" && exec sleep 30"#,
             )
             .arg("termctrl-launcher")
             .arg(env!("CARGO_BIN_EXE_termctrl"))
@@ -73,7 +73,7 @@ impl NamedSession {
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::from(
-                fs::File::create(self.runtime.join(format!("{operation}.stderr"))).unwrap(),
+                fs::File::create(self.runtime.join(format!("{generation}.stderr"))).unwrap(),
             ));
         unsafe {
             launcher.pre_exec(|| {
@@ -90,7 +90,7 @@ impl NamedSession {
             assert!(
                 launcher.try_wait().unwrap().is_none(),
                 "{operation} launcher exited early: {}",
-                fs::read_to_string(self.runtime.join(format!("{operation}.stderr")))
+                fs::read_to_string(self.runtime.join(format!("{generation}.stderr")))
                     .unwrap_or_default()
             );
             assert!(
@@ -104,7 +104,7 @@ impl NamedSession {
                 .unwrap(),
         );
         eprintln!(
-            "{operation}: launcher group {}, application/daemon {}",
+            "{operation}/{generation}: launcher group {}, application/daemon {}",
             self.launchers.last().unwrap().id(),
             fs::read_to_string(&pids).unwrap().trim()
         );
@@ -114,6 +114,7 @@ impl NamedSession {
     }
 
     fn assert_application_stopped(&self, operation: &str) {
+        // Keep the generation record for Drop: application exit does not prove daemon exit.
         let path = self.runtime.join(format!("{operation}.pids"));
         let pids = fs::read_to_string(&path).unwrap();
         let application = pids
@@ -135,7 +136,6 @@ impl NamedSession {
             std::io::Error::last_os_error().raw_os_error(),
             Some(libc::ESRCH)
         );
-        fs::remove_file(path).unwrap();
     }
 }
 
@@ -152,47 +152,131 @@ impl Drop for NamedSession {
             }
             let _ = launcher.wait();
         }
-        // Prefer normal shutdown so a live daemon reaps its application. This is bounded
-        // even on assertion failures; the PID fallback also covers a daemon killed by SIGHUP.
-        if self
-            .output(&["stop", "demo"])
-            .is_ok_and(|output| output.status.success())
-        {
-            let _ = fs::remove_dir_all(&self.runtime);
-            return;
-        }
-        if let Ok(entries) = fs::read_dir(&self.runtime) {
-            for entry in entries.flatten() {
-                if entry.path().extension().and_then(|value| value.to_str()) != Some("pids") {
-                    continue;
+        // Snapshot every generation before shutdown can remove any runtime files.
+        let mut records = Vec::new();
+        let mut cleaned = true;
+        match fs::read_dir(&self.runtime) {
+            Ok(entries) => {
+                for entry in entries {
+                    let Ok(entry) = entry else {
+                        cleaned = false;
+                        continue;
+                    };
+                    let path = entry.path();
+                    if path.extension().and_then(|value| value.to_str()) != Some("pids") {
+                        continue;
+                    }
+                    match fs::read_to_string(&path) {
+                        Ok(pids) => records.push((path, pids)),
+                        Err(_) => cleaned = false,
+                    }
                 }
-                if let Ok(pids) = fs::read_to_string(entry.path()) {
-                    for pid in pids
-                        .split_whitespace()
-                        .filter_map(|value| value.parse::<libc::pid_t>().ok())
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(_) => cleaned = false,
+        }
+        // A successful stop only accounts for the current generation, not failed predecessors.
+        let _ = self.output(&["stop", "demo"]);
+        let owns_pid =
+            |pid: libc::pid_t, path: &PathBuf, executable: &str| -> std::io::Result<bool> {
+                if pid <= 1 || pid == std::process::id() as libc::pid_t {
+                    return Ok(false);
+                }
+                if unsafe { libc::kill(pid, 0) } < 0 {
+                    let error = std::io::Error::last_os_error();
+                    return if error.raw_os_error() == Some(libc::ESRCH) {
+                        Ok(false)
+                    } else {
+                        Err(error)
+                    };
+                }
+                let output = Command::new("/bin/ps")
+                    .args(["-ww", "-p", &pid.to_string(), "-o", "uid=,command="])
+                    .output()?;
+                if !output.status.success() {
+                    return if unsafe { libc::kill(pid, 0) } < 0
+                        && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
                     {
-                        if pid > 1 && pid != std::process::id() as libc::pid_t {
-                            // The application execs sleep instead of spawning descendants.
-                            // Use individual PIDs: a broken daemon may share the runner's group.
-                            unsafe {
-                                libc::kill(pid, libc::SIGKILL);
+                        Ok(false)
+                    } else {
+                        Err(std::io::Error::other(
+                            "could not verify fixture process identity",
+                        ))
+                    };
+                }
+                let line = String::from_utf8_lossy(&output.stdout);
+                let Some((uid, command)) = line.trim().split_once(char::is_whitespace) else {
+                    return Err(std::io::Error::other("invalid fixture process identity"));
+                };
+                // The application blocks in a shell builtin, retaining its unique PID-file
+                // argument. Check it and the executable/UID rather than trusting a stale PID.
+                Ok(
+                    uid.parse::<libc::uid_t>().ok() == Some(unsafe { libc::geteuid() })
+                        && command.trim_start().starts_with(executable)
+                        && command.ends_with(&format!(" fixture {}", path.display())),
+                )
+            };
+        for (path, record) in &records {
+            let Ok(pids) = record
+                .split_whitespace()
+                .map(str::parse::<libc::pid_t>)
+                .collect::<Result<Vec<_>, _>>()
+            else {
+                cleaned = false;
+                continue;
+            };
+            if pids.len() != 2 {
+                cleaned = false;
+                continue;
+            }
+            for (pid, executable) in pids.into_iter().zip([
+                "/bin/sh -c ".to_owned(),
+                format!("{} __serve ", env!("CARGO_BIN_EXE_termctrl")),
+            ]) {
+                let deadline = Instant::now() + Duration::from_secs(2);
+                let mut signaled = false;
+                loop {
+                    match owns_pid(pid, path, &executable) {
+                        Ok(false) => break,
+                        Ok(true) if Instant::now() < deadline => {
+                            if !signaled {
+                                // Signal only a verified individual process, never its group.
+                                if unsafe { libc::kill(pid, libc::SIGKILL) } < 0
+                                    && std::io::Error::last_os_error().raw_os_error()
+                                        != Some(libc::ESRCH)
+                                {
+                                    cleaned = false;
+                                    break;
+                                }
+                                signaled = true;
                             }
-                            thread::sleep(Duration::from_millis(20));
+                            thread::sleep(Duration::from_millis(10));
+                        }
+                        _ => {
+                            cleaned = false;
+                            break;
                         }
                     }
                 }
             }
         }
-        let _ = fs::remove_dir_all(&self.runtime);
+        if cleaned {
+            let _ = fs::remove_dir_all(&self.runtime);
+        } else {
+            eprintln!(
+                "fixture cleanup could not be verified; retaining records at {}",
+                self.runtime.display()
+            );
+        }
     }
 }
 
 fn survives_launcher_hangup(restart: bool) {
     let operation = if restart { "restart" } else { "start" };
     let mut session = NamedSession::new(operation);
-    session.launch("start");
+    session.launch("start", "start");
     if restart {
-        session.launch("restart");
+        session.launch("restart", "restart");
     }
     let pids = fs::read_to_string(session.runtime.join(format!("{operation}.pids"))).unwrap();
     let daemon = pids
@@ -266,4 +350,69 @@ fn named_session_survives_launcher_process_group_hangup() {
 #[test]
 fn restarted_session_survives_launcher_process_group_hangup() {
     survives_launcher_hangup(true);
+}
+
+#[test]
+fn cleanup_stops_every_generation_after_a_failed_restart_assertion() {
+    // Preserve an independently reachable endpoint so even the failing regression
+    // run can stop the original daemon after the buggy destructor deletes its records.
+    let backup = NamedSession::new("cleanup-backup");
+    let mut unrelated = NamedSession::new("cleanup-unrelated");
+    unrelated.launch("start", "start");
+    let mut session = NamedSession::new("cleanup");
+    session.launch("start", "start");
+    let original = fs::read_to_string(session.runtime.join("start.pids")).unwrap();
+    fs::rename(
+        session.runtime.join("demo.sock"),
+        backup.runtime.join("demo.sock"),
+    )
+    .unwrap();
+    session.launch("start", "replacement");
+    let replacement = fs::read_to_string(session.runtime.join("replacement.pids")).unwrap();
+    // Simulate stale/reused PID records using another independently owned fixture,
+    // never a shared process or the test runner itself.
+    fs::write(
+        session.runtime.join("stale.pids"),
+        fs::read_to_string(unrelated.runtime.join("start.pids")).unwrap(),
+    )
+    .unwrap();
+    let runtime = session.runtime.clone();
+
+    let failure = std::panic::catch_unwind(move || session.assert_application_stopped("start"));
+    assert!(
+        failure.is_err(),
+        "the original generation must still be running at the assertion"
+    );
+    let pids: Vec<_> = original
+        .split_whitespace()
+        .chain(replacement.split_whitespace())
+        .map(|value| value.parse::<libc::pid_t>().unwrap())
+        .collect();
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let surviving = loop {
+        let surviving: Vec<_> = pids
+            .iter()
+            .copied()
+            .filter(|pid| unsafe { libc::kill(*pid, 0) } == 0)
+            .collect();
+        if surviving.is_empty() || Instant::now() >= deadline {
+            break surviving;
+        }
+        thread::sleep(Duration::from_millis(10));
+    };
+    eprintln!("failed-generation cleanup: surviving fixture PIDs {surviving:?}");
+    assert!(
+        surviving.is_empty(),
+        "cleanup left generation processes alive: {surviving:?}"
+    );
+    assert!(
+        !runtime.exists(),
+        "cleanup left its runtime directory behind"
+    );
+    let status: serde_json::Value = serde_json::from_slice(
+        &assert_success(unrelated.output(&["status", "demo", "--json"]).unwrap()).stdout,
+    )
+    .unwrap();
+    assert_eq!(status["state"], "running");
+    eprintln!("stale PID records: unrelated fixture generation remains running");
 }


### PR DESCRIPTION
## Why

Sending SIGHUP to the process group that launched `termctrl start` also kills the background session daemon. The application becomes unreachable even though named sessions are intended to remain available across CLI invocations. Restarted sessions have the same problem because both paths use `start_locked`.

## What Changes

| Operation | Before | After |
| --- | --- | --- |
| Start a named session, then send SIGHUP to its launcher group | `status` fails with connection refused | `status` remains running and `show` returns the application's screen |
| Restart a named session, then send SIGHUP to the new launcher group | The replacement daemon is also killed | The replacement session remains available; the prior application has exited |
| Explicitly stop the surviving session | Not reachable after the hangup | `stop` removes the socket and terminates the application |

Call `setsid` in the Unix background daemon's `pre_exec` hook, propagating failures through the existing spawn error. The daemon becomes its own session leader before exec.

The CLI regressions use an explicitly isolated launcher group, assert it is not the test runner's group, and signal only that owned group. They verify daemon session leadership, status, visible output, restart cleanup, and explicit stop. Cleanup retains every generation's PID record and verifies UID, executable, and the unique fixture argument before fallback signals to individual processes. A third regression deliberately fails the old-generation exit assertion, verifies both generations are cleaned up, and confirms stale PID records do not terminate an independently owned sentinel session.

## Scope

Related: #18. Extracts only its background-daemon detachment fix and regression intent; tape playback and pointer automation remain separate. Foreground `run`, cursor negotiation, Windows support, and the control protocol are unchanged.

Final review covers `4de9fec93aac920e60d355e5f6a8cfad54fba496..5f4f2e3ad4868421a7d92219bf4540c236980a17`, rebased onto `main` after #25 merged. The CPR files match that base; the diff contains only the background-daemon hook, integration tests, and Changeset.

Includes a patch Changeset for the fixed six-package npm group. No versions, lockfiles, tags, or published artifacts are changed.

## Verification

Local validation ran on macOS arm64, with Rust 1.95.0 and Zig 0.15.2. Both Linux CI runs passed before merge, including the new integration regressions.

```bash
export PATH="/opt/homebrew/opt/zig@0.15/bin:$PATH"
bun install --frozen-lockfile
cargo fmt --all -- --check
cargo test --locked --test daemon_detach -- --nocapture
cargo test --locked --all-targets
cargo clippy --locked --all-targets --all-features -- -D warnings
cargo build --locked --release
cargo test --locked --release --test daemon_detach -- --nocapture
bun run test:npm
bun run build:npm
bun run validate:npm
bun run changeset status --since origin/main
cargo package --locked --list
cargo package --locked
```

- Red: before the production fix, both CLI regressions failed with connection refused after launcher-group SIGHUP.
- Green: the final rebased full-suite retry passed 121 Rust tests, with one manual benchmark ignored. Clippy and formatting checks passed. Independent final focused checks passed all three integration tests in both debug and release profiles.
- Real PTY evidence: the release-built CLI survives the owned launcher-group hangup for both start and restart; status stays running, show returns `READY`, and stop removes the socket and application.
- Failed-generation cleanup: five debug and five release repeats of the cleanup regression left none of their 90 fixture PIDs or runtime directories behind. Independent final debug/release suite runs confirmed both generations were removed after the caught assertion failure, stale-record sentinel sessions remained running until their own teardown, and all 36 recorded fixture PIDs were absent afterward.
- npm: 12 client tests and 9 OpenTUI adapter tests passed; builds passed; packed client/native artifacts validated in clean Bun and Node/Vitest consumers on macOS arm64.
- Changesets reports exactly six patch releases, with no minor or major release.
- Crate packaging and verification passed. The repository's existing explicit package include list excludes the integration-test file from the published crate; it still runs in repository CI.
- Fixture processes and runtime directories were cleaned up.

The first full-suite run transiently failed `natural_parent_exit_terminates_pty_holding_descendants` at `src/session.rs:2297`. Its solo rerun, 20 focused repeats, and full-suite retry passed; an independent final solo rerun also passed. This test calls `Session::start` directly, not the named-session `start_locked` daemon-launch path, so it cannot reach the new `setsid` hook. `finish_exited_output` waits for PTY EOF rather than disappearance of the orphan descendant PID; the immediate `kill(pid, 0)` assertion can race orphan reaping. That is a plausible timing explanation, not a confirmed diagnosis of the transient failure.

An additional existing release check was run:

```bash
bun run --cwd packages/opentui release:check
```

It fails locally under Node 26.5.0/npm 11.17.0 because its `npm publish --dry-run` rejects the already-published version 1.1.0: `You cannot publish over the previously published versions: 1.1.0.` The release script and package version are unchanged in this PR. No publish was performed. This is separate from the passing build, test, packed-consumer, and crate checks above.
