### PR TITLE
fix(performance): remove control latency and repeated pointer rasterization

### DIFF
--- a/.changeset/responsive-terminal-control.md
+++ b/.changeset/responsive-terminal-control.md
@@ -2,6 +2,6 @@
 "@kitlangton/terminal-control": patch
 ---
 
-Wake named-session control requests as soon as they arrive instead of waiting for an idle polling sleep. Clarify immediate screen reads, readiness-driven demo workflows, and intentional capture/typing delays without changing stable-capture defaults.
+Wake named-session control requests as soon as they arrive instead of waiting for an idle polling sleep, and wake text-readiness checks on PTY output. Clarify immediate screen reads, readiness-driven demo workflows, and intentional capture/typing delays without changing stable-capture defaults.
 
 Reuse a bounded base raster during pointer video animation instead of repeating terminal text layout for every pointer position. Preserve frame pixels, recording timing, and screenshot behavior.

--- a/.changeset/responsive-terminal-control.md
+++ b/.changeset/responsive-terminal-control.md
@@ -3,3 +3,5 @@
 ---
 
 Wake named-session control requests as soon as they arrive instead of waiting for an idle polling sleep. Clarify immediate screen reads, readiness-driven demo workflows, and intentional capture/typing delays without changing stable-capture defaults.
+
+Reuse a bounded base raster during pointer video animation instead of repeating terminal text layout for every pointer position. Preserve frame pixels, recording timing, and screenshot behavior.

--- a/.changeset/responsive-terminal-control.md
+++ b/.changeset/responsive-terminal-control.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/terminal-control": patch
+---
+
+Wake named-session control requests as soon as they arrive instead of waiting for an idle polling sleep. Clarify immediate screen reads, readiness-driven demo workflows, and intentional capture/typing delays without changing stable-capture defaults.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,6 +16,11 @@ A named terminal application that remains available across waiting, input, resiz
 
 An embedded session owns the same live terminal lifecycle in-process; the named CLI session commands are an adapter for interacting with that lifecycle across invocations.
 
+Named `show` reads are immediate; explicit readiness waits end when their text appears. Quiet-time
+settling and input pacing are separate, intentional policies—not mandatory delays between actions.
+The TypeScript client's stable captures retain a quiet-period default for snapshot tests; demos
+can wait for readiness and explicitly capture immediately.
+
 ### Driver
 
 A versioned JSON Lines stdin/stdout adapter over embedded sessions for external agent tooling and the TypeScript test client. A driver process can manage multiple isolated sessions without exposing terminal process details to its client. Its capture response includes the reason capture completed so test clients can distinguish settled screen state from deadline fallback, and can optionally include ANSI or rendered SVG failure evidence.

--- a/README.md
+++ b/README.md
@@ -111,12 +111,16 @@ termctrl stop demo
 
 - `send` accepts `text:<value>`, named keys (`enter`, `escape`, arrows, `tab`, `shift-tab`, `backspace`, `delete`, `home`, `end`, `page-up`, `page-down`), and `ctrl-a` through `ctrl-z`. Pipe exact bytes with `--stdin`.
 - `mouse demo move 12 4` hovers at zero-based column 12, row 4; `mouse demo click 12 4` clicks. Use `down`, `move`, then `up` to drag; `--button right`, `--shift`, `--alt`, and `--ctrl` are supported. The app must enable mouse reporting (hover needs any-event tracking).
-- `wait` blocks until text is visible; use it instead of sleeping. It defaults to five seconds.
+- `show NAME` reads immediately; `wait` returns as soon as text is visible. Its five-second default is a maximum, not a fixed delay. Use it instead of sleeping.
 - `status` reports running/exited state, command, cwd, viewport, and recording path. `list` shows running sessions; use `--state`, `--command`, or `--cwd` to filter discovery, and `--all` to include every retained or unavailable entry.
 - `prune --dry-run` previews retained exited sessions and stale sockets; `prune` removes them without deleting recording artifacts.
 - `resize demo --cols 132 --rows 38` tests responsive layouts.
 - `restart demo` relaunches with the stored command, cwd, viewport, and recording settings.
 - An exited session keeps its final screen for `show` until stopped.
+
+For fast automation, batch a known `send` → `wait` → `show` transition in one shell call, or use
+MCP `interact` with `waitFor`. Leave typing unpaced unless the demo needs it; reserve PNG saves
+for visual checks and export video after the interactions.
 
 OpenTUI applications such as OpenCode need the opt-in host handshake:
 

--- a/docs/typescript-client.md
+++ b/docs/typescript-client.md
@@ -58,6 +58,19 @@ console.log(capture.reason, capture.text, capture.frame)
 
 ## Keyboard Input
 
+For readiness-driven demos rather than settled snapshot tests, wait for a literal marker and
+explicitly read the current screen without the default 250ms quiet period:
+
+```ts
+await session.keyboard.type("help\n")
+await session.screen.waitForText("Commands")
+const { text, frame } = await session.screen.capture({ settleMs: 0, deadlineMs: 0 })
+```
+
+Reuse that capture for both text and cells instead of making two requests. Keep the defaults when
+the whole screen must settle; a readiness marker does not guarantee that every animation stopped.
+Input is unpaced by default. `paceMs` is for intentional typing animation, not synchronization.
+
 Keyboard presses are typed as the sequences Terminal Control encodes exactly, such as `"Enter"`, `"ArrowDown"`, or `"Control+C"`. Use `session.keyboard.write(bytes)` when a test deliberately needs exact terminal bytes outside that supported key set.
 
 ## Mouse Input

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build:npm": "bun run --cwd packages/test build && bun run --cwd packages/opentui build",
     "test:npm": "bun run --cwd packages/test typecheck && bun run --cwd packages/test test && bun run --cwd packages/opentui typecheck && bun run --cwd packages/opentui test",
+    "bench:performance": "bun scripts/bench-performance.ts",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "validate:npm": "node scripts/validate-npm-packages.mjs",

--- a/perf/agent-rendering.md
+++ b/perf/agent-rendering.md
@@ -9,8 +9,8 @@ bun scripts/bench-performance.ts --mode all --runs 7 --out-dir /path/to/results
 ```
 
 The benchmark performs one warmup and seven measured runs per case; JSON Lines report medians,
-median absolute deviations, and raw samples. Use `--binary` to compare saved builds, and `--mode
-agent` or `--mode video` for individual experiments. Fixtures and isolated named sessions are
+median absolute deviations, and raw samples. Use `--binary` to compare saved builds, and
+`--mode agent` or `--mode video` for individual experiments. Fixtures and isolated named sessions are
 cleaned up; only synthetic videos remain when `--out-dir` is specified. `ffmpeg` is required.
 
 ## What is measured
@@ -31,9 +31,9 @@ part of these metrics. Results are machine/workload-specific, not performance gu
 
 1. **Named daemon wakeup:** replace the unconditional 10ms idle sleep with `poll` on the listener.
    Requests wake immediately; the same maximum idle interval still pumps PTY/semantic output.
-  Baseline: CLI show 14.29ms, CLI interaction 37.88ms (local macOS arm64).
-  The persistent-driver interaction is already 5.88ms; its worker's `recv_timeout` wakes for
-  requests, unlike the daemon's unconditional sleep. Do not replace that with busy polling.
+   Baseline: CLI show 14.29ms, CLI interaction 37.88ms (local macOS arm64).
+   The persistent-driver interaction is already 5.88ms; its worker's `recv_timeout` wakes for
+   requests, unlike the daemon's unconditional sleep. Do not replace that with busy polling.
    Retained: 15-run control/candidate comparison was 13.75 → 5.40ms for show and
    37.48 → 10.90ms for interaction (61% / 71% lower). All 23 session tests and clippy passed.
    The first 7-run candidate gave 4.59ms / 10.56ms; the result exceeds observed scheduling noise.
@@ -72,5 +72,8 @@ part of these metrics. Results are machine/workload-specific, not performance gu
 - Do not remove mouse capability checks or legacy daemon compatibility for one fewer round trip.
 - Inspect long-transcript screen reads separately: the named protocol still carries retained ANSI
   even for text-only consumers. A selective response needs an additive compatibility design.
+  A separate seven-run probe displaying only `READY` measured 3.92ms with no backlog versus
+  19.49ms after 1MiB of output had been cleared from the screen. This overhead remains; the current
+  changes do not claim to make screen-read cost independent of transcript size.
 - PNG intermediate files and ffmpeg encoding may dominate after raster reuse. Measure before
   changing the export pipeline or trading disk traffic for raw pixel pipe bandwidth.

--- a/perf/agent-rendering.md
+++ b/perf/agent-rendering.md
@@ -18,6 +18,8 @@ cleaned up; only synthetic videos remain when `--out-dir` is specified. `ffmpeg`
 - CLI `show` on a populated 80×24 real PTY.
 - CLI `send` → literal readiness `wait` → `show`, asserting the newly acknowledged input.
 - Persistent TypeScript driver input → literal readiness → immediate capture.
+- A second driver fixture adds a known 1ms application response time so the readiness wait is
+  already in flight when output arrives; this isolates unnecessary polling latency.
 - Two-second 80×24, 60fps, 2× video exports: plain, moving pointer, pointer with footer.
   Rendering-stage times use the existing stderr progress boundaries; total includes ffmpeg.
 
@@ -48,6 +50,19 @@ part of these metrics. Results are machine/workload-specific, not performance gu
    All 121 decoded frames of each of the three exports matched the baseline exactly. A 45-case
    test compares the old full SVG to layered rendering with fades, travel, compression, clipping,
    Unicode/styles, cursor, footer, geometry changes and 1×/1.5×/2× pixel ratios.
+   The 339-frame real PTY demo with speed edits, holds, captions, and resize also matched exactly.
+
+3. **Text-readiness wakeup:** wait on the existing output channel (up to the remaining deadline,
+   capped at 10ms for callbacks/semantics) instead of sleeping past new output. Retained: the
+   reactive fixture's send + readiness wait fell from 11.70ms to 1.28ms over 15 runs. Ordinary
+   driver interaction remained around 6ms, but the 17–19ms polling outliers disappeared in this
+   sample. Stable captures, quiet waits, and process-exit waits retain their existing semantics.
+
+   **Rejected broader variant:** applying output-triggered wakeups to all wait loops also changed
+   EOF observation in the exit path and hit `natural_parent_exit_terminates_pty_holding_descendants`.
+   That broader change was removed, not masked with a retry or weakened assertion. Exit/quiet/capture
+   loops and all cleanup code remain unchanged. Investigate exit/reaping timing separately before
+   attempting that optimization again; the exact cause was not established in this pass.
 
 ## Guardrails / next candidates
 

--- a/perf/agent-rendering.md
+++ b/perf/agent-rendering.md
@@ -1,0 +1,55 @@
+# Agent latency and video rendering
+
+Goal: shorten verified input → screen-read cycles and video exports without weakening readiness,
+changing input timing, or changing rendered pixels. Use a release binary, not debug-build timings.
+
+```sh
+PATH=/opt/homebrew/opt/zig@0.15/bin:$PATH cargo build --release
+bun scripts/bench-performance.ts --mode all --runs 7 --out-dir /path/to/results
+```
+
+The benchmark performs one warmup and seven measured runs per case; JSON Lines report medians,
+median absolute deviations, and raw samples. Use `--binary` to compare saved builds, and `--mode
+agent` or `--mode video` for individual experiments. Fixtures and isolated named sessions are
+cleaned up; only synthetic videos remain when `--out-dir` is specified. `ffmpeg` is required.
+
+## What is measured
+
+- CLI `show` on a populated 80×24 real PTY.
+- CLI `send` → literal readiness `wait` → `show`, asserting the newly acknowledged input.
+- Persistent TypeScript driver input → literal readiness → immediate capture.
+- Two-second 80×24, 60fps, 2× video exports: plain, moving pointer, pointer with footer.
+  Rendering-stage times use the existing stderr progress boundaries; total includes ffmpeg.
+
+No arbitrary sleeps, changed default settling, or reduced frame rate are used to improve scores.
+Application startup, external model/tool-call latency, and network package installation are not
+part of these metrics. Results are machine/workload-specific, not performance guarantees.
+
+## Experiments
+
+1. **Named daemon wakeup:** replace the unconditional 10ms idle sleep with `poll` on the listener.
+   Requests wake immediately; the same maximum idle interval still pumps PTY/semantic output.
+  Baseline: CLI show 14.29ms, CLI interaction 37.88ms (local macOS arm64).
+  The persistent-driver interaction is already 5.88ms; its worker's `recv_timeout` wakes for
+  requests, unlike the daemon's unconditional sleep. Do not replace that with busy polling.
+   Retained: 15-run control/candidate comparison was 13.75 → 5.40ms for show and
+   37.48 → 10.90ms for interaction (61% / 71% lower). All 23 session tests and clippy passed.
+   The first 7-run candidate gave 4.59ms / 10.56ms; the result exceeds observed scheduling noise.
+
+2. **Repeated terminal rasterization:** a changed pointer currently invalidates the whole rendered
+   screen, repeating SVG text layout and rasterization. Try one bounded cached base raster, painting
+   the pointer over a copy. Preserve the existing full-image cache and exact output pixels.
+   Baseline: 21.27s total / 20.39s rendering with pointer; 19.85s / 19.47s with pointer and footer.
+   Plain export: 0.88s total / 0.37s rendering. A two-second CPU sample during active rendering
+   placed most samples in SVG/text conversion. Pending candidate measurement and pixel comparison.
+
+## Guardrails / next candidates
+
+- Keep explicit quiet periods and input pacing. The TypeScript stable-capture defaults are a test
+  contract, not an accidental sleep; readiness-driven demos can explicitly capture immediately.
+- Keep Ghostty state confined to the session thread.
+- Do not remove mouse capability checks or legacy daemon compatibility for one fewer round trip.
+- Inspect long-transcript screen reads separately: the named protocol still carries retained ANSI
+  even for text-only consumers. A selective response needs an additive compatibility design.
+- PNG intermediate files and ffmpeg encoding may dominate after raster reuse. Measure before
+  changing the export pipeline or trading disk traffic for raw pixel pipe bandwidth.

--- a/perf/agent-rendering.md
+++ b/perf/agent-rendering.md
@@ -41,7 +41,13 @@ part of these metrics. Results are machine/workload-specific, not performance gu
    the pointer over a copy. Preserve the existing full-image cache and exact output pixels.
    Baseline: 21.27s total / 20.39s rendering with pointer; 19.85s / 19.47s with pointer and footer.
    Plain export: 0.88s total / 0.37s rendering. A two-second CPU sample during active rendering
-   placed most samples in SVG/text conversion. Pending candidate measurement and pixel comparison.
+   placed most samples in SVG/text conversion.
+   Retained: pointer export fell to 2.80s total / 2.33s rendering (7.6× / 8.8× faster);
+   pointer + footer to 3.08s / 2.68s (6.5× / 7.3×). Plain export was 0.91s versus 0.88s,
+   within the baseline's 52ms median absolute deviation. Only one base raster is retained.
+   All 121 decoded frames of each of the three exports matched the baseline exactly. A 45-case
+   test compares the old full SVG to layered rendering with fades, travel, compression, clipping,
+   Unicode/styles, cursor, footer, geometry changes and 1×/1.5×/2× pixel ratios.
 
 ## Guardrails / next candidates
 

--- a/scripts/bench-performance.ts
+++ b/scripts/bench-performance.ts
@@ -17,7 +17,10 @@ if (process.argv.includes("--fixture")) {
     for (let end; (end = pending.indexOf("\n")) >= 0;) {
       const value = pending.slice(0, end)
       pending = pending.slice(end + 1)
-      process.stdout.write(`\x1b[24;1H\x1b[2KACK:${value}`)
+      const acknowledge = () => process.stdout.write(`\x1b[24;1H\x1b[2KACK:${value}`)
+      // A known 1ms application response exposes latency in a wait already in flight.
+      if (process.argv.includes("--async-output")) setTimeout(acknowledge, 1)
+      else acknowledge()
     }
   })
   process.stdout.write(screen)
@@ -86,6 +89,14 @@ if (process.argv.includes("--fixture")) {
         await session.screen.waitForText(`ACK:${i}`)
         const snapshot = await session.screen.capture({ settleMs: 0, deadlineMs: 0 })
         if (!snapshot.text.includes(`ACK:${i}`)) throw new Error("stale screen")
+        return { ms: performance.now() - start }
+      })
+      await using reactive = await driver.launch({ command: [...fixture, "--async-output"] })
+      await reactive.screen.waitForText("READY")
+      await measure("driver_reactive_wait", async (i) => {
+        const start = performance.now()
+        await reactive.keyboard.type(`${i}\n`)
+        await reactive.screen.waitForText(`ACK:${i}`)
         return { ms: performance.now() - start }
       })
     }

--- a/scripts/bench-performance.ts
+++ b/scripts/bench-performance.ts
@@ -1,0 +1,125 @@
+// Release-binary, real-PTY benchmarks. No arbitrary sleep/readiness guesses.
+import { mkdtemp, mkdir, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { parseArgs } from "node:util"
+import { TerminalControl } from "../packages/test/src/index"
+
+const screen = "\x1b[?25l\x1b[2J" + Array.from({ length: 22 }, (_, row) =>
+  `\x1b[${row + 1};1H\x1b[38;5;${110 + row}m` + `Row ${row}: terminal rendering benchmark — 界 ━ `.padEnd(76, ".")
+).join("") + "\x1b[0m\x1b[24;1HREADY"
+
+if (process.argv.includes("--fixture")) {
+  process.stdin.setRawMode(true)
+  let pending = ""
+  process.stdin.on("data", (data) => {
+    pending += data.toString().replaceAll("\r", "\n")
+    for (let end; (end = pending.indexOf("\n")) >= 0;) {
+      const value = pending.slice(0, end)
+      pending = pending.slice(end + 1)
+      process.stdout.write(`\x1b[24;1H\x1b[2KACK:${value}`)
+    }
+  })
+  process.stdout.write(screen)
+} else {
+  const { values } = parseArgs({ options: {
+    binary: { type: "string", default: "target/release/termctrl" },
+    mode: { type: "string", default: "all" },
+    runs: { type: "string", default: "7" },
+    "out-dir": { type: "string" },
+  } })
+  const runs = Number(values.runs)
+  if (!Number.isInteger(runs) || runs < 1) throw new Error("runs must be a positive integer")
+  if (!["all", "agent", "video"].includes(values.mode!)) throw new Error("mode must be all, agent, or video")
+  const binary = resolve(values.binary!)
+  const temp = await mkdtemp(join(tmpdir(), "tp-"))
+  const output = values["out-dir"] ? resolve(values["out-dir"]) : temp
+  await mkdir(output, { recursive: true })
+  const env = { ...process.env, TERMCTRL_RUNTIME_DIR: temp }
+  const fixture = [process.execPath, import.meta.path, "--fixture"] as const
+  const median = (numbers: number[]) => [...numbers].sort((a, b) => a - b)[Math.floor(numbers.length / 2)]!
+  async function measure(name: string, run: (iteration: number) => Promise<Record<string, number>>) {
+    const results = []
+    for (let i = -1; i < runs; i++) {
+      const result = await run(i)
+      if (i >= 0) results.push(result)
+    }
+    for (const metric of Object.keys(results[0]!)) {
+      const samples = results.map((result) => result[metric]!)
+      const value = median(samples)
+      console.log(JSON.stringify({ name: `${name}.${metric}`, median: value,
+        mad: median(samples.map((sample) => Math.abs(sample - value))), samples }))
+    }
+  }
+  async function cli(args: string[]) {
+    const process = Bun.spawn([binary, ...args], { env, stdout: "pipe", stderr: "pipe" })
+    const [text, error, code] = await Promise.all([
+      new Response(process.stdout).text(), new Response(process.stderr).text(), process.exited,
+    ])
+    if (code !== 0) throw new Error(error)
+    return text
+  }
+  try {
+    if (values.mode !== "video") {
+      await cli(["start", "p", "--", ...fixture])
+      try {
+        await cli(["wait", "p", "READY"])
+        await measure("cli_show", async () => {
+          const start = performance.now()
+          if (!(await cli(["show", "p"])).includes("READY")) throw new Error("missing ready screen")
+          return { ms: performance.now() - start }
+        })
+        await measure("cli_interact", async (i) => {
+          const start = performance.now()
+          await cli(["send", "p", `text:${i}`, "enter"])
+          await cli(["wait", "p", `ACK:${i}`])
+          if (!(await cli(["show", "p"])).includes(`ACK:${i}`)) throw new Error("stale screen")
+          return { ms: performance.now() - start }
+        })
+      } finally { await cli(["stop", "p"]) }
+      await using driver = await TerminalControl.make({ binaryPath: binary })
+      await using session = await driver.launch({ command: fixture })
+      await session.screen.waitForText("READY")
+      await measure("driver_interact", async (i) => {
+        const start = performance.now()
+        await session.keyboard.type(`${i}\n`)
+        await session.screen.waitForText(`ACK:${i}`)
+        const snapshot = await session.screen.capture({ settleMs: 0, deadlineMs: 0 })
+        if (!snapshot.text.includes(`ACK:${i}`)) throw new Error("stale screen")
+        return { ms: performance.now() - start }
+      })
+    }
+    if (values.mode !== "agent") {
+      const bytes = (text: string) => Array.from(new TextEncoder().encode(text))
+      const entries: object[] = [
+        { type: "header", version: 2, cols: 80, rows: 24, cell_width: 9, cell_height: 18 },
+        { type: "output", at_ms: 0, bytes: bytes(screen) },
+      ]
+      for (let i = 1; i <= 10; i++) entries.push({ type: "mouse", at_ms: i * 200,
+        event: { action: i % 3 === 0 ? "click" : "move", x: i * 6, y: i % 18 }, bytes: [] })
+      entries.push({ type: "output", at_ms: 2000, bytes: bytes("\x1b[24;1HDONE") })
+      const recording = join(temp, "fixture.termctrl")
+      await Bun.write(recording, entries.map((entry) => JSON.stringify(entry)).join("\n") + "\n")
+      for (const [name, flags] of [
+        ["video_plain", []], ["video_pointer", ["--pointer-overlay"]],
+        ["video_pointer_footer", ["--pointer-overlay", "--footer"]],
+      ] as const) {
+        await measure(name, async () => {
+          const start = performance.now()
+          let renderStart = start, encodeStart = start
+          const child = Bun.spawn([binary, "video", recording, "--fps", "60", "--tail-ms", "0",
+            "--hide-cursor", ...flags, "--out", join(output, `${name}.mp4`)], { env, stdout: "ignore", stderr: "pipe" })
+          let error = ""
+          for await (const chunk of child.stderr) {
+            const line = new TextDecoder().decode(chunk)
+            error += line
+            if (line.includes("Rendering ")) renderStart = performance.now()
+            if (line.includes("Encoding ")) encodeStart = performance.now()
+          }
+          if (await child.exited !== 0) throw new Error(error)
+          return { total_ms: performance.now() - start, render_ms: encodeStart - renderStart }
+        })
+      }
+    }
+  } finally { await rm(temp, { recursive: true, force: true }) }
+}

--- a/skills/terminal-control/SKILL.md
+++ b/skills/terminal-control/SKILL.md
@@ -52,6 +52,18 @@ Do not treat logs as the visible state of an alternate-screen TUI.
 Named-session reads return immediately by default. Add settling only when intentionally waiting for
 quiet output. `wait` defaults to five seconds; set `--timeout` only when choosing another limit.
 
+For fast demos, keep the session alive, omit `--pace-ms` unless slow typing is intentional, and
+combine a known transition into one shell call:
+
+```bash
+termctrl send app text:help enter && termctrl wait app "Commands" && termctrl show app
+```
+
+The wait ends as soon as the text appears; its timeout is a maximum, not a fixed delay. Do not
+insert sleeps between these commands. Inspect text during interaction, save PNGs only for visual
+checks or requested evidence, and export video after driving the app. With MCP, prefer `interact`
+with `waitFor` to combine keyboard input, readiness, and a screen read in one tool call.
+
 ## Drive Input Precisely
 
 Send plain text with `text:<value>` and named keys as separate input atoms:

--- a/src/main.rs
+++ b/src/main.rs
@@ -301,10 +301,10 @@ struct SourceArgs {
     /// Color environment policy for a command source (default: auto for PTY, always for pipe).
     #[arg(long, value_enum)]
     color: Option<ColorMode>,
-    /// Capture after this many milliseconds without output (default: 250).
+    /// Capture after this many milliseconds without output (command default: 250; named session: 0).
     #[arg(long)]
     settle_ms: Option<u64>,
-    /// Capture or return after this deadline even if output continues (default: 5000).
+    /// Capture or return after this deadline even if output continues (command default: 5000; named session: 0).
     #[arg(long)]
     deadline_ms: Option<u64>,
     /// Wait this long before allowing the initial screen to settle.

--- a/src/recording.rs
+++ b/src/recording.rs
@@ -789,7 +789,6 @@ fn render_video_frames(
             _ => None,
         })
         .collect::<Vec<_>>();
-    let renderer = render::PngRenderer::new();
     let render_options = render::Options {
         cell_width: f32::from(options.cell_width.unwrap_or(recording.cell_width)),
         cell_height: f32::from(options.cell_height.unwrap_or(recording.cell_height)),
@@ -798,6 +797,7 @@ fn render_video_frames(
         font_family: options.font_family.clone(),
         show_cursor: !options.hide_cursor,
     };
+    let mut renderer = VideoRenderer::new(render_options.clone(), options.pixel_ratio);
     for (index, state) in samples.iter().enumerate() {
         let path = temp.join(format!("frame-{index:06}.png"));
         let elapsed_ms = (u128::from(index as u64) * 1000 / u128::from(options.fps)) as u64;
@@ -816,14 +816,7 @@ fn render_video_frames(
         } else {
             base_keys[*state].clone()
         };
-        render_or_link(
-            &renderer,
-            &mut rendered,
-            (key, overlay),
-            &path,
-            &render_options,
-            options.pixel_ratio,
-        )?;
+        render_or_link(&mut renderer, &mut rendered, (key, overlay), &path)?;
     }
     eprintln!("Rendered {} unique screens.", rendered.len());
     eprintln!("Encoding {}...", options.out.display());
@@ -842,23 +835,52 @@ fn render_video_frames(
     Ok(())
 }
 
+struct VideoRenderer {
+    png: render::PngRenderer,
+    base: Option<(Rc<Frame>, render::Rasterized)>,
+    options: render::Options,
+    pixel_ratio: f32,
+}
+
+impl VideoRenderer {
+    fn new(options: render::Options, pixel_ratio: f32) -> Self {
+        Self {
+            png: render::PngRenderer::new(),
+            base: None,
+            options,
+            pixel_ratio,
+        }
+    }
+
+    fn render(&mut self, frame: &Rc<Frame>, overlay: &str, path: &Path) -> Result<()> {
+        // Options are constant for one export. Retain only the latest base raster, not one
+        // full-resolution bitmap per terminal state. Pointer-only changes reuse its pixels.
+        if self
+            .base
+            .as_ref()
+            .is_none_or(|(previous, _)| previous != frame)
+        {
+            let raster = self
+                .png
+                .rasterize(&render::svg(frame, &self.options), self.pixel_ratio)?;
+            self.base = Some((Rc::clone(frame), raster));
+        }
+        self.png
+            .render_overlay(&self.base.as_ref().unwrap().1, overlay, path)
+    }
+}
+
 fn render_or_link(
-    renderer: &render::PngRenderer,
+    renderer: &mut VideoRenderer,
     rendered: &mut HashMap<(Rc<Frame>, String), PathBuf>,
     key: (Rc<Frame>, String),
     path: &Path,
-    options: &render::Options,
-    pixel_ratio: f32,
 ) -> Result<()> {
     if let Some(existing) = rendered.get(&key) {
         fs::hard_link(existing, path).or_else(|_| fs::copy(existing, path).map(|_| ()))?;
         return Ok(());
     }
-    let mut svg = render::svg(&key.0, options);
-    svg.truncate(svg.len() - "</svg>".len());
-    svg.push_str(&key.1);
-    svg.push_str("</svg>");
-    renderer.render(&svg, path, pixel_ratio)?;
+    renderer.render(&key.0, &key.1, path)?;
     rendered.insert(key, path.to_path_buf());
     Ok(())
 }
@@ -1481,8 +1503,8 @@ mod tests {
         let directory =
             std::env::temp_dir().join(format!("termctrl-pointer-cache-{}", std::process::id()));
         fs::create_dir_all(&directory).unwrap();
-        let renderer = render::PngRenderer::new();
         let options = render::Options::default();
+        let mut renderer = VideoRenderer::new(options.clone(), 1.0);
         let mut rendered = HashMap::new();
         let base = Rc::new(frame("ready"));
         let pointer = pointer::Track::new(
@@ -1495,27 +1517,23 @@ mod tests {
         );
         for (index, at_ms) in [800.0, 1050.0, 1100.0, 800.0].into_iter().enumerate() {
             render_or_link(
-                &renderer,
+                &mut renderer,
                 &mut rendered,
                 (
                     Rc::clone(&base),
                     pointer.svg(at_ms, u64::MAX, 40, 1, &options),
                 ),
                 &directory.join(format!("{index}.png")),
-                &options,
-                1.0,
             )
             .unwrap();
         }
         assert_eq!(rendered.len(), 3);
         assert!(rendered.keys().all(|(frame, _)| Rc::ptr_eq(frame, &base)));
         render_or_link(
-            &renderer,
+            &mut renderer,
             &mut rendered,
             (Rc::new(frame("ready")), String::new()),
             &directory.join("same-content.png"),
-            &options,
-            1.0,
         )
         .unwrap();
         assert_eq!(rendered.len(), 3);
@@ -1566,6 +1584,76 @@ mod tests {
                 .all(|frame| (frame.cols, frame.rows) == (4, 2))
         );
         assert_eq!(frames.last().unwrap().text(), "a");
+    }
+
+    #[test]
+    fn layered_video_rendering_matches_full_svg_pixels() {
+        use crate::mouse::{Action, MouseEvent};
+        let directory = std::env::temp_dir().join(format!("tc-layers-{}", std::process::id()));
+        fs::create_dir_all(&directory).unwrap();
+        let styled = crate::shot::from_ansi(
+            "\x1b[41m背景\x1b[0m\x1b[1;3;4mA&<\x1b[0m\r\n━⠋\x1b[2m faded\x1b[0m\r\n\x1b[8mhidden"
+                .as_bytes()
+                .to_vec(),
+            5,
+            24,
+            4096,
+        )
+        .unwrap()
+        .frame;
+        let mut resized = styled.clone();
+        resized.cols = 30;
+        resized.rows = 7;
+        let frames = [
+            styled.clone(),
+            with_footer(styled, Some("caption & text"), 1234),
+            resized,
+        ];
+        let pointer = pointer::Track::new(
+            &[
+                Entry::Mouse {
+                    at_ms: 200,
+                    event: MouseEvent::new(Action::Move, 0, 0),
+                    bytes: vec![],
+                },
+                Entry::Mouse {
+                    at_ms: 600,
+                    event: MouseEvent::new(Action::Click, 23, 4),
+                    bytes: vec![],
+                },
+            ],
+            PointerOptions::default(),
+        );
+        let reference = render::PngRenderer::new();
+        for ratio in [1.0, 1.5, 2.0] {
+            let options = render::Options {
+                padding: 0.5,
+                cell_width: 9.25,
+                cell_height: 18.5,
+                ..render::Options::default()
+            };
+            let mut renderer = VideoRenderer::new(options.clone(), ratio);
+            for (index, frame) in frames.iter().enumerate() {
+                let frame = Rc::new(frame.clone());
+                for at in [0.0, 150.0, 490.0, 650.0, 1300.0] {
+                    let overlay = pointer.svg(at, u64::MAX, frame.cols, frame.rows, &options);
+                    let mut svg = render::svg(&frame, &options);
+                    svg.truncate(svg.len() - "</svg>".len());
+                    svg.push_str(&overlay);
+                    svg.push_str("</svg>");
+                    let expected = directory.join("full.png");
+                    let actual = directory.join("layered.png");
+                    reference.render(&svg, &expected, ratio).unwrap();
+                    renderer.render(&frame, &overlay, &actual).unwrap();
+                    assert!(
+                        fs::read(&actual).unwrap() == fs::read(&expected).unwrap(),
+                        "different pixels at ratio {ratio}, frame {index}, time {at}"
+                    );
+                    assert!(Rc::ptr_eq(&renderer.base.as_ref().unwrap().0, &frame));
+                }
+            }
+        }
+        fs::remove_dir_all(directory).unwrap();
     }
 
     #[test]

--- a/src/render.rs
+++ b/src/render.rs
@@ -106,6 +106,13 @@ pub struct PngRenderer {
     options: resvg::usvg::Options<'static>,
 }
 
+/// A bounded video base layer; dimensions retain the SVG coordinate space at fractional scales.
+pub(crate) struct Rasterized {
+    pixmap: resvg::tiny_skia::Pixmap,
+    size: resvg::usvg::Size,
+    pixel_ratio: f32,
+}
+
 impl PngRenderer {
     pub fn new() -> Self {
         let mut options = resvg::usvg::Options::default();
@@ -114,6 +121,13 @@ impl PngRenderer {
     }
 
     pub fn render(&self, svg: &str, path: &Path, pixel_ratio: f32) -> Result<()> {
+        self.rasterize(svg, pixel_ratio)?
+            .pixmap
+            .save_png(path)
+            .context("write PNG artifact")
+    }
+
+    pub(crate) fn rasterize(&self, svg: &str, pixel_ratio: f32) -> Result<Rasterized> {
         if !pixel_ratio.is_finite() || pixel_ratio <= 0.0 {
             anyhow::bail!("PNG pixel ratio must be finite and greater than zero");
         }
@@ -140,8 +154,36 @@ impl PngRenderer {
             resvg::tiny_skia::Transform::from_scale(pixel_ratio, pixel_ratio),
             &mut pixmap.as_mut(),
         );
-        pixmap.save_png(path).context("write PNG artifact")?;
-        Ok(())
+        Ok(Rasterized {
+            pixmap,
+            size: tree.size(),
+            pixel_ratio,
+        })
+    }
+
+    pub(crate) fn render_overlay(
+        &self,
+        base: &Rasterized,
+        overlay: &str,
+        path: &Path,
+    ) -> Result<()> {
+        if overlay.is_empty() {
+            return base.pixmap.save_png(path).context("write PNG artifact");
+        }
+        let mut pixmap = base.pixmap.clone();
+        let svg = format!(
+            r#"<svg xmlns="http://www.w3.org/2000/svg" width="{}" height="{}">{overlay}</svg>"#,
+            base.size.width(),
+            base.size.height()
+        );
+        let tree = resvg::usvg::Tree::from_data(svg.as_bytes(), &self.options)
+            .context("parse rendered SVG")?;
+        resvg::render(
+            &tree,
+            resvg::tiny_skia::Transform::from_scale(base.pixel_ratio, base.pixel_ratio),
+            &mut pixmap.as_mut(),
+        );
+        pixmap.save_png(path).context("write PNG artifact")
     }
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -1574,11 +1574,28 @@ mod implementation {
                     }
                 }
                 Err(error) if error.kind() == ErrorKind::WouldBlock => {
-                    thread::sleep(Duration::from_millis(10));
+                    wait_for_request(listener)?;
                 }
                 Err(error) => return Err(error).context("accept session request"),
             }
         }
+    }
+
+    fn wait_for_request(listener: &UnixListener) -> Result<()> {
+        let mut descriptor = libc::pollfd {
+            fd: listener.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // Wake immediately for control requests, but still pump output/semantics every 10ms.
+        let result = unsafe { libc::poll(&mut descriptor, 1, 10) };
+        if result < 0 {
+            let error = std::io::Error::last_os_error();
+            if error.kind() != ErrorKind::Interrupted {
+                return Err(error).context("wait for session request");
+            }
+        }
+        Ok(())
     }
 
     fn handle(
@@ -1709,6 +1726,25 @@ mod implementation {
             drop(held);
             assert!(StartLock::acquire(&path).is_ok());
             let _ = fs::remove_file(path);
+        }
+
+        #[test]
+        fn control_readiness_preserves_requests_and_times_out_for_output_pumping() {
+            let socket = std::env::temp_dir().join(format!("tc-poll-{}.sock", std::process::id()));
+            let listener = bind_listener(&socket).unwrap();
+            // An idle timeout must allow the daemon to return to pumping output.
+            wait_for_request(&listener).unwrap();
+            assert_eq!(listener.accept().unwrap_err().kind(), ErrorKind::WouldBlock);
+            let mut client = UnixStream::connect(&socket).unwrap();
+            client.write_all(b"request").unwrap();
+            client.shutdown(std::net::Shutdown::Write).unwrap();
+            wait_for_request(&listener).unwrap();
+            let (mut peer, _) = listener.accept().unwrap();
+            let mut bytes = Vec::new();
+            peer.read_to_end(&mut bytes).unwrap();
+            assert_eq!(bytes, b"request");
+            drop(listener);
+            fs::remove_file(socket).unwrap();
         }
 
         #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::sync::mpsc::{self, Receiver, TryRecvError};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, TryRecvError};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -451,7 +451,7 @@ impl Session {
             if Instant::now() >= deadline {
                 bail!("timed out waiting for visible terminal text {text:?}");
             }
-            thread::sleep(Duration::from_millis(10));
+            self.wait_for_output(deadline)?;
         }
     }
 
@@ -652,6 +652,25 @@ impl Session {
             if !self.consume_one()? {
                 break;
             }
+        }
+        Ok(())
+    }
+
+    fn wait_for_output(&mut self, deadline: Instant) -> Result<()> {
+        // PTY output wakes readiness checks immediately. Bound the wait so process exit,
+        // semantic providers, and foreground input callbacks are still serviced regularly.
+        let timeout = deadline
+            .saturating_duration_since(Instant::now())
+            .min(Duration::from_millis(10));
+        if self.output_closed {
+            // A disconnected channel returns immediately; do not spin while awaiting process exit.
+            thread::sleep(timeout);
+            return Ok(());
+        }
+        match self.receive.recv_timeout(timeout) {
+            Ok(Some(output)) => self.apply_output(output)?,
+            Ok(None) | Err(RecvTimeoutError::Disconnected) => self.output_closed = true,
+            Err(RecvTimeoutError::Timeout) => {}
         }
         Ok(())
     }
@@ -1855,6 +1874,77 @@ mod implementation {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn text_readiness_wait_preserves_exit_and_timeout_errors() {
+        let mut exited = super::Session::start(
+            &["sh".into(), "-c".into(), "printf final".into()],
+            None,
+            None,
+            &crate::shot::Options::default(),
+        )
+        .unwrap();
+        let error = exited
+            .wait_for_text("never", std::time::Duration::from_secs(2))
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("session ended before visible terminal included")
+        );
+        assert_eq!(exited.terminal.text().unwrap(), "final");
+        let mut running = super::Session::start(
+            &["sh".into(), "-c".into(), "read line".into()],
+            None,
+            None,
+            &crate::shot::Options::default(),
+        )
+        .unwrap();
+        assert!(
+            running
+                .wait_for_text("never", std::time::Duration::ZERO)
+                .unwrap_err()
+                .to_string()
+                .contains("timed out waiting")
+        );
+    }
+
+    #[test]
+    fn output_wait_applies_bytes_and_preserves_timeout_and_eof_state() {
+        let mut session = super::Session::start(
+            &["sh".into(), "-c".into(), "read line".into()],
+            None,
+            None,
+            &crate::shot::Options::default(),
+        )
+        .unwrap();
+        let (send, receive) = std::sync::mpsc::channel();
+        session.receive = receive;
+        session.wait_for_output(std::time::Instant::now()).unwrap();
+        assert!(!session.output_closed);
+        send.send(Some(super::Output {
+            at_ms: 0,
+            bytes: b"ready".to_vec(),
+        }))
+        .unwrap();
+        session
+            .wait_for_output(std::time::Instant::now() + std::time::Duration::from_secs(1))
+            .unwrap();
+        assert_eq!(session.terminal.text().unwrap(), "ready");
+        assert!(!session.output_closed);
+        drop(send);
+        session
+            .wait_for_output(std::time::Instant::now() + std::time::Duration::from_secs(1))
+            .unwrap();
+        assert!(session.output_closed);
+        assert_eq!(
+            session
+                .capture(std::time::Duration::ZERO, std::time::Duration::ZERO)
+                .unwrap()
+                .reason,
+            super::CaptureReason::OutputClosed
+        );
+    }
+
     #[test]
     fn transcript_retention_preserves_zero_exact_and_overflow_limits() {
         for (limit, expected, expected_truncated) in


### PR DESCRIPTION
## Why

A named-session request could wait for an unconditional 10 ms daemon sleep, and text-readiness checks could sleep past new output. Pointer animation also laid out and rasterized unchanged terminal text for each new pointer position: a dense two-second recording took about 21 seconds to export locally.

## What Changes

| Operation | Before | After |
| --- | ---: | ---: |
| CLI send → wait → read | 37.5 ms | 10 ms |
| Readiness after a 1 ms fixture response | 11.7 ms | 1.3 ms |
| Pointer video export | 21.3 s | 2.8 s |
| Pointer + footer export | 19.8 s | 3.1 s |

Local medians across 7–15 measured runs after warmup on an Apple M2 Max. Video fixture: dense 80×24 terminal, two seconds, 60 fps, 2× pixels. These are workload-specific measurements, not universal guarantees.

- Wake the named daemon on control-socket readiness and text waits on PTY output. Periodic output/semantic pumping remains bounded.
- Retain one base raster per export and paint pointer changes over a copy. The full-image cache still distinguishes pointer frames, and base storage does not grow with the number of terminal states.
- Document immediate reads and efficient agent workflows without changing stable-capture or typing-pace defaults.
- Add a repeatable benchmark and record accepted/rejected experiments in `perf/agent-rendering.md`.

## Pixel And Lifecycle Guarantees

All 363 decoded frames from three synthetic exports and all 339 frames from the existing real-PTY edited demo match the previous renderer exactly. A 45-case regression checks layered/full rendering with styles, Unicode, clipping, cursor, fades, press scaling, footer, resize and fractional pixel ratios.

There is no intended visual change. Input timing, source-clock edits, quiet periods, and process cleanup are unchanged. A broader output-wakeup experiment in the exit/capture paths was rejected after hitting a lifecycle test; that change is not included.

## Scope

Local control latency and presentation-only raster reuse. Selective transcript transport and the PNG/ffmpeg intermediate pipeline are follow-ups, not hidden changes to this release.

## Verification

```bash
bun install --frozen-lockfile
cargo fmt --all -- --check
cargo test --all-targets
cargo clippy --all-targets --all-features -- -D warnings
cargo build --release
bun scripts/bench-performance.ts --mode all --runs 7
bun run test:npm
bun run build:npm
bun run validate:npm
bun run validate:opentui
cargo package --list
cargo package
```

All local checks above passed, including 146 Rust tests (one manual benchmark ignored), 16 TypeScript client tests, 10 OpenTUI tests, clean Bun/Node consumers, OpenTUI 0.4.1/0.4.5 consumers, and crate packaging. An additional 60 repeated lifecycle/readiness/callback checks passed. Platform release validation is required before publication.
