### PR TITLE
fix(performance): avoid retaining unused recording frames

### DIFF
--- a/.changeset/lean-recording-replay.md
+++ b/.changeset/lean-recording-replay.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/terminal-control": patch
+---
+
+Materialize only the requested recording screenshot instead of retaining every intermediate frame. Video replay no longer constructs an unused ANSI transcript. Preserve recording order, cutoff/marker behavior, and reflow across resizes.

--- a/perf/agent-rendering.md
+++ b/perf/agent-rendering.md
@@ -10,7 +10,7 @@ bun scripts/bench-performance.ts --mode all --runs 7 --out-dir /path/to/results
 
 The benchmark performs one warmup and seven measured runs per case; JSON Lines report medians,
 median absolute deviations, and raw samples. Use `--binary` to compare saved builds, and
-`--mode agent` or `--mode video` for individual experiments. Fixtures and isolated named sessions are
+`--mode agent`, `--mode video`, or `--mode replay` for individual experiments. Fixtures and isolated named sessions are
 cleaned up; only synthetic videos remain when `--out-dir` is specified. `ffmpeg` is required.
 
 ## What is measured
@@ -22,6 +22,7 @@ cleaned up; only synthetic videos remain when `--out-dir` is specified. `ffmpeg`
   already in flight when output arrives; this isolates unnecessary polling latency.
 - Two-second 80×24, 60fps, 2× video exports: plain, moving pointer, pointer with footer.
   Rendering-stage times use the existing stderr progress boundaries; total includes ffmpeg.
+- A final recording screenshot after 1,001 output events, without exporting the timeline.
 
 No arbitrary sleeps, changed default settling, or reduced frame rate are used to improve scores.
 Application startup, external model/tool-call latency, and network package installation are not
@@ -63,6 +64,14 @@ part of these metrics. Results are machine/workload-specific, not performance gu
    That broader change was removed, not masked with a retry or weakened assertion. Exit/quiet/capture
    loops and all cleanup code remain unchanged. Investigate exit/reaping timing separately before
    attempting that optimization again; the exact cause was not established in this pass.
+
+4. **Final recording screenshot:** replay previously retained every intermediate `Frame` for a
+   single requested screenshot. One private replay loop now lets screenshots retain bytes and
+   materialize only the final frame; video retains frames without building an unused transcript.
+   A dense 1,001-event probe improved from 67.76ms to 5.74ms (seven-run medians). A separate
+   `/usr/bin/time -l` measurement reported 133,201,920 → 5,275,648 bytes maximum resident memory.
+   Regression cases compare final-only and incremental frames across v1/v2, out-of-order times,
+   cutoffs, markers, Unicode, styles, cursors and multiple resizes.
 
 ## Guardrails / next candidates
 

--- a/scripts/bench-performance.ts
+++ b/scripts/bench-performance.ts
@@ -33,7 +33,7 @@ if (process.argv.includes("--fixture")) {
   } })
   const runs = Number(values.runs)
   if (!Number.isInteger(runs) || runs < 1) throw new Error("runs must be a positive integer")
-  if (!["all", "agent", "video"].includes(values.mode!)) throw new Error("mode must be all, agent, or video")
+  if (!["all", "agent", "video", "replay"].includes(values.mode!)) throw new Error("mode must be all, agent, video, or replay")
   const binary = resolve(values.binary!)
   const temp = await mkdtemp(join(tmpdir(), "tp-"))
   const output = values["out-dir"] ? resolve(values["out-dir"]) : temp
@@ -63,7 +63,8 @@ if (process.argv.includes("--fixture")) {
     return text
   }
   try {
-    if (values.mode !== "video") {
+    const bytes = (text: string) => Array.from(new TextEncoder().encode(text))
+    if (values.mode === "all" || values.mode === "agent") {
       await cli(["start", "p", "--", ...fixture])
       try {
         await cli(["wait", "p", "READY"])
@@ -100,8 +101,22 @@ if (process.argv.includes("--fixture")) {
         return { ms: performance.now() - start }
       })
     }
-    if (values.mode !== "agent") {
-      const bytes = (text: string) => Array.from(new TextEncoder().encode(text))
+    if (values.mode === "all" || values.mode === "replay") {
+      const entries = [
+        { type: "header", version: 2, cols: 80, rows: 24, cell_width: 9, cell_height: 18 },
+        { type: "output", at_ms: 0, bytes: bytes(screen) },
+        ...Array.from({ length: 1000 }, (_, i) => ({ type: "output", at_ms: i + 1,
+          bytes: bytes(`\x1b[24;1Hframe:${String(i).padStart(4, "0")}`) })),
+      ]
+      const recording = join(temp, "replay.termctrl")
+      await Bun.write(recording, entries.map((entry) => JSON.stringify(entry)).join("\n") + "\n")
+      await measure("recording_final_screen", async () => {
+        const start = performance.now()
+        if (!(await cli(["show", "--recording", recording])).includes("frame:0999")) throw new Error("incorrect replay")
+        return { ms: performance.now() - start }
+      })
+    }
+    if (values.mode === "all" || values.mode === "video") {
       const entries: object[] = [
         { type: "header", version: 2, cols: 80, rows: 24, cell_width: 9, cell_height: 18 },
         { type: "output", at_ms: 0, bytes: bytes(screen) },

--- a/src/recording.rs
+++ b/src/recording.rs
@@ -383,15 +383,14 @@ pub fn shot_at(path: &Path, at_ms: Option<u64>, marker: Option<&str>) -> Result<
             .with_context(|| format!("recording does not contain marker {marker:?}"))?,
         (None, None) => u64::MAX,
     };
-    let replay = replay(&recording, Some(at_ms))?;
+    let mut ansi = Vec::new();
+    let mut terminal = replay(&recording, Some(at_ms), |_, _, bytes| {
+        ansi.extend_from_slice(bytes);
+        Ok(())
+    })?;
     Ok(Shot {
-        frame: replay
-            .frames
-            .last()
-            .expect("replay always has an initial frame")
-            .frame
-            .clone(),
-        ansi: replay.ansi,
+        frame: terminal.frame()?,
+        ansi,
     })
 }
 
@@ -402,33 +401,42 @@ struct VideoFrame {
     footer_caption: Option<String>,
 }
 
-struct Replay {
-    ansi: Vec<u8>,
-    frames: Vec<VideoFrame>,
-}
-
 fn states(recording: &Recording) -> Result<Vec<VideoFrame>> {
-    Ok(replay(recording, None)?.frames)
+    let mut frames: Vec<VideoFrame> = Vec::new();
+    replay(recording, None, |terminal, at_ms, _| {
+        let frame = terminal.frame()?;
+        if !frames
+            .last()
+            .is_some_and(|previous| previous.frame == frame)
+        {
+            frames.push(VideoFrame {
+                at_ms,
+                frame,
+                footer_caption: None,
+            });
+        }
+        Ok(())
+    })?;
+    Ok(frames)
 }
 
-fn replay(recording: &Recording, cutoff: Option<u64>) -> Result<Replay> {
+fn replay(
+    recording: &Recording,
+    cutoff: Option<u64>,
+    mut observe: impl FnMut(&mut TerminalCore, u64, &[u8]) -> Result<()>,
+) -> Result<TerminalCore> {
     let mut terminal = TerminalCore::new(recording.rows, recording.cols, SCROLLBACK_ROWS)?;
-    let mut ansi = Vec::new();
-    let mut frames: Vec<VideoFrame> = Vec::new();
-    frames.push(VideoFrame {
-        at_ms: 0,
-        frame: terminal.frame()?,
-        footer_caption: None,
-    });
+    // Shots retain bytes and materialize only the final frame; videos retain visible states
+    // without constructing an unused transcript. Both replay exactly the same event sequence.
+    observe(&mut terminal, 0, &[])?;
     for event in &recording.events {
-        let at_ms = match event {
+        let (at_ms, bytes) = match event {
             Entry::Output { at_ms, bytes } => {
                 if cutoff.is_some_and(|cutoff| *at_ms > cutoff) {
                     continue;
                 }
-                ansi.extend_from_slice(bytes);
                 let _responses = terminal.apply_output(bytes);
-                *at_ms
+                (*at_ms, bytes.as_slice())
             }
             Entry::Resize {
                 at_ms,
@@ -441,27 +449,16 @@ fn replay(recording: &Recording, cutoff: Option<u64>) -> Result<Replay> {
                     continue;
                 }
                 terminal.resize(*cols, *rows, *cell_width, *cell_height)?;
-                *at_ms
+                (*at_ms, &[][..])
             }
             Entry::Input { .. }
             | Entry::Mouse { .. }
             | Entry::Marker { .. }
             | Entry::Header { .. } => continue,
         };
-        let frame = terminal.frame()?;
-        if frames
-            .last()
-            .is_some_and(|previous| previous.frame == frame)
-        {
-            continue;
-        }
-        frames.push(VideoFrame {
-            at_ms,
-            frame,
-            footer_caption: None,
-        });
+        observe(&mut terminal, at_ms, bytes)?;
     }
-    Ok(Replay { ansi, frames })
+    Ok(terminal)
 }
 
 fn visible_states(states: &[VideoFrame], include_startup: bool) -> &[VideoFrame] {
@@ -1015,6 +1012,102 @@ fn format_timecode(elapsed_ms: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn single_shots_match_incremental_frames_across_cutoffs_and_resizes() {
+        let path =
+            std::env::temp_dir().join(format!("tc-final-shot-{}.termctrl", std::process::id()));
+        for version in [1, 2] {
+            let mut entries = vec![
+                Entry::Header {
+                    version,
+                    cols: 8,
+                    rows: 3,
+                    cell_width: 9,
+                    cell_height: 18,
+                },
+                Entry::Output {
+                    at_ms: 5,
+                    bytes: "\x1b[41mA界\x1b[0m\r\nabcdefghijk".as_bytes().to_vec(),
+                },
+                Entry::Resize {
+                    at_ms: 10,
+                    cols: 4,
+                    rows: 3,
+                    cell_width: 9,
+                    cell_height: 18,
+                },
+                Entry::Input {
+                    at_ms: 12,
+                    origin: InputOrigin::Client,
+                    bytes: b"not output".to_vec(),
+                },
+                Entry::Output {
+                    at_ms: 20,
+                    bytes: b"\x1b[6 q\x1b[1;4mtext".to_vec(),
+                },
+                // Filtering must preserve recording order, not sort or stop at the first cutoff.
+                Entry::Output {
+                    at_ms: 15,
+                    bytes: b"\x1b[0m\r\nx".to_vec(),
+                },
+                Entry::Resize {
+                    at_ms: 30,
+                    cols: 10,
+                    rows: 5,
+                    cell_width: 9,
+                    cell_height: 18,
+                },
+                Entry::Output {
+                    at_ms: 35,
+                    bytes: b"\x1b[8mhidden\x1b[0m\x1b[?25l".to_vec(),
+                },
+                Entry::Marker {
+                    at_ms: 40,
+                    name: "end".into(),
+                },
+            ];
+            if version == 2 {
+                entries.push(Entry::Mouse {
+                    at_ms: 45,
+                    event: crate::mouse::MouseEvent::new(crate::mouse::Action::Click, 0, 0),
+                    bytes: b"not output".to_vec(),
+                });
+            }
+            fs::write(
+                &path,
+                entries
+                    .iter()
+                    .map(|entry| serde_json::to_string(entry).unwrap())
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            )
+            .unwrap();
+            let recording = read(&path).unwrap();
+            for cutoff in [0, 5, 10, 18, 20, 30, 40, u64::MAX] {
+                let mut frame = None;
+                let mut ansi = Vec::new();
+                replay(&recording, Some(cutoff), |terminal, _, bytes| {
+                    frame = Some(terminal.frame()?);
+                    ansi.extend_from_slice(bytes);
+                    Ok(())
+                })
+                .unwrap();
+                let shot = shot_at(&path, Some(cutoff), None).unwrap();
+                assert_eq!(
+                    shot.frame,
+                    frame.unwrap(),
+                    "version {version}, cutoff {cutoff}"
+                );
+                assert_eq!(shot.ansi, ansi);
+            }
+            assert_eq!(
+                shot_at(&path, None, Some("end")).unwrap().frame,
+                shot_at(&path, None, None).unwrap().frame
+            );
+        }
+        fs::remove_file(path).unwrap();
+    }
 
     fn edited_states(
         states: &[VideoFrame],


### PR DESCRIPTION
## Why

Reading one recording screenshot retained every intermediate terminal frame before returning only the last one. A 1,001-event dense-screen probe consumed about 127 MiB for a single screen read. Video replay also built an ANSI transcript it immediately discarded.

## What Changes

One private replay loop preserves event application and cutoff filtering, while each consumer collects only its required artifact:

- Screenshots retain output bytes and materialize the final frame once.
- Videos retain deduplicated visible frames, without a second accumulated transcript.

The reusable benchmark's seven-run median improved from **62.54 ms to 4.17 ms**. A separate dense-screen probe improved from 67.76 to 5.74 ms, with maximum resident memory reduced from **133,201,920 to 5,275,648 bytes**. These are local Apple M2 Max measurements, not universal guarantees.

## Replay Guarantees

Cutoff filtering retains recording order, including non-monotonic event timestamps. Resizes still reflow terminal state in that order. Input, mouse evidence, and markers are not interpreted as terminal output. Public APIs and recording formats are unchanged.

## Scope

Artifact-specific replay work only. Selective ANSI transport for live named-session reads remains separate.

## Verification

```bash
bun install --frozen-lockfile
cargo fmt --all -- --check
cargo test recording::
cargo test --all-targets
cargo clippy --all-targets --all-features -- -D warnings
cargo build --release
bun scripts/bench-performance.ts --mode replay --binary /path/to/before
bun scripts/bench-performance.ts --mode replay
bun run test:npm
bun run build:npm
bun run validate:npm
bun run validate:opentui
cargo package --list
cargo package
```

All local checks passed, including 147 Rust tests (28 recording tests; one manual benchmark ignored), 16 client tests, 10 OpenTUI tests, clean npm/OpenTUI consumers and crate packaging. New cases compare final-only and incremental frames across v1/v2, timestamp cutoffs, markers, out-of-order events, Unicode/styles, cursor updates and multiple resizes. All 339 decoded frames of the real-PTY edited demo remain identical. Platform CI and release validation are required before publication.
