### PR TITLE
chore: release terminal-control 1.2.0

### DIFF
--- a/.changeset/lean-recording-replay.md
+++ b/.changeset/lean-recording-replay.md
@@ -1,5 +1,0 @@
----
-"@kitlangton/terminal-control": patch
----
-
-Materialize only the requested recording screenshot instead of retaining every intermediate frame. Video replay no longer constructs an unused ANSI transcript. Preserve recording order, cutoff/marker behavior, and reflow across resizes.

--- a/.changeset/responsive-terminal-control.md
+++ b/.changeset/responsive-terminal-control.md
@@ -1,7 +1,0 @@
----
-"@kitlangton/terminal-control": patch
----
-
-Wake named-session control requests as soon as they arrive instead of waiting for an idle polling sleep, and wake text-readiness checks on PTY output. Clarify immediate screen reads, readiness-driven demo workflows, and intentional capture/typing delays without changing stable-capture defaults.
-
-Reuse a bounded base raster during pointer video animation instead of repeating terminal text layout for every pointer position. Preserve frame pixels, recording timing, and screenshot behavior.

--- a/.changeset/robust-terminal-evidence.md
+++ b/.changeset/robust-terminal-evidence.md
@@ -1,5 +1,0 @@
----
-"@kitlangton/terminal-control": patch
----
-
-Preserve color-query replies when terminal escape prefixes arrive across separate output chunks, exclude invisible text when trimming video startup, and keep the original test failure when automatic failure-artifact capture fails. Simplify shared input encoding, terminal ownership, and recording rendering without changing public interfaces.

--- a/.changeset/smooth-pointer-input.md
+++ b/.changeset/smooth-pointer-input.md
@@ -1,7 +1,0 @@
----
-"@kitlangton/terminal-control": minor
----
-
-Add typed mouse input for hover, clicks, and drags through the CLI, Rust sessions, TypeScript client, and MCP. Encode input using the application's negotiated mouse reporting mode and validate current viewport coordinates.
-
-Add opt-in video pointer overlays with smooth travel, press feedback, fades, and reduced motion. Keep animation aligned through edits and resizes without changing real input timing. New recordings use format v2 for typed mouse evidence; current readers continue to accept v1 recordings.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "terminal-control"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminal-control"
-version = "1.1.1"
+version = "1.2.0"
 edition = "2024"
 rust-version = "1.93"
 description = "Control and test terminal applications through stable visible state"

--- a/bun.lock
+++ b/bun.lock
@@ -10,35 +10,35 @@
     },
     "packages/darwin-arm64": {
       "name": "@kitlangton/terminal-control-darwin-arm64",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "bin": {
         "termctrl": "bin/termctrl",
       },
     },
     "packages/darwin-x64": {
       "name": "@kitlangton/terminal-control-darwin-x64",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "bin": {
         "termctrl": "bin/termctrl",
       },
     },
     "packages/linux-arm64-gnu": {
       "name": "@kitlangton/terminal-control-linux-arm64-gnu",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "bin": {
         "termctrl": "bin/termctrl",
       },
     },
     "packages/linux-x64-gnu": {
       "name": "@kitlangton/terminal-control-linux-x64-gnu",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "bin": {
         "termctrl": "bin/termctrl",
       },
     },
     "packages/opentui": {
       "name": "@kitlangton/terminal-control-opentui",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "devDependencies": {
         "@opentui/core": "^0.4.5",
         "@types/bun": "^1.3.0",
@@ -51,7 +51,7 @@
     },
     "packages/test": {
       "name": "@kitlangton/terminal-control",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "devDependencies": {
         "@types/bun": "^1.3.0",
         "@types/node": "^24.0.0",
@@ -59,10 +59,10 @@
         "vitest": "^3.2.4",
       },
       "optionalDependencies": {
-        "@kitlangton/terminal-control-darwin-arm64": "1.1.1",
-        "@kitlangton/terminal-control-darwin-x64": "1.1.1",
-        "@kitlangton/terminal-control-linux-arm64-gnu": "1.1.1",
-        "@kitlangton/terminal-control-linux-x64-gnu": "1.1.1",
+        "@kitlangton/terminal-control-darwin-arm64": "1.2.0",
+        "@kitlangton/terminal-control-darwin-x64": "1.2.0",
+        "@kitlangton/terminal-control-linux-arm64-gnu": "1.2.0",
+        "@kitlangton/terminal-control-linux-x64-gnu": "1.2.0",
       },
       "peerDependencies": {
         "vitest": ">=3.0.0",

--- a/packages/darwin-arm64/CHANGELOG.md
+++ b/packages/darwin-arm64/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @kitlangton/terminal-control-darwin-arm64
 
+## 1.2.0
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/darwin-arm64/package.json
+++ b/packages/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control-darwin-arm64",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Native termctrl binary for Terminal Control on macOS arm64",
   "license": "MIT",
   "repository": "https://github.com/anomalyco/terminal-control",

--- a/packages/darwin-x64/CHANGELOG.md
+++ b/packages/darwin-x64/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @kitlangton/terminal-control-darwin-x64
 
+## 1.2.0
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/darwin-x64/package.json
+++ b/packages/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control-darwin-x64",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Native termctrl binary for Terminal Control on macOS x64",
   "license": "MIT",
   "repository": "https://github.com/anomalyco/terminal-control",

--- a/packages/linux-arm64-gnu/CHANGELOG.md
+++ b/packages/linux-arm64-gnu/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @kitlangton/terminal-control-linux-arm64-gnu
 
+## 1.2.0
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/linux-arm64-gnu/package.json
+++ b/packages/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control-linux-arm64-gnu",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Native termctrl binary for Terminal Control on Linux arm64 GNU",
   "license": "MIT",
   "repository": "https://github.com/anomalyco/terminal-control",

--- a/packages/linux-x64-gnu/CHANGELOG.md
+++ b/packages/linux-x64-gnu/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @kitlangton/terminal-control-linux-x64-gnu
 
+## 1.2.0
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/linux-x64-gnu/package.json
+++ b/packages/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control-linux-x64-gnu",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Native termctrl binary for Terminal Control on Linux x64 GNU",
   "license": "MIT",
   "repository": "https://github.com/anomalyco/terminal-control",

--- a/packages/opentui/CHANGELOG.md
+++ b/packages/opentui/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @kitlangton/terminal-control-opentui
 
+## 1.2.0
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/opentui/package.json
+++ b/packages/opentui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control-opentui",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Expose consistent OpenTUI semantic snapshots through Terminal Control",
   "license": "MIT",
   "repository": {

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @kitlangton/terminal-control
 
+## 1.2.0
+
+### Minor Changes
+
+- d4518f4: Add typed mouse input for hover, clicks, and drags through the CLI, Rust sessions, TypeScript client, and MCP. Encode input using the application's negotiated mouse reporting mode and validate current viewport coordinates.
+
+  Add opt-in video pointer overlays with smooth travel, press feedback, fades, and reduced motion. Keep animation aligned through edits and resizes without changing real input timing. New recordings use format v2 for typed mouse evidence; current readers continue to accept v1 recordings.
+
+### Patch Changes
+
+- 138ea31: Materialize only the requested recording screenshot instead of retaining every intermediate frame. Video replay no longer constructs an unused ANSI transcript. Preserve recording order, cutoff/marker behavior, and reflow across resizes.
+- b0a4d8b: Wake named-session control requests as soon as they arrive instead of waiting for an idle polling sleep, and wake text-readiness checks on PTY output. Clarify immediate screen reads, readiness-driven demo workflows, and intentional capture/typing delays without changing stable-capture defaults.
+
+  Reuse a bounded base raster during pointer video animation instead of repeating terminal text layout for every pointer position. Preserve frame pixels, recording timing, and screenshot behavior.
+
+- d4518f4: Preserve color-query replies when terminal escape prefixes arrive across separate output chunks, exclude invisible text when trimming video startup, and keep the original test failure when automatic failure-artifact capture fails. Simplify shared input encoding, terminal ownership, and recording rendering without changing public interfaces.
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Typed terminal application control and testing with snapshots, recordings, and failure artifacts",
   "license": "MIT",
   "repository": {
@@ -38,10 +38,10 @@
     "prepack": "bun run build"
   },
   "optionalDependencies": {
-    "@kitlangton/terminal-control-darwin-arm64": "1.1.1",
-    "@kitlangton/terminal-control-darwin-x64": "1.1.1",
-    "@kitlangton/terminal-control-linux-arm64-gnu": "1.1.1",
-    "@kitlangton/terminal-control-linux-x64-gnu": "1.1.1"
+    "@kitlangton/terminal-control-darwin-arm64": "1.2.0",
+    "@kitlangton/terminal-control-darwin-x64": "1.2.0",
+    "@kitlangton/terminal-control-linux-arm64-gnu": "1.2.0",
+    "@kitlangton/terminal-control-linux-x64-gnu": "1.2.0"
   },
   "peerDependencies": {
     "vitest": ">=3.0.0"


### PR DESCRIPTION
## Why

Ship the merged typed mouse input, animated recording overlay, reliability fixes, and measured control/rendering improvements as one aligned release.

## What Changes

- Consume the pending Changesets and advance all six npm packages to 1.2.0.
- Match Cargo package/lock and Bun workspace/native-dependency metadata to the same version.
- Generate changelogs from the reviewed changes.

## Scope

Version and changelog preparation only. Publication uses the existing trusted-publishing workflow after platform artifact and clean-consumer validation.

## Verification

```bash
bun install --frozen-lockfile
cargo fmt --all -- --check
cargo test --all-targets
cargo clippy --all-targets --all-features -- -D warnings
cargo build --release
bun run test:npm
bun run build:npm
bun run validate:npm
bun run validate:opentui
cargo package --list
cargo package
cargo publish --dry-run --locked
```

All local checks passed at 1.2.0, including clean Bun/Node consumers and OpenTUI 0.4.1/0.4.5 consumers. Verified all six package manifests, Cargo manifest/lock, Bun workspace/native-dependency metadata, consumed Changesets, and generated changelogs agree. Inspected the crate and local npm tarball contents: source/schemas/licenses in the crate; compiled client/adapter exports; executable and license notices in the native package.

After merge, the manual release workflow will validate the complete macOS/Linux arm64/x64 tarball set before trusted publication.
