### PR TITLE
fix(release): build native packages for baseline CPUs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,14 @@ jobs:
       - run: cargo fmt --all -- --check
       - run: cargo test
       - run: cargo clippy --all-targets -- -D warnings
-      - run: cargo build --release
+      - run: node --test scripts/portable-zig.test.mjs
+      - run: scripts/build-portable.sh
+      - name: Verify x86-64 baseline CPU compatibility
+        run: |
+          set -o pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y qemu-user
+          printf 'portable-terminal' | qemu-x86_64 -cpu qemu64 target/release/termctrl show --input - | grep -Fx portable-terminal
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
       - run: bun run --cwd packages/test typecheck

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -37,7 +37,15 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-      - run: cargo build --release
+      - run: node --test scripts/portable-zig.test.mjs
+      - run: scripts/build-portable.sh
+      - name: Verify x86-64 baseline CPU compatibility
+        if: matrix.package == 'linux-x64-gnu'
+        run: |
+          set -o pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y qemu-user
+          printf 'portable-terminal' | qemu-x86_64 -cpu qemu64 target/release/termctrl show --input - | grep -Fx portable-terminal
       - run: node scripts/native-packages.mjs "${{ matrix.package }}" "$PWD/target/release/termctrl" "$PWD/npm-artifacts"
       - uses: actions/upload-artifact@v7
         with:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -24,6 +24,12 @@ Native packaging rejects a Rust executable whose `termctrl --version` differs fr
 manifest. The OpenTUI manifest must already match the TypeScript client before publishing. Do not
 bypass the package-set checks or publish package formats at different versions.
 
+Build distributed binaries with `scripts/build-portable.sh`, not a host-tuned Ghostty archive.
+The pinned `libghostty-vt-sys` 0.2.1 does not select a portable CPU; the script forces Zig's
+`-Dcpu=baseline` for Ghostty and clears that dependency's release build outputs before rebuilding.
+The release workflow also exercises Linux x64 on QEMU's baseline CPU. Remove the compatibility
+shim when upgrading to a published dependency that defaults to a baseline CPU itself.
+
 ## Validate The Release
 
 `bun run validate:opentui` packs the current adapter into a temporary directory and checks its

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Patch Changes
 
+- Build distributed native binaries for a baseline CPU instead of the build runner's instruction set, preventing illegal-instruction crashes on older CPUs.
 - 138ea31: Materialize only the requested recording screenshot instead of retaining every intermediate frame. Video replay no longer constructs an unused ANSI transcript. Preserve recording order, cutoff/marker behavior, and reflow across resizes.
 - b0a4d8b: Wake named-session control requests as soon as they arrive instead of waiting for an idle polling sleep, and wake text-readiness checks on PTY output. Clarify immediate screen reads, readiness-driven demo workflows, and intentional capture/typing delays without changing stable-capture defaults.
 

--- a/scripts/build-portable.sh
+++ b/scripts/build-portable.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+TERMCTRL_REAL_ZIG=$(command -v zig)
+export TERMCTRL_REAL_ZIG
+export PATH="$root/scripts/portable-zig:$PATH"
+cd "$root"
+# PATH is not a tracked input of the dependency's build script. Discard only its release
+# outputs so a previous host-native archive cannot silently survive a portable rebuild.
+cargo clean --release -p libghostty-vt-sys
+cargo build --release "$@"

--- a/scripts/portable-zig.test.mjs
+++ b/scripts/portable-zig.test.mjs
@@ -1,0 +1,28 @@
+import { strict as assert } from "node:assert"
+import { spawnSync } from "node:child_process"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { test } from "node:test"
+
+test("portable Zig selects baseline only for Ghostty and preserves arguments", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "termctrl-zig-test-"))
+  try {
+    const real = join(directory, "real zig")
+    await writeFile(real, '#!/bin/sh\nprintf "%s\\n" "$@"\n', { mode: 0o700 })
+    const shim = resolve(import.meta.dirname, "portable-zig/zig")
+    const run = (args) => spawnSync(shim, args, { env: { ...process.env, TERMCTRL_REAL_ZIG: real }, encoding: "utf8" })
+    for (const args of [["version"], ["build", "-Dcpu=native", "--prefix", "path with spaces"], ["build", "-Demit-lib-vt=true", "-Dcpu=baseline"]]) {
+      const result = run(args)
+      assert.equal(result.status, 0, result.stderr)
+      assert.equal(result.stdout, args.join("\n") + "\n")
+    }
+    const args = ["build", "-Demit-lib-vt=true", "-Doptimize=ReleaseFast", "--prefix", "path with spaces"]
+    const result = run(args)
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(result.stdout, [...args, "-Dcpu=baseline"].join("\n") + "\n")
+    assert.notEqual(run(["build", "-Demit-lib-vt=true", "-Dcpu=native"]).status, 0)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})

--- a/scripts/portable-zig/zig
+++ b/scripts/portable-zig/zig
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -eu
+: "${TERMCTRL_REAL_ZIG:?Use scripts/build-portable.sh to select the real Zig executable}"
+
+# libghostty-vt-sys 0.2.1 otherwise lets Zig select the build host's CPU.
+# Scope the compatibility shim to Ghostty, not Zig's version probe or other builds.
+if [ "${1-}" = build ]; then
+  ghostty=false
+  cpu=
+  for arg in "$@"; do
+    case "$arg" in
+      -Demit-lib-vt=true) ghostty=true ;;
+      -Dcpu=*) cpu=$arg ;;
+    esac
+  done
+  if [ "$ghostty" = true ]; then
+    case "$cpu" in
+      '') exec "$TERMCTRL_REAL_ZIG" "$@" -Dcpu=baseline ;;
+      -Dcpu=baseline) ;;
+      *) echo "portable Ghostty builds require -Dcpu=baseline" >&2; exit 1 ;;
+    esac
+  fi
+fi
+exec "$TERMCTRL_REAL_ZIG" "$@"


### PR DESCRIPTION
## Why

All four native builds completed in the 1.2.0 release dry run, but its Linux x64 clean consumer terminated with `SIGILL`; the other consumer jobs were cancelled by the matrix. The failed artifact contains unconditional AVX-512 `vmovdqu64` instructions in `ghostty_terminal_new`: the native library was tuned to the build runner rather than the CPUs the package supports.

The pinned `libghostty-vt-sys` 0.2.1 lets Zig autodetect the host CPU and offers no CPU override. Upstream has a baseline-CPU fix, but it is not available in the published dependency yet. No 1.2.0 package has been published.

## What Changes

- Build distributed binaries through `scripts/build-portable.sh`, which selects `-Dcpu=baseline` only for Ghostty's Zig build.
- Clear only the dependency's release build outputs first: Cargo does not track the shim's PATH change, so an existing host-tuned archive must not be reused.
- Preserve other Zig invocations and quoted arguments; reject an explicit non-baseline Ghostty CPU instead of silently producing an unsafe package.
- Exercise terminal initialization under QEMU's baseline x86-64 CPU in both CI and the Linux x64 release build.
- Document the temporary compatibility shim and add the fix to the still-unpublished 1.2.0 changelog.

## Scope

Native build portability only. Rust APIs, terminal behavior, dependency revisions and the prepared release version are unchanged. Remove the shim after adopting a published dependency with a baseline default.

## Verification

```bash
node --test scripts/portable-zig.test.mjs
sh -n scripts/build-portable.sh scripts/portable-zig/zig
scripts/build-portable.sh
bun install --frozen-lockfile
cargo fmt --all -- --check
cargo test --all-targets
cargo clippy --all-targets --all-features -- -D warnings
cargo build --release
bun run test:npm
bun run build:npm
bun run validate:npm
bun run validate:opentui
cargo package --list
cargo package
```

All local checks passed, including a fresh portable build, Rust/client/adapter tests, clean consumers, and crate packaging. Both GitHub CI runs passed, including the baseline QEMU CPU smoke test on native Linux. The shim test covers version probes, unrelated builds, whitespace-containing arguments, existing baseline selection, and rejection of host-native Ghostty selection. Disassembled the failed release artifact to identify the AVX-512 initialization path. Local Docker emulation failed inside QEMU and is not claimed as a faithful reproduction. The full platform consumer matrix is being rerun before publication.
