### PR TITLE
refactor(core): borrow terminal state until snapshots need ownership

### DIFF
--- a/.changeset/borrow-terminal-state.md
+++ b/.changeset/borrow-terminal-state.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/terminal-control": patch
+---
+
+Avoid cloning cached terminal frames for internal text/status inspection and duplicate recording states. Borrow unedited video states instead of copying the entire timeline, and borrow socket paths during named-session request polling. Public captures remain independent owned snapshots; terminal behavior, recording formats, and rendered output are unchanged.

--- a/perf/agent-rendering.md
+++ b/perf/agent-rendering.md
@@ -73,6 +73,16 @@ part of these metrics. Results are machine/workload-specific, not performance gu
    Regression cases compare final-only and incremental frames across v1/v2, out-of-order times,
    cutoffs, markers, Unicode, styles, cursors and multiple resizes.
 
+5. **Borrow existing snapshots:** internal text/status reads now borrow the cached terminal frame;
+   owned captures clone explicitly, and recording replay clones only distinct retained states.
+   Unedited video export also borrows its existing state list rather than deep-copying the timeline.
+   For a dense 1,001-event recording sampled at 1fps (two output frames), three-run median maximum
+   resident memory fell from 414,334,976 to 284,868,608 bytes (about 395 to 272 MiB). Sampling at 1fps
+   here isolates retained timeline work; it is not a change to video defaults or a speed claim.
+   Paired 15-run driver-interaction medians remained around 5.7–6.0ms. Forty v1/v2 screenshot/ANSI
+   comparisons, 187 decoded frames across eight synthetic video variants, and the 339-frame edited
+   real-PTY demo were identical. A retained-frame test covers later output, cursor changes, and resize.
+
 ## Guardrails / next candidates
 
 - Keep explicit quiet periods and input pacing. The TypeScript stable-capture defaults are a test

--- a/src/recording.rs
+++ b/src/recording.rs
@@ -258,11 +258,12 @@ pub fn video(path: &Path, options: &VideoOptions) -> Result<()> {
     };
     let edit = options.edit.as_deref().map(read_edit).transpose()?;
     let playback = Playback::new(&recording.events, edit.as_ref(), states[0].at_ms)?;
-    let states = match &edit {
-        Some(_) => edited_states(states, &playback.clips, caption_placement)?,
-        None => states.to_vec(),
-    };
-    let samples = samples(&states, options);
+    let edited = edit
+        .as_ref()
+        .map(|_| edited_states(states, &playback.clips, caption_placement))
+        .transpose()?;
+    let states = edited.as_deref().unwrap_or(states);
+    let samples = samples(states, options);
     if let Some(parent) = options
         .out
         .parent()
@@ -288,7 +289,7 @@ pub fn video(path: &Path, options: &VideoOptions) -> Result<()> {
     let result = render_video_frames(
         &temp,
         &recording,
-        &states,
+        states,
         &samples,
         options,
         pointer.as_ref(),
@@ -389,7 +390,7 @@ pub fn shot_at(path: &Path, at_ms: Option<u64>, marker: Option<&str>) -> Result<
         Ok(())
     })?;
     Ok(Shot {
-        frame: terminal.frame()?,
+        frame: terminal.frame()?.clone(),
         ansi,
     })
 }
@@ -407,11 +408,11 @@ fn states(recording: &Recording) -> Result<Vec<VideoFrame>> {
         let frame = terminal.frame()?;
         if !frames
             .last()
-            .is_some_and(|previous| previous.frame == frame)
+            .is_some_and(|previous| &previous.frame == frame)
         {
             frames.push(VideoFrame {
                 at_ms,
-                frame,
+                frame: frame.clone(),
                 footer_caption: None,
             });
         }
@@ -1088,7 +1089,7 @@ mod tests {
                 let mut frame = None;
                 let mut ansi = Vec::new();
                 replay(&recording, Some(cutoff), |terminal, _, bytes| {
-                    frame = Some(terminal.frame()?);
+                    frame = Some(terminal.frame()?.clone());
                     ansi.extend_from_slice(bytes);
                     Ok(())
                 })
@@ -1282,7 +1283,7 @@ mod tests {
     fn painted_frame() -> Frame {
         let mut terminal = TerminalCore::new(1, 2, 0).unwrap();
         let _responses = terminal.apply_output(b"\x1b[48;2;30;34;42m ");
-        terminal.frame().unwrap()
+        terminal.frame().unwrap().clone()
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -516,7 +516,7 @@ impl Session {
             if let Some(reason) = reason {
                 return Ok(CaptureResult {
                     shot: Shot {
-                        frame: self.terminal.frame()?,
+                        frame: self.terminal.frame()?.clone(),
                         ansi: self.ansi.clone(),
                     },
                     reason,
@@ -1105,7 +1105,7 @@ pub fn infer_name(command: &[String]) -> Result<String> {
 
 fn request(name: &str, request: Request) -> Result<Response> {
     validate_name(name)?;
-    let response = implementation::request(socket_path(name)?, &request)?;
+    let response = implementation::request(&socket_path(name)?, &request)?;
     if let Some(error) = response.error {
         bail!(error);
     }
@@ -1212,12 +1212,12 @@ mod implementation {
         ensure_socket_path(&runtime.join(format!("{name}.sock")))?;
         let _lock = StartLock::acquire(&runtime.join(format!("{name}.lock")))?;
         let socket = runtime.join(format!("{name}.sock"));
-        if let Ok(response) = request(socket.clone(), &Request::Stop) {
+        if let Ok(response) = request(&socket, &Request::Stop) {
             if let Some(error) = response.error {
                 bail!(error);
             }
             let deadline = Instant::now() + Duration::from_secs(2);
-            while request(socket.clone(), &Request::Ping).is_ok() {
+            while request(&socket, &Request::Ping).is_ok() {
                 if Instant::now() >= deadline {
                     bail!("timed out stopping session {name:?} before restart");
                 }
@@ -1298,7 +1298,7 @@ mod implementation {
         let mut daemon = daemon.spawn().context("start session daemon")?;
         let deadline = Instant::now() + Duration::from_secs(5);
         loop {
-            if request(socket.clone(), &Request::Ping).is_ok() {
+            if request(&socket, &Request::Ping).is_ok() {
                 return Ok(());
             }
             if let Some(status) = daemon.try_wait().context("poll session daemon")? {
@@ -1312,9 +1312,9 @@ mod implementation {
         }
     }
 
-    pub fn request(socket: PathBuf, request: &Request) -> Result<Response> {
-        ensure_socket_path(&socket)?;
-        let mut stream = UnixStream::connect(&socket).with_context(|| {
+    pub fn request(socket: &Path, request: &Request) -> Result<Response> {
+        ensure_socket_path(socket)?;
+        let mut stream = UnixStream::connect(socket).with_context(|| {
             format!("connect to session at {}; is it running?", socket.display())
         })?;
         let mut writer = std::io::BufWriter::with_capacity(64 * 1024, &mut stream);
@@ -1342,7 +1342,7 @@ mod implementation {
             else {
                 continue;
             };
-            let (status, error, unavailable) = match request(path, &Request::Status) {
+            let (status, error, unavailable) = match request(&path, &Request::Status) {
                 Ok(response) => (response.status, response.error, None),
                 Err(error) => {
                     let reason = if stale_socket_error(&error) {
@@ -1386,7 +1386,7 @@ mod implementation {
                 socket.display()
             );
         }
-        match request(socket.clone(), &Request::Status) {
+        match request(&socket, &Request::Status) {
             Ok(response) => {
                 if let Some(error) = response.error {
                     bail!(error);
@@ -1398,7 +1398,7 @@ mod implementation {
                     return Ok(None);
                 }
                 if !dry_run {
-                    let response = request(socket, &Request::Stop)?;
+                    let response = request(&socket, &Request::Stop)?;
                     if let Some(error) = response.error {
                         bail!(error);
                     }
@@ -1551,7 +1551,7 @@ mod implementation {
     }
 
     fn remove_stale_socket(name: &str, socket: &Path) -> Result<()> {
-        if request(socket.to_owned(), &Request::Ping).is_ok() {
+        if request(socket, &Request::Ping).is_ok() {
             bail!("session {name:?} is already running");
         }
         match fs::remove_file(socket) {
@@ -1787,12 +1787,12 @@ mod implementation {
                 )
             });
             let deadline = Instant::now() + Duration::from_secs(2);
-            while request(socket.clone(), &Request::Ping).is_err() {
+            while request(&socket, &Request::Ping).is_err() {
                 assert!(Instant::now() < deadline, "session daemon did not start");
                 thread::sleep(Duration::from_millis(10));
             }
             request(
-                socket.clone(),
+                &socket,
                 &Request::Wait {
                     text: name.clone(),
                     timeout_ms: 2_000,
@@ -1801,7 +1801,7 @@ mod implementation {
             .unwrap();
 
             let response = request(
-                socket.clone(),
+                &socket,
                 &Request::Show {
                     settle_ms: 0,
                     deadline_ms: 0,
@@ -1809,7 +1809,7 @@ mod implementation {
             )
             .unwrap();
             assert_eq!(response.captured.unwrap().frame.text(), name);
-            request(socket, &Request::Stop).unwrap();
+            request(&socket, &Request::Stop).unwrap();
             server.join().unwrap().unwrap();
         }
     }
@@ -1842,7 +1842,7 @@ mod implementation {
     ) -> Result<()> {
         bail!("persistent sessions require Unix sockets")
     }
-    pub fn request(_: PathBuf, _: &Request) -> Result<Response> {
+    pub fn request(_: &Path, _: &Request) -> Result<Response> {
         bail!("persistent sessions require Unix sockets")
     }
     pub fn list() -> Result<Vec<NamedSessionStatus>> {

--- a/src/shot.rs
+++ b/src/shot.rs
@@ -84,7 +84,7 @@ pub fn from_ansi(bytes: Vec<u8>, rows: u16, cols: u16, max_bytes: usize) -> Resu
     let mut terminal = TerminalCore::new(rows, cols, 0)?;
     let _responses = terminal.apply_output(&bytes);
     Ok(Shot {
-        frame: terminal.frame()?,
+        frame: terminal.frame()?.clone(),
         ansi: bytes,
     })
 }
@@ -168,7 +168,7 @@ pub fn from_command(command: &[String], cwd: Option<&Path>, options: &Options) -
             )?;
         }
         Ok(Shot {
-            frame: terminal.frame()?,
+            frame: terminal.frame()?.clone(),
             ansi,
         })
     })();
@@ -275,7 +275,7 @@ pub fn from_pipe_command(
             );
         }
         Ok(Shot {
-            frame: terminal.frame()?,
+            frame: terminal.frame()?.clone(),
             ansi,
         })
     })();

--- a/src/terminal_core.rs
+++ b/src/terminal_core.rs
@@ -157,7 +157,13 @@ impl TerminalCore {
         Ok(bytes.as_ref().to_vec())
     }
 
-    pub(crate) fn frame(&mut self) -> Result<Frame> {
+    /// Borrow the current snapshot; clone only when retaining it beyond the next terminal update.
+    pub(crate) fn frame(&mut self) -> Result<&Frame> {
+        self.update_frame()?;
+        Ok(self.cached_frame.as_ref().expect("frame cache populated"))
+    }
+
+    fn update_frame(&mut self) -> Result<()> {
         let snapshot = self
             .render_state
             .update(&self.terminal)
@@ -168,11 +174,8 @@ impl TerminalCore {
             .context("read Ghostty cursor style")?;
         let cursor_style_changed = self.cursor_style != next_cursor_style;
         self.cursor_style = next_cursor_style;
-        if dirty == Dirty::Clean
-            && !cursor_style_changed
-            && let Some(frame) = &self.cached_frame
-        {
-            return Ok(frame.clone());
+        if dirty == Dirty::Clean && !cursor_style_changed && self.cached_frame.is_some() {
+            return Ok(());
         }
         let cols = snapshot.cols().context("read Ghostty columns")?;
         let rows = snapshot.rows().context("read Ghostty rows")?;
@@ -298,8 +301,8 @@ impl TerminalCore {
             frame.cells.sort_unstable_by_key(|cell| (cell.y, cell.x));
             frame
         };
-        self.cached_frame = Some(frame.clone());
-        Ok(frame)
+        self.cached_frame = Some(frame);
+        Ok(())
     }
 }
 
@@ -424,7 +427,7 @@ mod tests {
         terminal.apply_output(b"\x1b[6 q");
         let frame = terminal.frame().unwrap();
 
-        assert_eq!(frame.cursor.unwrap().style, CursorStyle::Bar);
+        assert_eq!(frame.cursor.as_ref().unwrap().style, CursorStyle::Bar);
     }
 
     #[test]
@@ -477,12 +480,34 @@ mod tests {
         assert_eq!(terminal.frame().unwrap().text(), "alpha\nbeta");
 
         let _responses = terminal.apply_output(b"\rB");
-        let updated = terminal.frame().unwrap();
+        let updated = terminal.frame().unwrap().clone();
         assert_eq!(updated.text(), "alpha\nBeta");
-        assert_eq!(terminal.frame().unwrap(), updated);
+        assert_eq!(terminal.frame().unwrap(), &updated);
 
         let _responses = terminal.apply_output(b"\r\x1b[2K");
         assert_eq!(terminal.frame().unwrap().text(), "alpha");
+    }
+
+    #[test]
+    fn retained_snapshot_survives_later_output_cursor_changes_and_resize() {
+        let mut terminal = TerminalCore::new(3, 10, 100).unwrap();
+        terminal.apply_output("A界e\u{301}\r\nbeta".as_bytes());
+        let retained = terminal.frame().unwrap().clone();
+        let original = serde_json::to_value(&retained).unwrap();
+
+        terminal.apply_output(b"\rB\x1b[6 q");
+        let updated = terminal.frame().unwrap();
+        assert_eq!(updated.text(), "A界e\u{301}\nBeta");
+        assert_eq!(updated.cursor.as_ref().unwrap().style, CursorStyle::Bar);
+        terminal.resize(5, 4, 9, 18).unwrap();
+        assert_eq!(terminal.frame().unwrap().cols, 5);
+        terminal.apply_output(b"\x1b[2J\x1b[Hdone");
+        assert_eq!(terminal.frame().unwrap().text(), "done");
+
+        assert_eq!(serde_json::to_value(&retained).unwrap(), original);
+        assert_eq!(retained.text(), "A界e\u{301}\nbeta");
+        assert_eq!(retained.cols, 10);
+        assert_eq!(retained.cursor.unwrap().style, CursorStyle::Block);
     }
 
     #[test]
@@ -496,7 +521,8 @@ mod tests {
         let _warmup = terminal.frame().unwrap();
         let started = std::time::Instant::now();
         for _ in 0..1_000 {
-            std::hint::black_box(terminal.frame().unwrap());
+            // Keep measuring an owned snapshot, not just borrowing the cached frame.
+            std::hint::black_box(terminal.frame().unwrap().clone());
         }
         println!(
             "METRIC repeated_frame_median_proxy_us={:.1}",


### PR DESCRIPTION
## Why

Internal screen inspection copied every cached cell even when it only needed text or a visibility flag. Unedited video export also deep-copied the entire state list before passing it to read-only consumers. A dense 1,001-event export retained about 395 MiB in the measured probe.

## What Changes

- Borrow the private cached frame for text/status inspection; clone explicitly when returning an independent capture or retaining a distinct recording state.
- Borrow the existing unedited video state list; only edited timelines allocate their replacement list.
- Borrow socket paths during named-session request polling rather than repeatedly copying them.

Public captures remain owned snapshots: later output, cursor changes, and resizing cannot modify an earlier capture. Public APIs, wire formats, timing, and rendered output are unchanged.

The dense export probe's three-run median peak RSS fell from **414,334,976 to 284,868,608 bytes** (about **395 to 272 MiB**). It deliberately samples at 1fps to isolate retained timeline work; this does not change export defaults or claim a frame-rate-based speedup. Paired 15-run driver-interaction medians stayed around 5.7–6.0ms on the local Apple M2 Max.

## Scope

Three ownership simplifications selected from a fresh whole-codebase review. No lifecycle/EOF rewrite, new cache, public-interface redesign, or feature expansion. Existing compatibility paths and public exports remain intact.

## Verification

```bash
bun install --frozen-lockfile
cargo fmt --all -- --check
cargo test --all-targets
cargo clippy --all-targets --all-features -- -D warnings
cargo build --release
bun scripts/bench-performance.ts --mode agent --runs 15 --binary /path/to/before
bun scripts/bench-performance.ts --mode agent --runs 15
bun run test:npm
bun run build:npm
bun run validate:npm
bun run validate:opentui
cargo package --list
cargo package
```

148 Rust tests passed; the existing owned-frame benchmark remains intentionally ignored and still measures owned snapshots. Independent core and recording reviews found no blockers. Added a retained-snapshot regression across output, cursor changes, and resizing.

Baseline/candidate comparison matched 40 v1/v2 JSON/ANSI snapshots and all 526 decoded video frames: eight synthetic variants covering startup, resize, pointer/reduced motion, cursor hiding, footer and edits, plus the existing 339-frame real-PTY edited demo. All local checks above passed, including 16 client tests, 10 OpenTUI tests, clean Bun/Node consumers, OpenTUI 0.4.1/0.4.5 consumers, and crate packaging. CI and the platform release matrix must pass before publication.
