### PR TITLE
chore: release terminal-control 1.2.1

### DIFF
--- a/.changeset/borrow-terminal-state.md
+++ b/.changeset/borrow-terminal-state.md
@@ -1,5 +1,0 @@
----
-"@kitlangton/terminal-control": patch
----
-
-Avoid cloning cached terminal frames for internal text/status inspection and duplicate recording states. Borrow unedited video states instead of copying the entire timeline, and borrow socket paths during named-session request polling. Public captures remain independent owned snapshots; terminal behavior, recording formats, and rendered output are unchanged.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "terminal-control"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminal-control"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2024"
 rust-version = "1.93"
 description = "Control and test terminal applications through stable visible state"

--- a/bun.lock
+++ b/bun.lock
@@ -10,35 +10,35 @@
     },
     "packages/darwin-arm64": {
       "name": "@kitlangton/terminal-control-darwin-arm64",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "bin": {
         "termctrl": "bin/termctrl",
       },
     },
     "packages/darwin-x64": {
       "name": "@kitlangton/terminal-control-darwin-x64",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "bin": {
         "termctrl": "bin/termctrl",
       },
     },
     "packages/linux-arm64-gnu": {
       "name": "@kitlangton/terminal-control-linux-arm64-gnu",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "bin": {
         "termctrl": "bin/termctrl",
       },
     },
     "packages/linux-x64-gnu": {
       "name": "@kitlangton/terminal-control-linux-x64-gnu",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "bin": {
         "termctrl": "bin/termctrl",
       },
     },
     "packages/opentui": {
       "name": "@kitlangton/terminal-control-opentui",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "devDependencies": {
         "@opentui/core": "^0.4.5",
         "@types/bun": "^1.3.0",
@@ -51,7 +51,7 @@
     },
     "packages/test": {
       "name": "@kitlangton/terminal-control",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "devDependencies": {
         "@types/bun": "^1.3.0",
         "@types/node": "^24.0.0",
@@ -59,10 +59,10 @@
         "vitest": "^3.2.4",
       },
       "optionalDependencies": {
-        "@kitlangton/terminal-control-darwin-arm64": "1.2.0",
-        "@kitlangton/terminal-control-darwin-x64": "1.2.0",
-        "@kitlangton/terminal-control-linux-arm64-gnu": "1.2.0",
-        "@kitlangton/terminal-control-linux-x64-gnu": "1.2.0",
+        "@kitlangton/terminal-control-darwin-arm64": "1.2.1",
+        "@kitlangton/terminal-control-darwin-x64": "1.2.1",
+        "@kitlangton/terminal-control-linux-arm64-gnu": "1.2.1",
+        "@kitlangton/terminal-control-linux-x64-gnu": "1.2.1",
       },
       "peerDependencies": {
         "vitest": ">=3.0.0",

--- a/packages/darwin-arm64/CHANGELOG.md
+++ b/packages/darwin-arm64/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @kitlangton/terminal-control-darwin-arm64
 
+## 1.2.1
+
 ## 1.2.0
 
 ## 1.1.1

--- a/packages/darwin-arm64/package.json
+++ b/packages/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control-darwin-arm64",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Native termctrl binary for Terminal Control on macOS arm64",
   "license": "MIT",
   "repository": "https://github.com/anomalyco/terminal-control",

--- a/packages/darwin-x64/CHANGELOG.md
+++ b/packages/darwin-x64/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @kitlangton/terminal-control-darwin-x64
 
+## 1.2.1
+
 ## 1.2.0
 
 ## 1.1.1

--- a/packages/darwin-x64/package.json
+++ b/packages/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control-darwin-x64",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Native termctrl binary for Terminal Control on macOS x64",
   "license": "MIT",
   "repository": "https://github.com/anomalyco/terminal-control",

--- a/packages/linux-arm64-gnu/CHANGELOG.md
+++ b/packages/linux-arm64-gnu/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @kitlangton/terminal-control-linux-arm64-gnu
 
+## 1.2.1
+
 ## 1.2.0
 
 ## 1.1.1

--- a/packages/linux-arm64-gnu/package.json
+++ b/packages/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control-linux-arm64-gnu",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Native termctrl binary for Terminal Control on Linux arm64 GNU",
   "license": "MIT",
   "repository": "https://github.com/anomalyco/terminal-control",

--- a/packages/linux-x64-gnu/CHANGELOG.md
+++ b/packages/linux-x64-gnu/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @kitlangton/terminal-control-linux-x64-gnu
 
+## 1.2.1
+
 ## 1.2.0
 
 ## 1.1.1

--- a/packages/linux-x64-gnu/package.json
+++ b/packages/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control-linux-x64-gnu",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Native termctrl binary for Terminal Control on Linux x64 GNU",
   "license": "MIT",
   "repository": "https://github.com/anomalyco/terminal-control",

--- a/packages/opentui/CHANGELOG.md
+++ b/packages/opentui/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @kitlangton/terminal-control-opentui
 
+## 1.2.1
+
 ## 1.2.0
 
 ## 1.1.1

--- a/packages/opentui/package.json
+++ b/packages/opentui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control-opentui",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Expose consistent OpenTUI semantic snapshots through Terminal Control",
   "license": "MIT",
   "repository": {

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @kitlangton/terminal-control
 
+## 1.2.1
+
+### Patch Changes
+
+- 286e7ff: Avoid cloning cached terminal frames for internal text/status inspection and duplicate recording states. Borrow unedited video states instead of copying the entire timeline, and borrow socket paths during named-session request polling. Public captures remain independent owned snapshots; terminal behavior, recording formats, and rendered output are unchanged.
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/terminal-control",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Typed terminal application control and testing with snapshots, recordings, and failure artifacts",
   "license": "MIT",
   "repository": {
@@ -38,10 +38,10 @@
     "prepack": "bun run build"
   },
   "optionalDependencies": {
-    "@kitlangton/terminal-control-darwin-arm64": "1.2.0",
-    "@kitlangton/terminal-control-darwin-x64": "1.2.0",
-    "@kitlangton/terminal-control-linux-arm64-gnu": "1.2.0",
-    "@kitlangton/terminal-control-linux-x64-gnu": "1.2.0"
+    "@kitlangton/terminal-control-darwin-arm64": "1.2.1",
+    "@kitlangton/terminal-control-darwin-x64": "1.2.1",
+    "@kitlangton/terminal-control-linux-arm64-gnu": "1.2.1",
+    "@kitlangton/terminal-control-linux-x64-gnu": "1.2.1"
   },
   "peerDependencies": {
     "vitest": ">=3.0.0"


### PR DESCRIPTION
## Why

Prepare the aligned patch release for the ownership simplifications in #33. Internal reads and unedited video exports no longer retain unnecessary copies; public snapshots and output remain unchanged.

## What Changes

- Consume the patch Changeset and align all six npm packages at 1.2.1.
- Align Cargo and Bun lockfile metadata with those versions.
- Include the generated changelog entry for borrowed terminal state and timeline reuse.

## Scope

Version preparation only. Source changes were reviewed and tested in #33. Publish through the existing four-platform validation and trusted-publishing workflow.

## Verification

```bash
bun install --frozen-lockfile
cargo fmt --all -- --check
cargo test --all-targets
cargo clippy --all-targets --all-features -- -D warnings
cargo build --release
bun run test:npm
bun run build:npm
bun run validate:npm
bun run validate:opentui
cargo package --list
cargo package
cargo publish --dry-run --locked
```

All local checks passed at 1.2.1, including 148 Rust tests, 16 client tests, 10 OpenTUI tests, clean Bun/Node consumers and OpenTUI 0.4.1/0.4.5 consumers. Verified aligned manifests/locks and consumed Changeset; inspected the crate's 28-file list for source, schemas, and license notices.

After merge, the release workflow will build and validate the complete macOS/Linux arm64/x64 tarball set before trusted publication.
